### PR TITLE
snapcraft.yaml: pull meson early

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -144,6 +144,20 @@ hooks:
       - system-observe
 
 parts:
+  # Workarounds
+  pull-meson-early:
+    source: snapcraft/empty
+    override-build: |
+      # No-op
+      true
+    override-stage: |
+      # No-op
+      true
+    plugin: nil
+    override-pull: |
+      # Fetch meson early to cause all downloads at the beginning of the build.
+      python3 -m pip install -U meson
+
   # Dependencies
   btrfs:
     source: snapcraft/empty


### PR DESCRIPTION
Plugins cannot pull dependenices during pull step. Instead, add a part that pulls meson during pull step. This helps with completing build steps offline.

I recently managed to complete LXD riscv64 build in Launchpad. This patch was used during that successful build, please consider applying it.