### PR TITLE
Revert "edk2: Bump to 202305"

### DIFF
--- a/patches/edk2-0004-gcc-errors.patch
+++ b/patches/edk2-0004-gcc-errors.patch
@@ -15,12 +15,15 @@ diff --git a/BaseTools/Conf/tools_def.template b/BaseTools/Conf/tools_def.templa
 index 933b3160fd..cba2cf19a8 100755
 --- a/BaseTools/Conf/tools_def.template
 +++ b/BaseTools/Conf/tools_def.template
-@@ -739,7 +739,7 @@ NOOPT_*_*_OBJCOPY_ADDDEBUGFLAG     = --a
+@@ -1918,7 +1918,7 @@ NOOPT_*_*_OBJCOPY_ADDDEBUGFLAG     = --add-gnu-debuglink=$(DEBUG_DIR)/$(MODULE_N
  *_*_*_DTCPP_PATH                   = DEF(DTCPP_BIN)
  *_*_*_DTC_PATH                     = DEF(DTC_BIN)
  
 -DEFINE GCC_ALL_CC_FLAGS            = -g -Os -fshort-wchar -fno-builtin -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -include AutoGen.h -fno-common
 +DEFINE GCC_ALL_CC_FLAGS            = -g -Os -fshort-wchar -fno-builtin -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -include AutoGen.h -fno-common -Wno-maybe-uninitialized
- DEFINE GCC_ARM_CC_FLAGS            = DEF(GCC_ALL_CC_FLAGS) -mlittle-endian -mabi=aapcs -fno-short-enums -funsigned-char -ffunction-sections -fdata-sections -fomit-frame-pointer -Wno-address -mthumb -fno-pic -fno-pie
- DEFINE GCC_LOONGARCH64_CC_FLAGS    = DEF(GCC_ALL_CC_FLAGS) -mabi=lp64d -fno-asynchronous-unwind-tables -fno-plt -Wno-address -fno-short-enums -fsigned-char -ffunction-sections -fdata-sections
- DEFINE GCC_ARM_CC_XIPFLAGS         = -mno-unaligned-access
+ DEFINE GCC_IA32_CC_FLAGS           = DEF(GCC_ALL_CC_FLAGS) -m32 -malign-double -freorder-blocks -freorder-blocks-and-partition -O2 -mno-stack-arg-probe
+ DEFINE GCC_X64_CC_FLAGS            = DEF(GCC_ALL_CC_FLAGS) -mno-red-zone -Wno-address -mno-stack-arg-probe
+ DEFINE GCC_ARM_CC_FLAGS            = DEF(GCC_ALL_CC_FLAGS) -mlittle-endian -mabi=aapcs -fno-short-enums -funsigned-char -ffunction-sections -fdata-sections -fomit-frame-pointer -Wno-address -mthumb -mfloat-abi=soft -fno-pic -fno-pie
+-- 
+2.27.0
+

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -304,7 +304,7 @@ parts:
     override-pull: |-
       [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
       set -ex
-      git clone https://github.com/tianocore/edk2 . -b edk2-stable202305
+      git clone https://github.com/tianocore/edk2 . -b edk2-stable202208
 
       git config user.email "noreply@lists.canonical.com"
       git config user.name "LXD snap builder"


### PR DESCRIPTION
This reverts commit 4e7f26458c4418e0bda215d055c705d80a3b6854.

It was discovered that starting from edk2-stable202302 old Linux kernels are failing to find a root block device and to boot:
```
[ 0.810971] virtio_scsi virtio6: virtio: device uses modern interface
but does not have VIRTIO_F_VERSION_1
[ 0.815024] virtio_net virtio10: virtio: device uses modern interface
but does not have VIRTIO_F_VERSION_1

...

[ 0.816576] virtio_net: probe of virtio10 failed with error -22
[ 0.819963] ACPI: PCI Interrupt Link [GSIA] enabled at IRQ 16
[ 0.821354] ahci 0000:00:1f.2: AHCI 0001.0000 32 slots 6 ports 1.5
Gbps 0x3f impl SATA mode
[ 0.822518] ahci 0000:00:1f.2: flags: 64bit ncq only
[ 0.824508] virtio_scsi: probe of virtio6 failed with error -22
```

Issue is reproducible only on AMD processors.

See also:
https://discourse.ubuntu.com/t/ubuntu-18-04-vm-doesnt-start-on-ubuntu-20-04-on-lxd-5-15/37048

This is a *temporary* workaround. We still need to debug edk2 and fix it.

@stgraber found workaround that works without downgrading edk2:
`lxc config set NAME raw.qemu "-cpu qemu64"`