### PR TITLE
Avoid implicit "." `source` dir in legacy Snapcraft

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -91,6 +91,7 @@ hooks:
 parts:
   # Dependencies
   btrfs:
+    source: snapcraft/empty
     plugin: nil
     stage-packages:
       - btrfs-tools
@@ -100,6 +101,7 @@ parts:
       - bin/mkfs.btrfs
 
   ceph:
+    source: snapcraft/empty
     plugin: nil
     stage-packages:
       - ceph-common
@@ -139,6 +141,7 @@ parts:
     source-tag: go1.11.2
 
   lvm:
+    source: snapcraft/empty
     plugin: nil
     stage-packages:
       - dmeventd
@@ -170,6 +173,7 @@ parts:
       - lib/*/libreadline.so*
 
   nano:
+    source: snapcraft/empty
     plugin: nil
     stage-packages:
       - nano
@@ -210,6 +214,7 @@ parts:
       - lib/libnvidia-container.so*
 
   openvswitch:
+    source: snapcraft/empty
     plugin: nil
     stage-packages:
       - openvswitch-switch
@@ -267,6 +272,7 @@ parts:
       - lib/*/libuv*
 
   vim:
+    source: snapcraft/empty
     plugin: nil
     stage-packages:
       - vim-tiny
@@ -278,6 +284,7 @@ parts:
       - etc/vimrc
 
   xfs:
+    source: snapcraft/empty
     plugin: nil
     stage-packages:
       - xfsprogs
@@ -628,6 +635,7 @@ parts:
       - bin/snap-query
 
   strip:
+    source: snapcraft/empty
     after:
       - btrfs
       - ceph

--- a/snapcraft/empty/README
+++ b/snapcraft/empty/README
@@ -1,0 +1,6 @@
+This is a fake source directory to avoid the default behavior of legacy 2.x Snapcraft which sets an implicit "." `source` directory for parts without the `source` key.  This prevents parts that uses the `nil` plugin be considered "changed" whenever a file under "." directory is modified.
+
+Refer the following snapcraft forum topic for more info about this issue:
+
+    Snapcraft implicit source - snapcraft - snapcraft.io
+    https://forum.snapcraft.io/t/snapcraft-implicit-source/7060


### PR DESCRIPTION
There is a default behavior of legacy 2.x Snapcraft which sets an
implicit "." `source` directory for parts without the `source` key.
This prevents parts that uses the `nil` plugin be considered "changed"
whenever a file under "." directory is modified.

This patch sets a fake source directory to all parts without the
`source` key to workaround the issue.

Refer the following snapcraft forum topic for more info:

    Snapcraft implicit source - snapcraft - snapcraft.io
    https://forum.snapcraft.io/t/snapcraft-implicit-source/7060

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>