### PR TITLE
Remove MicroCeph setup from daemon.start

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -295,8 +295,6 @@ echo "==> Setting up ceph configuration"
 if [ "${ceph_builtin:-"false"}" = "true" ]; then
     mkdir -p "${SNAP_COMMON}/ceph"
     ln -s "${SNAP_COMMON}/ceph" /etc/ceph
-elif [ -e "/var/snap/microceph" ]; then
-    ln -s /var/snap/microceph/current/conf/ /etc/ceph
 else
     ln -s /var/lib/snapd/hostfs/etc/ceph /etc/ceph
 fi


### PR DESCRIPTION
As mentioned in #149, this PR is split out so we can be sure the autoconnection of snaps works before potentially losing functionality.