### PR TITLE
github: Tweak SSH integration with Launchpad

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -23,8 +23,11 @@ jobs:
         run: |
           ssh-agent -a "${SSH_AUTH_SOCK}" > /dev/null
           ssh-add - <<< "${{ secrets.LAUNCHPAD_LXD_BOT_KEY }}"
-          mkdir -p ~/.ssh/
-          ssh-keyscan -H git.launchpad.net >> ~/.ssh/known_hosts
+          mkdir -m 0700 -p ~/.ssh/
+          # In ephemeral environments like GitHub Action runners, relying on TOFU isn't providing any security
+          # so require the key obtained by `ssh-keyscan` to match the expected hash from https://help.launchpad.net/SSHFingerprints
+          ssh-keyscan git.launchpad.net >> ~/.ssh/known_hosts
+          ssh-keygen -qlF git.launchpad.net | grep -xF 'git.launchpad.net RSA SHA256:UNOzlP66WpDuEo34Wgs8mewypV0UzqHLsIFoqwe8dYo'
 
       - name: Install Go
         uses: actions/setup-go@v4


### PR DESCRIPTION
This essentially hardcodes the expected key for git.launchpad.net meaning that it will stop working if it's ever changed. This is however the price to pay to have it's authenticity checked.