### PR TITLE
Use MicroOVN's client certificate instead of ovnnb

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -324,8 +324,8 @@ if [ "${ovn_builtin:-"false"}" = "true" ]; then
 elif [ -d /var/snap/microovn/ ]; then
     echo "=> Detected MicroOVN"
     mkdir /etc/ovn
-    ln -s /var/snap/microovn/common/data/pki/ovnnb-cert.pem /etc/ovn/cert_host
-    ln -s /var/snap/microovn/common/data/pki/ovnnb-privkey.pem /etc/ovn/key_host
+    ln -s /var/snap/microovn/common/data/pki/client-cert.pem /etc/ovn/cert_host
+    ln -s /var/snap/microovn/common/data/pki/client-privkey.pem /etc/ovn/key_host
     ln -s /var/snap/microovn/common/data/pki/cacert.pem /etc/ovn/ovn-central.crt
 else
     ln -s /var/lib/snapd/hostfs/etc/ovn /etc/ovn


### PR DESCRIPTION
Client certificates are generated on all MicroOVN
nodes while OVN NB certificates are present only
on those nodes that run "central" service. Which
are, by default, first 3 nodes.

[Related MicroOVN change](https://github.com/canonical/microovn/pull/37)