### PR TITLE
daemon.start: use libsegfault for lxcfs

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -523,6 +523,11 @@ else
         [ "${lxcfs_cfs:-"false"}" = "true" ] && lxcfs_args="${lxcfs_args} --enable-cfs"
         [ "${lxcfs_debug:-"false"}" = "true" ] && lxcfs_args="${lxcfs_args} -d"
 
+        # Preload libSegFault.so to catch crashes
+        export LD_PRELOAD="${LD_PRELOAD:+${LD_PRELOAD}:}/lib/${ARCH}/libSegFault.so"
+        export SEGFAULT_USE_ALTSTACK=1
+        export SEGFAULT_SIGNALS="all"
+
         if [ -n "${lxcfs_args}" ]; then
             # shellcheck disable=SC2086
             lxcfs ${lxcfs_args} "${SNAP_COMMON}/var/lib/lxcfs" -p "${SNAP_COMMON}/lxcfs.pid" &


### PR DESCRIPTION
This option enables preloading of libSegFault.so from glibc. It allows us to easily catch and print backtrace + register values when crash occurs.

It doesn't prevent from coredump generation if needed.

Stacktrace can be read from:
journalctl -u snap.lxd.daemon.service

Example:
** Segmentation fault
147658]: Register dump:
147658]:  RAX: 0000000000000005   RBX: 00005562952d1820   RCX: 00000000ffffe000
147658]:  RDX: 0000000000000000   RSI: 00007f24fa6b4ec9   RDI: 00007f24ec000c30
147658]:  RBP: 00007f24f9d86b40   R8 : 0000000000000000   R9 : 00007f24fa68c6e8
147658]:  R10: 0000556294dde145   R11: 0000000000000007   R12: 00000000000
...

Signed-off-by: Alexander Mikhalitsyn <aleksandr.mikhalitsyn@canonical.com>