### PR TITLE
Bump /proc/sys/kernel/keys/maxkeys out of the box

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -348,6 +348,13 @@ if [ "$(stat -c '%u' /proc)" = 0 ]; then
         fi
     fi
 
+    if [ -e /proc/sys/kernel/keys/maxkeys ]; then
+        if [ "$(cat /proc/sys/kernel/keys/maxkeys)" -lt "2000" ]; then
+            echo "==> Increasing the number of keys for a nonroot user"
+            echo 2000 > /proc/sys/kernel/keys/maxkeys || true
+        fi
+    fi
+
     if [ -e /proc/sys/kernel/unprivileged_userns_clone ]; then
         if [ "$(cat /proc/sys/kernel/unprivileged_userns_clone)" = "0" ]; then
             echo "==> Enabling unprivileged containers kernel support"


### PR DESCRIPTION
The default limit as 200 will be obvious when provisioning multiple LXD
containers and installing snap packages into those at the same time.
Let's bump it as well as /proc/sys/fs/inotify/max_user_instances out of
the box. See more details in https://launchpad.net/bugs/1891223

Closes: #65