### PR TITLE
buginfo: Use "--format=yaml" in list commands

### DIFF
--- a/snapcraft/commands/buginfo
+++ b/snapcraft/commands/buginfo
@@ -45,37 +45,37 @@ if lxc info >/dev/null 2>&1; then
 
     echo "## Instances"
     echo '```'
-    lxc list
+    lxc list --format=yaml
     echo '```'
     echo ""
 
     echo "## Images"
     echo '```'
-    lxc image list
+    lxc image list --format=yaml
     echo '```'
     echo ""
 
     echo "## Storage pools"
     echo '```'
-    lxc storage list
+    lxc storage list --format=yaml
     echo '```'
     echo ""
 
     echo "## Networks"
     echo '```'
-    lxc network list
+    lxc network list --format=yaml
     echo '```'
     echo ""
 
     echo "## Projects"
     echo '```'
-    lxc project list
+    lxc project list --format=yaml
     echo '```'
     echo ""
 
     echo "## Profiles"
     echo '```'
-    lxc profile list
+    lxc profile list --format=yaml
     echo '```'
     echo ""
 
@@ -88,7 +88,7 @@ if lxc info >/dev/null 2>&1; then
     if lxc cluster list >/dev/null 2>&1; then
         echo "## Cluster"
         echo '```'
-        lxc cluster list
+        lxc cluster list --format=yaml
         echo '```'
         echo ""
     fi


### PR DESCRIPTION
lxc.buginfo has a few "lxc x list" commands listed without any specified
format.  This defaults to the "table" format.  However, the default "table"
format does not provide some information that another format, like the "yaml"
format, provides.  Some of the additional information could be useful for
engineers debugging a lxc setup.  This PR appends "--format=yaml" to the
applicable list commands.

Signed-off-by: Adam Bell <adam.bell@canonical.com>