### PR TITLE
Content interface for MicroOVN

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -59,6 +59,10 @@ source-code: https://github.com/canonical/lxd
 website: https://ubuntu.com/lxd
 confinement: strict
 
+ ovn-conf:
+   interface: content
+   target: "${SNAP_DATA}/microovn"
+
 apps:
   # Main commands
   activate:

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -321,12 +321,6 @@ echo "==> Setting up OVN configuration"
 if [ "${ovn_builtin:-"false"}" = "true" ]; then
     mkdir -p "${SNAP_COMMON}/ovn"
     ln -s "${SNAP_COMMON}/ovn" /etc/ovn
-elif [ -d /var/snap/microovn/ ]; then
-    echo "=> Detected MicroOVN"
-    mkdir /etc/ovn
-    ln -s /var/snap/microovn/common/data/pki/client-cert.pem /etc/ovn/cert_host
-    ln -s /var/snap/microovn/common/data/pki/client-privkey.pem /etc/ovn/key_host
-    ln -s /var/snap/microovn/common/data/pki/cacert.pem /etc/ovn/ovn-central.crt
 else
     ln -s /var/lib/snapd/hostfs/etc/ovn /etc/ovn
 fi
@@ -486,8 +480,6 @@ if [ "${openvswitch_builtin:-"false"}" = "true" ]; then
            "${SNAP}/share/openvswitch/scripts/ovs-ctl" start --system-id=random
         )
     )
-elif [ -d /var/snap/microovn/ ]; then
-    ln -s /var/snap/microovn/common/run/switch /run/openvswitch
 else
     ln -s /var/lib/snapd/hostfs/run/openvswitch /run/openvswitch
 fi

--- a/snapcraft/hooks/connect-plug-ovn-data
+++ b/snapcraft/hooks/connect-plug-ovn-data
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if ! test -e /etc/ovn ; then
+  mkdir /etc/ovn
+fi
+
+ln -snf ${SNAP_DATA}/microovn/data/pki/client-cert.pem /etc/ovn/cert_host
+ln -snf ${SNAP_DATA}/microovn/data/pki/client-privkey.pem /etc/ovn/key_host
+ln -snf ${SNAP_DATA}/microovn/data/pki/cacert.pem /etc/ovn/ovn-central.crt

--- a/snapcraft/hooks/connect-plug-ovn-run
+++ b/snapcraft/hooks/connect-plug-ovn-run
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+
+ln -snf ${SNAP_DATA}/microovn/run/switch /run/openvswitch

--- a/snapcraft/hooks/disconnect-plug-ovn-data
+++ b/snapcraft/hooks/disconnect-plug-ovn-data
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ "${ovn_builtin:-"false"}" = "true" ]; then
+    mkdir -p "${SNAP_COMMON}/ovn"
+    ln -snf "${SNAP_COMMON}/ovn" /etc/ovn
+else
+    ln -snf /var/lib/snapd/hostfs/etc/ovn /etc/ovn
+fi

--- a/snapcraft/hooks/disconnect-plug-ovn-run
+++ b/snapcraft/hooks/disconnect-plug-ovn-run
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+if [ "${openvswitch_builtin:-"false"}" = "true" ]; then
+    export OVS_RUNDIR="${SNAP_COMMON}/openvswitch/run/"
+    (
+        set -e
+        export OVS_LOGDIR="${SNAP_COMMON}/openvswitch/logs/"
+        export OVS_DBDIR="${SNAP_COMMON}/openvswitch/db/"
+        export OVS_SYSCONFDIR="${SNAP_COMMON}/openvswitch/conf/"
+        export OVS_PKGDATADIR="${SNAP}/share/openvswitch/"
+        export OVS_BINDIR="${SNAP}/bin/"
+        export OVS_SBINDIR="${SNAP}/bin/"
+
+        mkdir -p "${OVS_SYSCONFDIR}/openvswitch"
+        (
+            # Close socket activation fd
+            exec 3<&- || true
+
+           "${SNAP}/share/openvswitch/scripts/ovs-ctl" start --system-id=random
+        )
+    )
+else
+    ln -snf /var/lib/snapd/hostfs/run/openvswitch /run/openvswitch
+fi


### PR DESCRIPTION
Adds support for the hypothetical `MicroOVN` `ovn-conf` slot, which does not yet exist. This will be a draft until it does.