### PR TITLE
lxcfs: fix nesting setup for backward compatibility purpose

### DIFF
--- a/patches/lxcfs-0001-hook.patch
+++ b/patches/lxcfs-0001-hook.patch
@@ -1,6 +1,6 @@
---- /snap/lxd/current/lxcfs/lxc.mount.hook	2022-03-13 17:39:48.000000000 +0000
-+++ lxc.mount.hook	2022-03-14 14:52:09.311244584 +0000
-@@ -37,7 +37,9 @@ if [ -d /var/snap/lxd/common/var/lib/lxc
+--- /snap/lxd/current/lxcfs/lxc.mount.hook	2022-03-31 10:12:30.716747887 +0800
++++ lxc.mount.hook	2022-03-31 10:12:19.996567394 +0800
+@@ -37,10 +37,18 @@
  fi
  
  # Allow nesting lxcfs
@@ -11,3 +11,12 @@
      mount -n --bind /var/snap/lxd/common/var/lib/lxcfs "${LXC_ROOTFS_MOUNT}/var/snap/lxd/common/var/lib/lxcfs/"
  fi
  
++# For backward compatibility, hand `/var/lib/lxcfs` through the host to
++# the container being as the lxcfs mount point.
++if [ -d "${LXC_ROOTFS_MOUNT}/var/lib/lxcfs/" ]; then
++    mount -n --bind /var/snap/lxd/common/var/lib/lxcfs "${LXC_ROOTFS_MOUNT}/var/lib/lxcfs/"
++fi
++
+ # no need for lxcfs cgroups if we have cgroup namespaces
+ [ -n "$LXC_CGNS_AWARE" ] && [ -f /proc/self/ns/cgroup ] && exit 0
+


### PR DESCRIPTION
For backward compatibility, hand `/var/lib/lxcfs` through the host to
the container being as the lxcfs mount point.

Signed-off-by: gary-wzl77 <gary.wang@canonical.com>