### PR TITLE
Fix Unicode character compatibility in `lxc config edit`

### DIFF
--- a/snapcraft/commands/lxc
+++ b/snapcraft/commands/lxc
@@ -33,6 +33,10 @@ if [ "${EDITOR:-}" != "nano" ]; then
 fi
 export VISUAL=${EDITOR:-}
 
+# Reset all locales as it isn't available in the snap (#29)
+LANG=C.UTF-8
+export LC_ALL=C.UTF-8
+
 LXC="lxc"
 if [ -x "${SNAP_COMMON}/lxc.debug" ]; then
     LXC="${SNAP_COMMON}/lxc.debug"


### PR DESCRIPTION
![default](https://user-images.githubusercontent.com/13408130/50347994-835f9200-0572-11e9-9d6d-0a908fbf8743.png)

Currently, Unicode characters will become garbled when editing container
configs due to the unsupported user locale settings.  This patch fixes
the problem by resetting the locales to `C.UTF-8`.

Note that this is not a complete fix as it also disables the L10N as the
locales are hardcoded, the `locales-launch` remote part[1] is a solution
for this problem.

Fixes #29.

[1] https://forum.snapcraft.io/t/the-locales-launch-remote-part/8729

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>