### PR TITLE
lxcfs: fix nesting setup for backward compatibility purpose

### DIFF
--- a/patches/lxcfs-0001-hook.patch
+++ b/patches/lxcfs-0001-hook.patch
@@ -1,6 +1,6 @@
---- /root/parts/lxcfs/install/snap/lxd/current/lxcfs/lxc.mount.hook	2022-03-23 22:47:13.153225112 +0000
-+++ lxc.mount.hook	2022-03-23 23:23:21.614527054 +0000
-@@ -31,8 +31,10 @@ if [ -d /var/snap/lxd/common/var/lib/lxc
+--- /root/parts/lxcfs/install/snap/lxd/current/lxcfs/lxc.mount.hook	2022-03-31 11:35:47.937752513 +0800
++++ lxc.mount.hook	2022-03-31 11:30:15.094738379 +0800
+@@ -31,8 +31,16 @@
  fi
  
  # Allow nesting lxcfs
@@ -10,6 +10,12 @@
 +    rm -Rf "${LXC_ROOTFS_MOUNT}/var/snap/lxd/common/var/lib/lxcfs"
 +    mkdir -p "${LXC_ROOTFS_MOUNT}/var/snap/lxd/common/var/lib/lxcfs"
 +    mount -n --bind /var/snap/lxd/common/var/lib/lxcfs "${LXC_ROOTFS_MOUNT}/var/snap/lxd/common/var/lib/lxcfs/"
++fi
++
++# For backward compatibility, hand `/var/lib/lxcfs` through the host to
++# the container being as the lxcfs mount point.
++if [ -d "${LXC_ROOTFS_MOUNT}/var/lib/lxcfs/" ]; then
++    mount -n --bind /var/snap/lxd/common/var/lib/lxcfs "${LXC_ROOTFS_MOUNT}/var/lib/lxcfs/"
  fi
  
  # no need for lxcfs cgroups if we have cgroup namespaces


### PR DESCRIPTION
For backward compatibility, hand `/var/lib/lxcfs` through the host to
the container being as the lxcfs mount point.

Signed-off-by: gary-wzl77 <gary.wang@canonical.com>