### PR TITLE
snapcraft.yaml: use core22-step-dependencies

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -146,6 +146,7 @@ hooks:
 parts:
   # Dependencies
   btrfs:
+    build-attributes: [core22-step-dependencies]
     source: snapcraft/empty
     plugin: nil
     stage-packages:
@@ -158,6 +159,7 @@ parts:
       - bin/mkfs.btrfs
 
   ceph:
+    build-attributes: [core22-step-dependencies]
     source: snapcraft/empty
     plugin: nil
     stage-packages:
@@ -182,6 +184,7 @@ parts:
       - lib/python3
 
   criu:
+    build-attributes: [core22-step-dependencies]
     source: https://github.com/checkpoint-restore/criu
     source-tag: v3.16.1
     source-type: git
@@ -220,6 +223,7 @@ parts:
       - lib/*/libproto*
 
   dqlite:
+    build-attributes: [core22-step-dependencies]
     after:
       - raft
       - sqlite
@@ -240,6 +244,7 @@ parts:
       - lib/*/libuv*
 
   edk2:
+    build-attributes: [core22-step-dependencies]
     source: https://github.com/tianocore/edk2
     source-type: git
     source-tag: IRRELEVANT
@@ -318,6 +323,7 @@ parts:
       - share/qemu/*
 
   libmnl:
+    build-attributes: [core22-step-dependencies]
     source: https://git.netfilter.org/libmnl
     source-type: git
     source-tag: libmnl-1.0.4
@@ -330,6 +336,7 @@ parts:
       - lib/libmnl*so*
 
   libnftnl:
+    build-attributes: [core22-step-dependencies]
     after:
       - libmnl
     source: https://git.netfilter.org/libnftnl
@@ -348,6 +355,7 @@ parts:
       sed -i "s# /lib/libmnl.la# ${SNAPCRAFT_STAGE}/lib/libmnl.la#g" "${SNAPCRAFT_PART_INSTALL}/lib/libnftnl.la"
 
   libseccomp:
+    build-attributes: [core22-step-dependencies]
     source: https://github.com/seccomp/libseccomp
     source-type: git
     source-tag: v2.5.3
@@ -363,6 +371,7 @@ parts:
       - lib/libseccomp*so*
 
   libtpms:
+    build-attributes: [core22-step-dependencies]
     source: https://github.com/stefanberger/libtpms
     source-type: git
     source-tag: v0.9.3
@@ -378,6 +387,7 @@ parts:
       - lib/libtpms*so*
 
   liburing:
+    build-attributes: [core22-step-dependencies]
     source: https://github.com/axboe/liburing
     source-type: git
     source-tag: liburing-2.1
@@ -394,6 +404,7 @@ parts:
       - lib/liburing*so*
 
   libusb:
+    build-attributes: [core22-step-dependencies]
     source: https://github.com/libusb/libusb
     source-type: git
     source-tag: v1.0.25
@@ -407,6 +418,7 @@ parts:
       - lib/libusb*so*
 
   logrotate:
+    build-attributes: [core22-step-dependencies]
     source: snapcraft/empty
     plugin: nil
     stage-packages:
@@ -421,6 +433,7 @@ parts:
       - bin/logrotate
 
   lvm:
+    build-attributes: [core22-step-dependencies]
     source: snapcraft/empty
     plugin: nil
     stage-packages:
@@ -453,6 +466,7 @@ parts:
       - lib/*/libreadline.so*
 
   nano:
+    build-attributes: [core22-step-dependencies]
     source: snapcraft/empty
     plugin: nil
     stage-packages:
@@ -464,6 +478,7 @@ parts:
       - etc/nanorc
 
   nftables:
+    build-attributes: [core22-step-dependencies]
     after:
       - libmnl
       - libnftnl
@@ -500,6 +515,7 @@ parts:
       - lib/libnftables*so*
 
   nvidia-container:
+    build-attributes: [core22-step-dependencies]
     after:
       - libseccomp
     source: https://github.com/NVIDIA/libnvidia-container
@@ -532,6 +548,7 @@ parts:
       - lib/libnvidia-container*.so*
 
   openvswitch:
+    build-attributes: [core22-step-dependencies]
     source: https://github.com/openvswitch/ovs
     source-type: git
     source-tag: v2.17.0
@@ -562,6 +579,7 @@ parts:
       - share/openvswitch/
 
   ovn:
+    build-attributes: [core22-step-dependencies]
     after:
       - openvswitch
     source: https://github.com/ovn-org/ovn
@@ -578,6 +596,7 @@ parts:
       - bin/ovn-sbctl
 
   spice-protocol:
+    build-attributes: [core22-step-dependencies]
     source: https://github.com/freedesktop/spice-protocol
     source-type: git
     source-tag: v0.14.4
@@ -586,6 +605,7 @@ parts:
     prime: []
 
   spice-server:
+    build-attributes: [core22-step-dependencies]
     after:
       - spice-protocol
     source: https://github.com/freedesktop/spice
@@ -619,6 +639,7 @@ parts:
       - lib/*/libpixman*so*
 
   swtpm:
+    build-attributes: [core22-step-dependencies]
     after:
       - libseccomp
       - libtpms
@@ -652,6 +673,7 @@ parts:
       - lib/*/libjson-glib-1.0.so*
 
   qemu:
+    build-attributes: [core22-step-dependencies]
     after:
       - libseccomp
       - liburing
@@ -760,6 +782,7 @@ parts:
       - share/qemu/vgabios-*.bin*
 
   qemu-ovmf-secureboot:
+    build-attributes: [core22-step-dependencies]
     after:
       - edk2
       - qemu
@@ -807,6 +830,7 @@ parts:
       - share/qemu/*
 
   raft:
+    build-attributes: [core22-step-dependencies]
     source: https://github.com/canonical/raft
     source-type: git
     source-depth: 1
@@ -826,6 +850,7 @@ parts:
       - lib/*/libuv.so*
 
   sqlite:
+    build-attributes: [core22-step-dependencies]
     source: https://github.com/sqlite/sqlite
     source-type: git
     source-depth: 1
@@ -840,6 +865,7 @@ parts:
       - lib/libsqlite3*so*
 
   squashfs-tools-ng:
+    build-attributes: [core22-step-dependencies]
     source: https://github.com/AgentD/squashfs-tools-ng
     source-type: git
     source-tag: v1.1.3
@@ -855,6 +881,7 @@ parts:
       - lib/libsquashfs.so*
 
   vim:
+    build-attributes: [core22-step-dependencies]
     source: snapcraft/empty
     plugin: nil
     stage-packages:
@@ -868,6 +895,7 @@ parts:
       - etc/vimrc
 
   xfs:
+    build-attributes: [core22-step-dependencies]
     source: snapcraft/empty
     plugin: nil
     stage-packages:
@@ -883,6 +911,7 @@ parts:
       - bin/mkfs.xfs
 
   xtables:
+    build-attributes: [core22-step-dependencies]
     source: snapcraft/empty
     plugin: nil
     stage-packages:
@@ -899,6 +928,7 @@ parts:
       - lib/libebtc.so.*
 
   xz:
+    build-attributes: [core22-step-dependencies]
     source: snapcraft/empty
     plugin: nil
     stage-packages:
@@ -918,6 +948,7 @@ parts:
       ln -s xz "${SNAPCRAFT_PART_INSTALL}/usr/bin/lzma"
 
   zfs-0-6:
+    build-attributes: [core22-step-dependencies]
     source: https://github.com/openzfs/zfs
     source-type: git
     source-tag: zfs-0.6.5.11
@@ -954,6 +985,7 @@ parts:
       rm -Rf "${SNAPCRAFT_PART_INSTALL}.tmp"
 
   zfs-0-7:
+    build-attributes: [core22-step-dependencies]
     source: https://github.com/openzfs/zfs
     source-type: git
     source-tag: zfs-0.7.13
@@ -987,6 +1019,7 @@ parts:
       rm -Rf "${SNAPCRAFT_PART_INSTALL}.tmp"
 
   zfs-0-8:
+    build-attributes: [core22-step-dependencies]
     source: https://github.com/openzfs/zfs
     source-type: git
     source-tag: zfs-0.8.6
@@ -1021,6 +1054,7 @@ parts:
       rm -Rf "${SNAPCRAFT_PART_INSTALL}.tmp"
 
   zfs-2-0:
+    build-attributes: [core22-step-dependencies]
     source: https://github.com/openzfs/zfs
     source-type: git
     source-tag: zfs-2.0.7
@@ -1055,6 +1089,7 @@ parts:
       rm -Rf "${SNAPCRAFT_PART_INSTALL}.tmp"
 
   zfs-2-1:
+    build-attributes: [core22-step-dependencies]
     source: https://github.com/openzfs/zfs
     source-type: git
     source-tag: zfs-2.1.3
@@ -1090,6 +1125,7 @@ parts:
 
 
   zstd:
+    build-attributes: [core22-step-dependencies]
     source: snapcraft/empty
     plugin: nil
     stage-packages:
@@ -1102,6 +1138,7 @@ parts:
 
   # Core components
   lxc:
+    build-attributes: [core22-step-dependencies]
     after:
       - libseccomp
     source: https://github.com/lxc/lxc
@@ -1187,6 +1224,7 @@ parts:
       patch -p1 $SNAPCRAFT_PART_INSTALL/snap/lxd/current/lxcfs/lxc.mount.hook < "${SNAPCRAFT_PROJECT_DIR}/patches/lxcfs-0001-hook.patch"
 
   lxd:
+    build-attributes: [core22-step-dependencies]
     source: https://github.com/lxc/lxd
     source-type: git
     after:
@@ -1279,6 +1317,7 @@ parts:
       - bin/lxd-user
 
   lxd-migrate:
+    build-attributes: [core22-step-dependencies]
     source: lxd-migrate/
     after:
       - lxd
@@ -1308,12 +1347,14 @@ parts:
       - bin/upgrade-bridge
 
   shmounts:
+    build-attributes: [core22-step-dependencies]
     source: shmounts/
     plugin: make
     prime:
       - bin/setup-shmounts
 
   snap-query:
+    build-attributes: [core22-step-dependencies]
     source: snap-query/
     build-snaps:
       - go
@@ -1330,6 +1371,7 @@ parts:
       - bin/snap-query
 
   strip:
+    build-attributes: [core22-step-dependencies]
     source: snapcraft/empty
     after:
       - btrfs
@@ -1382,6 +1424,7 @@ parts:
       exit 0
 
   wrappers:
+    build-attributes: [core22-step-dependencies]
     plugin: dump
     source: snapcraft/
     organize:


### PR DESCRIPTION
This build attribute insures that all parts are pulled during LP's snapcraft pull call, and that they are not subsequently repulled again during build.

This requires for pull steps of each part to not require the before parts to be pulled.

This feature is currently present in snapcraft latest/edge only, possibly will be available in 7.x/6.0.3.

This means this patch cannot be applied, unless the builds are changed to use snapcraft from latest/edge which is undesirable.

I recently managed to complete LXD riscv64 build in Launchpad. This patch was used during that successful build. After establishing 6h build time, the network proxy allowed time has been requested to be increased. So it might be the case that lxd snap riscv64 builds might be successful now even without this patch applied.