### PR TITLE
Allow usage of external OVS tools.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -43,6 +43,7 @@ description: |-
    - lxcfs.loadavg: Start tracking per-container load average [default=false]
    - lxcfs.cfs: Consider CPU shares for CPU usage [default=false]
    - openvswitch.builtin: Run a snap-specific OVS daemon [default=false]
+   - openvswitch.external: Use the system's OVS tools (ignores openvswitch.builtin) [default=false]
    - ovn.builtin: Use snap-specific OVN configuration [default=false]
    - shiftfs.enable: Enable shiftfs support [default=auto]
 

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -164,6 +164,11 @@ if [ "${ceph_external:-"false"}" = "true" ]; then
     ln -s "${SNAP}/wrappers/run-host" "/run/bin/rbd"
 fi
 
+if [ "${openvswitch_external:-"false"}" = "true" ]; then
+    ln -s "${SNAP}/wrappers/run-host" "/run/bin/ovs-appctl"
+    ln -s "${SNAP}/wrappers/run-host" "/run/bin/ovs-vsctl"
+fi
+
 if [ "${lvm_external:-"false"}" = "true" ]; then
     ln -s "${SNAP}/wrappers/run-host" "/run/bin/lvm"
     ln -s "${SNAP}/wrappers/run-host" "/run/bin/vgs"

--- a/snapcraft/hooks/configure
+++ b/snapcraft/hooks/configure
@@ -60,6 +60,7 @@ lxcfs_loadavg=$(get_bool "$(snapctl get lxcfs.loadavg)")
 lxcfs_pidfd=$(get_bool "$(snapctl get lxcfs.pidfd)")
 lxcfs_cfs=$(get_bool "$(snapctl get lxcfs.cfs)")
 openvswitch_builtin=$(get_bool "$(snapctl get openvswitch.builtin)")
+openvswitch_external=$(get_bool "$(snapctl get openvswitch.external)")
 ovn_builtin=$(get_bool "$(snapctl get ovn.builtin)")
 shiftfs_enable=$(get_bool "$(snapctl get shiftfs.enable)")
 
@@ -86,6 +87,7 @@ config="${SNAP_COMMON}/config"
     echo "lxcfs_pidfd=${lxcfs_pidfd:-"false"}"
     echo "lxcfs_cfs=${lxcfs_cfs:-"false"}"
     echo "openvswitch_builtin=${openvswitch_builtin:-"false"}"
+    echo "openvswitch_external=${openvswitch_external:-"false"}"
     echo "ovn_builtin=${ovn_builtin:-"false"}"
     echo "shiftfs_enable=${shiftfs_enable:-"auto"}"
 } > "${config}"


### PR DESCRIPTION
`ovs-appctl` and `ovs-vsctl` tools can be linked to host FS on-demand as
some users may want to use their own version of these tools.

_Note_: `ovs-appctl` was mainly added to override access to its embedded
version as it seems that LXD is not using it anyway.

Signed-off-by: Vincent KHERBACHE <v.kherbache@titandc.fr>