### PR TITLE
Don't try to install edk2 deps on non-edk2 architectures

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -229,9 +229,14 @@ parts:
     source-depth: 1
     plugin: nil
     build-packages:
-      - acpica-tools
-      - nasm
-      - uuid-dev
+      - on amd64:
+        - acpica-tools
+        - nasm
+        - uuid-dev
+      - on arm64:
+        - acpica-tools
+        - nasm
+        - uuid-dev
     override-pull: |-
       set -ex
       git clone https://github.com/tianocore/edk2 . -b edk2-stable202108


### PR DESCRIPTION
Some of them don't exist everywhere, e.g. acpica-tools isn't available
on riscv64 in focal. override-build short-circuits outside amd64 and
arm64, so don't require the build-deps either.

It seems like the dpkg features of architecture lists and negative
matches weren't carried over, so there's no non-duplicatastic way to do
this AFAICS.