### PR TITLE
edk2: disable EFI memory attributes protocol again

### DIFF
--- a/patches/edk2-0006-disable-EFI-memory-attributes-protocol.patch
+++ b/patches/edk2-0006-disable-EFI-memory-attributes-protocol.patch
@@ -1,0 +1,30 @@
+From cb5e0080ffd3f522f83b8e9273eac10e132ce7c7 Mon Sep 17 00:00:00 2001
+From: Alexander Mikhalitsyn <aleksandr.mikhalitsyn@canonical.com>
+Date: Thu, 7 Sep 2023 09:07:08 +0200
+Subject: [PATCH] edk2: disable EFI memory attributes protocol
+
+https://github.com/canonical/lxd/issues/12211
+
+Signed-off-by: Alexander Mikhalitsyn <aleksandr.mikhalitsyn@canonical.com>
+---
+ ArmPkg/Drivers/CpuDxe/CpuDxe.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ArmPkg/Drivers/CpuDxe/CpuDxe.c b/ArmPkg/Drivers/CpuDxe/CpuDxe.c
+index d04958e79e..c01d571379 100644
+--- a/ArmPkg/Drivers/CpuDxe/CpuDxe.c
++++ b/ArmPkg/Drivers/CpuDxe/CpuDxe.c
+@@ -244,8 +244,8 @@ CpuDxeInitialize (
+                   &mCpuHandle,
+                   &gEfiCpuArchProtocolGuid,
+                   &mCpu,
+-                  &gEfiMemoryAttributeProtocolGuid,
+-                  &mMemoryAttribute,
++//                  &gEfiMemoryAttributeProtocolGuid,
++//                  &mMemoryAttribute,
+                   NULL
+                   );
+ 
+-- 
+2.34.1
+

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -324,6 +324,7 @@ parts:
       patch --binary -p1 < "${CRAFT_PROJECT_DIR}/patches/edk2-0005-disable-dynamic-mmio-winsize.patch"
       # revert "ArmVirtPkg: make EFI_LOADER_DATA non-executable" as it breaks almost everything
       git revert 2997ae38739756ecba9b0de19e86032ebc689ef9
+      patch --binary -p1 < "${CRAFT_PROJECT_DIR}/patches/edk2-0006-disable-EFI-memory-attributes-protocol.patch"
 
       # Setup CSM blob
       if [ "$(uname -m)" = "x86_64" ]; then


### PR DESCRIPTION
Unfortunately, we have to disable EFI memory attributes protocol that was introduced in
https://github.com/tianocore/edk2/commit/1c4dfadb4611ef511816dfdfbdb37d7d100b5a4b starting from edk2-stable202305 as it leads to crash of SecureBoot shim

There is a fix for shim that addresses this issue, but it will take a few month until this fix will be landed to different Linux distros and we can't make our users wait for it.
Fix for shim:
https://github.com/rhboot/shim/commit/c7b305152802c8db688605654f75e1195def9fd6

This commit was reverted as a part of ("edk2: disable NX protection feature") but it was a mistake. Somehow, I made a systematic error in my test of edk2 with ("edk2: disable EFI memory attributes protocol") reverted and found that it works. But it's not. And I found *why* I made this mistake.

Just to be clear EFI_MEMORY_ATTRIBUTES protocol and "ArmVirtPkg: make EFI_LOADER_DATA non-executable" are about setting NX flags on some pages on arm64. And both of commits led to regressions but on the *different* stages of boot process.

I. "ArmVirtPkg: make EFI_LOADER_DATA non-executable" makes boot process to fail with Synchronous Exception *after* efi-shim/grub2 finished their work: ================
BdsDxe: loading Boot0001 "UEFI QEMU QEMU HARDDISK " from PciRoot(0x0)/Pci(0x1,0x1)/Pci(0x0,0x0)/Scsi(0x0,0x1) BdsDxe: starting Boot0001 "UEFI QEMU QEMU HARDDISK " from PciRoot(0x0)/Pci(0x1,0x1)/Pci(0x0,0x0)/Scsi(0x0,0x1) Welcome to GRUB!
  Booting `openSUSE Leap 15.5'

Loading Linux 5.14.21-150500.55.19-default ...
Loading initial ramdisk ...

Synchronous Exception at 0x000000006C217504
================

II. EFI_MEMORY_ATTRIBUTES ("ArmPkg/CpuDxe: Implement EFI memory attributes protocol") makes shim (!) to fail with Synchronous Exception like that: ================
BdsDxe: loading Boot0001 "UEFI QEMU QEMU HARDDISK " from PciRoot(0x0)/Pci(0x1,0x1)/Pci(0x0,0x0)/Scsi(0x0,0x1) BdsDxe: starting Boot0001 "UEFI QEMU QEMU HARDDISK " from PciRoot(0x0)/Pci(0x1,0x1)/Pci(0x0,0x0)/Scsi(0x0,0x1)

Synchronous Exception at 0x000000007C318000

Synchronous Exception at 0x000000007C318000
================

Now about *how* I made this mistake during testing. $ lxc launch ubuntu:jammy jammy-secboot1 --vm -c security.secureboot=true --console Synchronous Exception
$ lxc stop jammy-secboot1 --force
$ ./replace_firmware.sh
$ lxc start jammy-secboot1 --console
Everything works!
$ lxc stop jammy-secboot1 --force
$ ./revert_firmware.sh
$ lxc start jammy-secboot1 --console
Everything is still working!

The catch here is that Synchronous Exception that happens in shim happens only on a clean NVRAM! If VM was boot successfully one time, then it will boot successfuly even after upgrade to a new firmware. (only about EFI_MEMORY_ATTRIBUTE protocol thing!)

Fixes https://github.com/canonical/lxd/issues/12211