### PR TITLE
Content interface for MicroCeph

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -59,6 +59,11 @@ source-code: https://github.com/canonical/lxd
 website: https://ubuntu.com/lxd
 confinement: strict
 
+plugs:
+ ceph-conf:
+   interface: content
+   target: "$SNAP_DATA/microceph"
+
 apps:
   # Main commands
   activate:

--- a/snapcraft/hooks/connect-plug-ceph-conf
+++ b/snapcraft/hooks/connect-plug-ceph-conf
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# Utility functions
+get_bool() {
+    value=$(echo "${1:-}" | tr '[:upper:]' '[:lower:]')
+
+    # See if it's true
+    for yes in "true" "1" "yes" "on"; do
+        if [ "${value}" = "${yes}" ]; then
+            echo "true"
+            return
+        fi
+    done
+
+    # See if it's false
+    for no in "false" "0" "no" "off"; do
+        if [ "${value}" = "${no}" ]; then
+            echo "false"
+            return
+        fi
+    done
+
+    # Invalid value (or not set)
+    return
+}
+
+ceph_builtin=$(get_bool "$(snapctl get ceph.builtin)")
+
+if ! [ "${ceph_builtin:-"false"}" = "true" ]; then
+  ln -snf ${SNAP_DATA}/microceph/conf/ /etc/ceph
+fi

--- a/snapcraft/hooks/disconnect-plug-ceph-conf
+++ b/snapcraft/hooks/disconnect-plug-ceph-conf
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# Utility functions
+get_bool() {
+    value=$(echo "${1:-}" | tr '[:upper:]' '[:lower:]')
+
+    # See if it's true
+    for yes in "true" "1" "yes" "on"; do
+        if [ "${value}" = "${yes}" ]; then
+            echo "true"
+            return
+        fi
+    done
+
+    # See if it's false
+    for no in "false" "0" "no" "off"; do
+        if [ "${value}" = "${no}" ]; then
+            echo "false"
+            return
+        fi
+    done
+
+    # Invalid value (or not set)
+    return
+}
+
+ceph_builtin=$(get_bool "$(snapctl get ceph.builtin)")
+
+if [ "${ceph_builtin:-"false"}" = "true" ]; then
+    mkdir -p "${SNAP_COMMON}/ceph"
+    ln -snf "${SNAP_COMMON}/ceph" /etc/ceph
+else
+    ln -snf /var/lib/snapd/hostfs/etc/ceph /etc/ceph
+fi


### PR DESCRIPTION
Adds support in LXD for `MicroCeph`s `ceph-conf` slot.

This will add a directory under `/var/snap/lxd/` containing the data in microceph at `/var/snap/microceph/current`. When the slot is connected to the plug, the `connect` hook runs, setting the appropriate `MicroCeph` symlink. On disconnect, it resets the symlink back to `hostfs` or `builtin`.

There's some quirks around auto-connection because it's only supposed to work with the same publisher, and `--devmode` snaps don't have a publisher so I can't actually test that until this is merged into `latest/edge`. For that reason I've split removing the corresponding blocks in `daemon.start` to a different PR.