### PR TITLE
snapcraft: adding OpenBLAS dependency to solve numpy build issue

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1346,6 +1346,7 @@ parts:
       - libxml2-dev
       - libxslt-dev
       - libblas-dev
+      - libopenblas-dev
       - liblapack-dev
       - pkg-config
       - shellcheck


### PR DESCRIPTION
The latest numpy branch set `openblas` as its BLAS backend by default : https://github.com/numpy/numpy/blob/main/meson_options.txt

