### PR TITLE
snapcraft/hooks: Share common functions among hooks

### DIFF
--- a/snapcraft/hooks/configure
+++ b/snapcraft/hooks/configure
@@ -1,46 +1,16 @@
-#!/bin/sh -eu
+#!/bin/sh
+
+set -eu
 
 # Re-exec outside of apparmor confinement
 if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" != "unconfined" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
 fi
 
-# Utility functions
-get_bool() {
-    value=$(echo "${1:-}" | tr '[:upper:]' '[:lower:]')
+SNAP_CURRENT="$(realpath "${SNAP}/..")/current"
+export "${SNAP_CURRENT}"
 
-    # See if it's true
-    for yes in "true" "1" "yes" "on"; do
-        if [ "${value}" = "${yes}" ]; then
-            echo "true"
-            return
-        fi
-    done
-
-    # See if it's false
-    for no in "false" "0" "no" "off"; do
-        if [ "${value}" = "${no}" ]; then
-            echo "false"
-            return
-        fi
-    done
-
-    # Invalid value (or not set)
-    return
-}
-
-verify_int () {
-    value="${1:-}"
-
-    # Verify if the value is a positive integer
-    if echo "${value}" | grep -Eq '^[0-9]+$'; then
-        echo "${value}"
-        return
-    fi
-
-    # Invalid value (or not set)
-    return
-}
+. "${SNAP_CURRENT}/snap/hooks/common"
 
 # Don't fail if the mount namespace isn't properly setup yet
 if [ ! -e /run/snapd-snap.socket ]; then

--- a/snapcraft/hooks/connect-plug-ceph-conf
+++ b/snapcraft/hooks/connect-plug-ceph-conf
@@ -1,31 +1,13 @@
 #!/bin/sh
 
-# Utility functions
-get_bool() {
-    value=$(echo "${1:-}" | tr '[:upper:]' '[:lower:]')
+set -eu
 
-    # See if it's true
-    for yes in "true" "1" "yes" "on"; do
-        if [ "${value}" = "${yes}" ]; then
-            echo "true"
-            return
-        fi
-    done
+SNAP_CURRENT="$(realpath "${SNAP}/..")/current"
+export "${SNAP_CURRENT}"
 
-    # See if it's false
-    for no in "false" "0" "no" "off"; do
-        if [ "${value}" = "${no}" ]; then
-            echo "false"
-            return
-        fi
-    done
-
-    # Invalid value (or not set)
-    return
-}
+. "${SNAP_CURRENT}/snap/hooks/common"
 
 ceph_builtin=$(get_bool "$(snapctl get ceph.builtin)")
-
 if ! [ "${ceph_builtin:-"false"}" = "true" ]; then
   ln -snf ${SNAP_DATA}/microceph/conf/ /etc/ceph
 fi

--- a/snapcraft/hooks/disconnect-plug-ceph-conf
+++ b/snapcraft/hooks/disconnect-plug-ceph-conf
@@ -1,31 +1,13 @@
 #!/bin/sh
 
-# Utility functions
-get_bool() {
-    value=$(echo "${1:-}" | tr '[:upper:]' '[:lower:]')
+set -eu
 
-    # See if it's true
-    for yes in "true" "1" "yes" "on"; do
-        if [ "${value}" = "${yes}" ]; then
-            echo "true"
-            return
-        fi
-    done
+SNAP_CURRENT="$(realpath "${SNAP}/..")/current"
+export "${SNAP_CURRENT}"
 
-    # See if it's false
-    for no in "false" "0" "no" "off"; do
-        if [ "${value}" = "${no}" ]; then
-            echo "false"
-            return
-        fi
-    done
-
-    # Invalid value (or not set)
-    return
-}
+. "${SNAP_CURRENT}/snap/hooks/common"
 
 ceph_builtin=$(get_bool "$(snapctl get ceph.builtin)")
-
 if [ "${ceph_builtin:-"false"}" = "true" ]; then
     mkdir -p "${SNAP_COMMON}/ceph"
     ln -snf "${SNAP_COMMON}/ceph" /etc/ceph


### PR DESCRIPTION
Turns out the correct path to source here is `{SNAP}/snap/hooks/`. We already do this in `daemon.start` as well, to source the `configure` script: https://github.com/canonical/lxd-pkg-snap/blob/440402dbd32e5d61977106cc8acc988ed47e280b/snapcraft/commands/daemon.start#L48

The difference being that in `daemon.start` we use `/meta` which `exec`s the scripts under `/snap`.

