### PR TITLE
commands: don't try to access USER variable if it is not set

### DIFF
--- a/snapcraft/commands/lxc
+++ b/snapcraft/commands/lxc
@@ -19,7 +19,7 @@ if [ -n "${HOME:-}" ] && [ ! -d "${HOME}/.config/lxc" ]; then
     mkdir -p "${HOME}/.config"
     if [ -n "${USER:-}" ] && [ -d "/home/${USER}/.config/lxc" ]; then
         cp -r "/home/${USER}/.config/lxc" "${HOME}/.config/lxc" || true
-    elif [ "${USER}" = "root" ] && [ -d "/root/.config/lxc" ]; then
+    elif [ "${USER:-}" = "root" ] && [ -d "/root/.config/lxc" ]; then
         cp -r "/root/.config/lxc" "${HOME}/.config/lxc" || true
     fi
 fi


### PR DESCRIPTION
In environments were USER isn't set the lxc script fail when trying to
access the variable:

/snap/lxd/9348/commands/lxc: 22: /snap/lxd/9348/commands/lxc: USER: parameter not set

-----

@stgraber I've found this with the latest 3.0/stable snap of LXD (revision 9348). So when merged I think you want to cherry pick this to 3.0 too.