### PR TITLE
snapcraft: remove strip for liblxc

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1539,7 +1539,6 @@ parts:
       strip -s ${SNAPCRAFT_PRIME}/bin/lxc
       strip -s ${SNAPCRAFT_PRIME}/bin/lxd*
       strip -s ${SNAPCRAFT_PRIME}/bin/snap*
-      strip -s ${SNAPCRAFT_PRIME}/lib/liblxc*
       strip -s ${SNAPCRAFT_PRIME}/lib/libdqlite*
       strip -s ${SNAPCRAFT_PRIME}/lib/libsqlite*
 


### PR DESCRIPTION
liblxc is small even with debuginfo it's about 400 KiB.

This simplifies coredumps analysis.

Signed-off-by: Alexander Mikhalitsyn <aleksandr.mikhalitsyn@canonical.com>