### PR TITLE
Bump /proc/sys/kernel/keys/maxbytes out of the box

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -409,6 +409,13 @@ if [ "$(stat -c '%u' /proc)" = 0 ]; then
         fi
     fi
 
+    if [ -e /proc/sys/kernel/keys/maxbytes ]; then
+        if [ "$(cat /proc/sys/kernel/keys/maxbytes)" -lt "2000000" ]; then
+            echo "==> Increasing the number of bytes for a nonroot user"
+            echo 2000000 > /proc/sys/kernel/keys/maxbytes || true
+        fi
+    fi
+
     if [ -e /proc/sys/kernel/unprivileged_userns_clone ]; then
         if [ "$(cat /proc/sys/kernel/unprivileged_userns_clone)" = "0" ]; then
             echo "==> Enabling unprivileged containers kernel support"


### PR DESCRIPTION
The default limit as 20000 can prevent ~20 LXD containers on a host from starting with Ubuntu guest (and cloud-init, snapd and jujud in it). 20 is not a huge number like 100 or 1,000 so it's fair to accommodate it out of the box.

Let's bump it in a similar way to /proc/sys/kernel/keys/maxkeys which we already did some time ago. See more details in
https://launchpad.net/bugs/1891223

Follow-up of #65 and #66

Signed-off-by: Nobuto Murata <nobuto.murata@canonical.com>