### PR TITLE
snapcraft/hooks: Exec interface hooks outside of apparmor confinement

### DIFF
--- a/snapcraft/hooks/connect-plug-ceph-conf
+++ b/snapcraft/hooks/connect-plug-ceph-conf
@@ -1,4 +1,10 @@
 #!/bin/sh
+set -eu
+
+# Re-exec outside of apparmor confinement
+if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" != "unconfined" ]; then
+    exec aa-exec -p unconfined -- "$0" "$@"
+fi
 
 # Utility functions
 get_bool() {

--- a/snapcraft/hooks/disconnect-plug-ceph-conf
+++ b/snapcraft/hooks/disconnect-plug-ceph-conf
@@ -1,4 +1,10 @@
 #!/bin/sh
+set -eu
+
+# Re-exec outside of apparmor confinement
+if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" != "unconfined" ]; then
+    exec aa-exec -p unconfined -- "$0" "$@"
+fi
 
 # Utility functions
 get_bool() {


### PR DESCRIPTION
`edge` is once again broken, but now only when `microceph` is already installed.

Another error that couldn't be picked up by a local install with snap install --dangerous

The hooks fail with the error:
```
- Run hook connect-plug-ceph-conf of snap "lxd" (run hook "connect-plug-ceph-conf": ln: failed to create symbolic link '/etc/ceph': Permission denied)
```

So this commit adds a line that execs them outside the apparmor confinement to get around the error, similar to the `configure` hook.