### PR TITLE
snapcraft.yaml: skip pulling EDK2 when not building it

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -239,6 +239,7 @@ parts:
         - nasm
         - uuid-dev
     override-pull: |-
+      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
       set -ex
       git clone https://github.com/tianocore/edk2 . -b edk2-stable202108
 


### PR DESCRIPTION
EDK2 is only built on aarch64 and x86_64. But currently it is cloned
everywhere. Skip cloning it as well when not building it.