### PR TITLE
nogetgo: fix getting build base on snapcraft 4.0+

### DIFF
--- a/snap/plugins/nogetgo.py
+++ b/snap/plugins/nogetgo.py
@@ -140,7 +140,12 @@ class GoPlugin(snapcraft.BasePlugin):
     def __init__(self, name: str, options, project: "Project") -> None:
         super().__init__(name, options, project)
 
-        self._setup_base_tools(options.go_channel, project.info.get_build_base())
+        if hasattr(project, "_get_build_base"):
+            base = project._get_build_base()
+        else:
+            base = project.info.base
+
+        self._setup_base_tools(options.go_channel, base)
         self._is_classic = project.info.confinement == "classic"
 
         self._install_bin_dir = os.path.join(self.installdir, "bin")


### PR DESCRIPTION
If available, use project._get_build_base() to get the project's
build base.

If _get_build_base() is not available (snapcraft < 4.0), then
resort to using project.info.base, which is safe to use for this
project as it specifies a base.  ProjectInfo will eventually be
removed, so this prioritizes the new interface.
