### PR TITLE
snapcraft.yaml: do not pull qemu when not building

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -719,6 +719,7 @@ parts:
       - libusbredirhost1
       - libusbredirparser1
     override-pull: |-
+      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "ppc64le" ] && [ "$(uname -m)" != "s390x" ] && exit 0
       set -ex
       git clone https://gitlab.com/qemu/qemu . -b v6.1.1
     override-build: |-


### PR DESCRIPTION
On riscv64 qemu is not built, but the git clone takes a long time. Skip git clone when not building it.

I recently managed to complete LXD riscv64 build in Launchpad. This patch was used during that successful build, please consider applying it.