### PR TITLE
Allow timeout for waitready to be set on LXD snap package dynamically.

### DIFF
--- a/snapcraft/hooks/configure
+++ b/snapcraft/hooks/configure
@@ -28,7 +28,7 @@ verify_int () {
     value=$(echo "${1:-}")
 
     # Verify if the value is a positive integer
-    if [[ "${value}" =~ ^[0-9]+$ ]]; then
+    if $(echo "${value}" | grep -Eq '^[0-9]+$'); then
         echo "${value}"
         return
     fi

--- a/snapcraft/hooks/configure
+++ b/snapcraft/hooks/configure
@@ -24,6 +24,19 @@ get_bool() {
     return
 }
 
+verify_int () {
+    value=$(echo "${1:-}")
+
+    # Verify if the value is a positive integer
+    if [[ "${value}" =~ ^[0-9]+$ ]]; then
+        echo "${value}"
+        return
+    fi
+
+    # Invalid value (or not set)
+    return
+}
+
 # Don't fail if the mount namespace isn't properly setup yet
 if [ ! -e /run/snapd-snap.socket ]; then
     exit 0
@@ -34,6 +47,7 @@ daemon_debug=$(get_bool "$(snapctl get daemon.debug)")
 daemon_group=$(snapctl get daemon.group)
 ceph_builtin=$(get_bool "$(snapctl get ceph.builtin)")
 openvswitch_builtin=$(get_bool "$(snapctl get openvswitch.builtin)")
+waitready_timeout=$(verify_int "$(snapctl get waitready.timeout)")
 
 # Generate the config
 config="${SNAP_COMMON}/config"
@@ -44,6 +58,7 @@ config="${SNAP_COMMON}/config"
     echo "daemon_group=${daemon_group:-"lxd"}"
     echo "ceph_builtin=${ceph_builtin:-"false"}"
     echo "openvswitch_builtin=${openvswitch_builtin:-"false"}"
+    echo "waitready_timeout=${waitready_timeout:-"600"}"
 } > "${config}"
 
 exit 0

--- a/snapcraft/wrappers/daemon.start
+++ b/snapcraft/wrappers/daemon.start
@@ -220,7 +220,7 @@ ${CMD} &
 ## Wait for it to be ready
 PID=$!
 echo $PID > "${SNAP_COMMON}/lxd.pid"
-"${LXD}" waitready --timeout=600
+"${LXD}" waitready --timeout="${waitready_timeout}"
 
 ## Put database in versioned path
 if [ ! -L "${SNAP_COMMON}/lxd/lxd.db" ]; then


### PR DESCRIPTION
In order to set a custom value, one can use the command: `sudo snap set lxd waitready.timeout=<VALUE>` where VALUE is an INT >= 0.
After the setting is there it is necessary a daemon restart for it to be applied: `sudo systemctl restart snap.lxd.daemon`

Fixes https://github.com/lxc/lxd-pkg-snap/issues/5