### PR TITLE
snapcraft/hooks: Remove shebang and executable bit on common file

### DIFF
--- a/snapcraft/hooks/common
+++ b/snapcraft/hooks/common
@@ -1,6 +1,3 @@
-#!/bin/sh
-
-
 set -eu
 
 # Utility functions


### PR DESCRIPTION
**Note**: this was not tested locally due to a local problem with `snapcraft`.