### PR TITLE
edk2: set SMM_REQUIRE=FALSE

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -354,7 +354,7 @@ parts:
               . ./edksetup.sh
               make -C BaseTools ARCH=${ARCH}
               build -a ${ARCH} -t GCC5 -b RELEASE -p ${PKG} \
-                -DSMM_REQUIRE=TRUE \
+                -DSMM_REQUIRE=FALSE \
                 -DSECURE_BOOT_ENABLE=TRUE \
                 -DNETWORK_IP4_ENABLE=TRUE \
                 -DNETWORK_IP6_ENABLE=TRUE \


### PR DESCRIPTION
It was reported [1] that on VM with relatively large amount (>12) of vCPUs boot process get stuck just after BdsDxe: loading Boot000C "ubuntu" from HD(15,GPT,...)/\EFI\ubuntu\shimx64.efi BdsDxe: starting Boot000C "ubuntu" from HD(15,GPT,... is printed to the VM console.

Matthew Parkinson (topic starter) discovered that disabling SMM_REQUIRE helps to fix issue.

Currently we don't know where the bug is, it can be Linux Kernel KVM, Qemu or EDK2. I'm on the way to make a good report for upstream developers.

I was able to reproduce an analogical issue on my laptop with VM that has 15 vCPUs and can confirm that SMM_REQUIRE=FALSE fixes issue for me too. Reproducer rate on my environment is like 1/10.

I believe that it makes sense to disable SMM as it should not make any troubles for our users but instead make VMs work for some users.

[1] https://discourse.ubuntu.com/t/lxd-vm-agent-fails-to-come-online-with-lxd-5-15-and-large-vm-resource-requirements