### PR TITLE
edk2: disable EFI memory attributes protocol

### DIFF
--- a/patches/edk2-0006-disable-EFI-memory-attributes-protocol.patch
+++ b/patches/edk2-0006-disable-EFI-memory-attributes-protocol.patch
@@ -1,0 +1,30 @@
+From cb5e0080ffd3f522f83b8e9273eac10e132ce7c7 Mon Sep 17 00:00:00 2001
+From: Alexander Mikhalitsyn <aleksandr.mikhalitsyn@canonical.com>
+Date: Thu, 7 Sep 2023 09:07:08 +0200
+Subject: [PATCH] edk2: disable EFI memory attributes protocol
+
+https://github.com/canonical/lxd/issues/12211
+
+Signed-off-by: Alexander Mikhalitsyn <aleksandr.mikhalitsyn@canonical.com>
+---
+ ArmPkg/Drivers/CpuDxe/CpuDxe.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ArmPkg/Drivers/CpuDxe/CpuDxe.c b/ArmPkg/Drivers/CpuDxe/CpuDxe.c
+index d04958e79e..c01d571379 100644
+--- a/ArmPkg/Drivers/CpuDxe/CpuDxe.c
++++ b/ArmPkg/Drivers/CpuDxe/CpuDxe.c
+@@ -244,8 +244,8 @@ CpuDxeInitialize (
+                   &mCpuHandle,
+                   &gEfiCpuArchProtocolGuid,
+                   &mCpu,
+-                  &gEfiMemoryAttributeProtocolGuid,
+-                  &mMemoryAttribute,
++//                  &gEfiMemoryAttributeProtocolGuid,
++//                  &mMemoryAttribute,
+                   NULL
+                   );
+ 
+-- 
+2.34.1
+

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -322,6 +322,7 @@ parts:
       patch -p1 < "${CRAFT_PROJECT_DIR}/patches/edk2-0003-boot-delay.patch"
       patch -p1 < "${CRAFT_PROJECT_DIR}/patches/edk2-0004-gcc-errors.patch"
       patch --binary -p1 < "${CRAFT_PROJECT_DIR}/patches/edk2-0005-disable-dynamic-mmio-winsize.patch"
+      patch --binary -p1 < "${CRAFT_PROJECT_DIR}/patches/edk2-0006-disable-EFI-memory-attributes-protocol.patch"
 
       # Setup CSM blob
       if [ "$(uname -m)" = "x86_64" ]; then


### PR DESCRIPTION
Unfortunately, we have to disable EFI memory attributes protocol that was introduced in
https://github.com/tianocore/edk2/commit/1c4dfadb4611ef511816dfdfbdb37d7d100b5a4b starting from edk2-stable202305 as it leads to crash of SecureBoot shim

There is a fix for shim that addresses this issue, but it will take a few month until this fix will be landed to different Linux distros and we can't make our users wait for it.
Fix for shim:
https://github.com/rhboot/shim/commit/c7b305152802c8db688605654f75e1195def9fd6

Fixes https://github.com/canonical/lxd/issues/12211