### PR TITLE
snapcraft: ensure BLAS is installed (required by numpy)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1345,6 +1345,8 @@ parts:
       - libudev-dev
       - libxml2-dev
       - libxslt-dev
+      - libblas-dev
+      - liblapack-dev
       - pkg-config
       - shellcheck
       - pypy-dev


### PR DESCRIPTION
Fix the following:
*  https://launchpadlibrarian.net/687861641/buildlog_snap_ubuntu_jammy_ppc64el_lxd-latest-edge_BUILDING.txt.gz
* https://launchpadlibrarian.net/687861866/buildlog_snap_ubuntu_jammy_s390x_lxd-latest-edge_BUILDING.txt.gz