### PR TITLE
Change systemd unit arguments from hard-coded lxd to SNAP_INSTANCE_NAME.

### DIFF
--- a/snapcraft/commands/daemon.activate
+++ b/snapcraft/commands/daemon.activate
@@ -39,11 +39,11 @@ daemon_user_group="${daemon_user_group:-"lxd"}"
 
 # Detect missing socket activation support
 echo "==> Checking for socket activation support"
-if ! nsenter -t 1 -m systemctl is-active -q snap.lxd.daemon.unix.socket; then
+if ! nsenter -t 1 -m systemctl is-active -q snap.${SNAP_INSTANCE_NAME}.daemon.unix.socket; then
     sleep 3s
-    if ! nsenter -t 1 -m systemctl is-active -q snap.lxd.daemon.unix.socket; then
+    if ! nsenter -t 1 -m systemctl is-active -q snap.${SNAP_INSTANCE_NAME}.daemon.unix.socket; then
         echo "===> System doesn't support socket activation, starting LXD now"
-        nsenter -t 1 -m systemctl start snap.lxd.daemon
+        nsenter -t 1 -m systemctl start snap.${SNAP_INSTANCE_NAME}.daemon
         exit 0
     fi
 fi
@@ -52,7 +52,7 @@ fi
 SNAP_MODEL="$(nsenter -t 1 -m snap model --assertion | grep "^model: " | cut -d' ' -f2)"
 if echo "${SNAP_MODEL}" | grep -q "^lxd-core"; then
     echo "==> LXD appliance detected, starting LXD"
-    nsenter -t 1 -m systemctl start snap.lxd.daemon --no-block
+    nsenter -t 1 -m systemctl start snap.${SNAP_INSTANCE_NAME}.daemon --no-block
     exit 0
 fi
 
@@ -107,7 +107,7 @@ fi
 echo "==> Checking if LXD needs to be activated"
 if ! "${LXD}" activateifneeded; then
     echo "====> Activation check failed, forcing activation"
-    nsenter -t 1 -m systemctl start snap.lxd.daemon
+    nsenter -t 1 -m systemctl start snap.${SNAP_INSTANCE_NAME}.daemon
 fi
 
 exit 0

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -37,7 +37,7 @@ if echo "${SNAP_MODEL}" | grep -q "^lxd-core"; then
 fi
 
 # Workaround for systemd nuking our cgroups on refreshes
-nsenter -t 1 -m systemd-run -u snap.lxd.workaround -p Delegate=yes -r /bin/true >/dev/null 2>&1 || true
+nsenter -t 1 -m systemd-run -u snap.${SNAP_INSTANCE_NAME}.workaround -p Delegate=yes -r /bin/true >/dev/null 2>&1 || true
 
 # Cleanup last state
 true > "${SNAP_COMMON}/state"


### PR DESCRIPTION
Creating your own personal snap of lxd with a different name fails during installation because the daemon.activate and daemon.start scripts hard-code the snap name to lxd:
```
# sudo snap install --devmode virtuous-sloth-lxd_0+git.d6919a5-dirty_amd64.snap
error: cannot perform the following tasks:
- Start snap "virtuous-sloth-lxd" (unset) services (systemctl command [start snap.virtuous-sloth-lxd.activate.service] failed with exit status 1: Job for snap.virtuous-sloth-lxd.activate.service failed because the control process exited with error code.
See "systemctl status snap.virtuous-sloth-lxd.activate.service" and "journalctl -xeu snap.virtuous-sloth-lxd.activate.service" for details.
```
I can do devmode without changing the snap name but would like to try pusblishing virtuous-sloth-lxd in snapcraft.io for my own edification of the whole process.

I chose SNAP_INSTANCE_NAME instead of SNAP_NAME even though lxd does not support multiple instances because it seemed the right thing to do anyway.