### PR TITLE
snapcraft.yaml: go get during pull stage, instead of build

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1213,6 +1213,20 @@ parts:
       - usbutils
       - xdelta3
     plugin: nil
+    override-pull: |
+      snapcraftctl pull
+      set -ex
+
+      # Setup build environment
+      export GOPATH=$(realpath ./.go)
+
+      # Setup the GOPATH
+      rm -Rf "${GOPATH}"
+      mkdir -p "${GOPATH}/src/github.com/lxc"
+      ln -s "$(pwd)" "${GOPATH}/src/github.com/lxc/lxd"
+
+      # Download the dependencies
+      go get -d -v ./...
     override-build: |
       set -ex
 
@@ -1226,14 +1240,6 @@ parts:
       export CGO_CFLAGS="-I${SNAPCRAFT_STAGE}/include/ -I${SNAPCRAFT_STAGE}/usr/local/include/"
       export CGO_LDFLAGS="-L${SNAPCRAFT_STAGE}/lib/ -L${SNAPCRAFT_STAGE}/usr/local/lib/"
       export CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
-
-      # Setup the GOPATH
-      rm -Rf "${GOPATH}"
-      mkdir -p "${GOPATH}/src/github.com/lxc"
-      ln -s "$(pwd)" "${GOPATH}/src/github.com/lxc/lxd"
-
-      # Download the dependencies
-      go get -d -v ./...
 
       # Build the binaries
       go build -o "${SNAPCRAFT_PART_INSTALL}/bin/lxc" github.com/lxc/lxd/lxc
@@ -1286,6 +1292,15 @@ parts:
     build-snaps:
       - go
     plugin: nil
+    override-pull: |
+      snapcraftctl pull
+      set -ex
+
+      # Setup build environment
+      export GOPATH=$(realpath ./.go)
+
+      # Download the dependencies
+      go get -d -v ./...
     override-build: |
       set -ex
 
@@ -1293,9 +1308,6 @@ parts:
       export GOPATH=$(realpath ./.go)
       export CGO_CFLAGS="-I${SNAPCRAFT_STAGE}/include/ -I${SNAPCRAFT_STAGE}/usr/local/include/"
       export CGO_LDFLAGS="-L${SNAPCRAFT_STAGE}/lib/ -L${SNAPCRAFT_STAGE}/usr/local/lib/"
-
-      # Download the dependencies
-      go get -d -v ./...
 
       # Build the binaries
       go build -o "${SNAPCRAFT_PART_INSTALL}/bin/lxd-migrate" -tags=libsqlite3 ./


### PR DESCRIPTION
Ensure that go get is done during pull, instead of build step.

I am not a regular golang coder, this pull request needs especially careful review to ensure that go-get & go-build actually get build-deps which are then used by go-build, instead of like resulting in duplicate downloads that are not reused.

I recently managed to complete LXD riscv64 build in Launchpad. This patch was used during that successful build, please consider applying it.