### PR TITLE
snapcraft: add glibc-tools as a stage dependency for lxcfs

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1164,6 +1164,7 @@ parts:
       - ninja-build
     stage-packages:
       - fuse3
+      - glibc-tools
     plugin: meson
     meson-parameters:
       - --prefix=/


### PR DESCRIPTION
glibc-tools provides libSegFault.so

After migration to core22 the error appeared:
... ERROR: ld.so: object '/lib/x86_64-linux-gnu/libSegFault.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.