### PR TITLE
snapcraft: add libSegFault.so to the prime step

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1182,6 +1182,8 @@ parts:
       - bin/fusermount
       - lib/*/libfuse3.so.*
 
+      - lib/*/libSegFault.so
+
       - bin/lxcfs
       - lib/liblxcfs.so
 

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -525,7 +525,7 @@ else
         [ "${lxcfs_debug:-"false"}" = "true" ] && lxcfs_args="${lxcfs_args} -d"
 
         # Preload libSegFault.so to catch crashes
-        export LD_PRELOAD="${LD_PRELOAD:+${LD_PRELOAD}:}/lib/${ARCH}/libSegFault.so"
+        export LD_PRELOAD="${LD_PRELOAD:+${LD_PRELOAD}:}${SNAP_CURRENT}/lib/${ARCH}/libSegFault.so"
         export SEGFAULT_USE_ALTSTACK=1
         export SEGFAULT_SIGNALS="all"
 


### PR DESCRIPTION
My previous fix (https://github.com/lxc/lxd-pkg-snap/pull/116) was insufficient, unfortunately.
Let's add libSegFault.so to the prime step and adjust path to it in LD_PRELOAD env variable.