### PR TITLE
MicroCeph content interface

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -59,6 +59,11 @@ source-code: https://github.com/canonical/lxd
 website: https://ubuntu.com/lxd
 confinement: strict
 
+plugs:
+ ceph-conf:
+   interface: content
+   target: "$SNAP_DATA/microceph"
+
 apps:
   # Main commands
   activate:
@@ -141,6 +146,14 @@ apps:
       - system-observe
 
 hooks:
+  connect-plug-ceph-conf:
+    plugs:
+      - lxd-support
+      - system-observe
+  disconnect-plug-ceph-conf:
+    plugs:
+      - lxd-support
+      - system-observe
   configure:
     plugs:
       - lxd-support

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -295,8 +295,6 @@ echo "==> Setting up ceph configuration"
 if [ "${ceph_builtin:-"false"}" = "true" ]; then
     mkdir -p "${SNAP_COMMON}/ceph"
     ln -s "${SNAP_COMMON}/ceph" /etc/ceph
-elif [ -e "/var/snap/microceph" ]; then
-    ln -s /var/snap/microceph/current/conf/ /etc/ceph
 else
     ln -s /var/lib/snapd/hostfs/etc/ceph /etc/ceph
 fi

--- a/snapcraft/hooks/connect-plug-ceph-conf
+++ b/snapcraft/hooks/connect-plug-ceph-conf
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -eu
+
+# Re-exec outside of apparmor confinement
+if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" != "unconfined" ]; then
+    exec aa-exec -p unconfined -- "$0" "$@"
+fi
+
+# Utility functions
+get_bool() {
+    value=$(echo "${1:-}" | tr '[:upper:]' '[:lower:]')
+
+    # See if it's true
+    for yes in "true" "1" "yes" "on"; do
+        if [ "${value}" = "${yes}" ]; then
+            echo "true"
+            return
+        fi
+    done
+
+    # See if it's false
+    for no in "false" "0" "no" "off"; do
+        if [ "${value}" = "${no}" ]; then
+            echo "false"
+            return
+        fi
+    done
+
+    # Invalid value (or not set)
+    return
+}
+
+ceph_builtin=$(get_bool "$(snapctl get ceph.builtin)")
+
+if ! [ "${ceph_builtin:-"false"}" = "true" ]; then
+  ln -snf ${SNAP_DATA}/microceph/conf/ /etc/ceph
+fi

--- a/snapcraft/hooks/disconnect-plug-ceph-conf
+++ b/snapcraft/hooks/disconnect-plug-ceph-conf
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -eu
+
+# Re-exec outside of apparmor confinement
+if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" != "unconfined" ]; then
+    exec aa-exec -p unconfined -- "$0" "$@"
+fi
+
+# Utility functions
+get_bool() {
+    value=$(echo "${1:-}" | tr '[:upper:]' '[:lower:]')
+
+    # See if it's true
+    for yes in "true" "1" "yes" "on"; do
+        if [ "${value}" = "${yes}" ]; then
+            echo "true"
+            return
+        fi
+    done
+
+    # See if it's false
+    for no in "false" "0" "no" "off"; do
+        if [ "${value}" = "${no}" ]; then
+            echo "false"
+            return
+        fi
+    done
+
+    # Invalid value (or not set)
+    return
+}
+
+ceph_builtin=$(get_bool "$(snapctl get ceph.builtin)")
+
+if [ "${ceph_builtin:-"false"}" = "true" ]; then
+    mkdir -p "${SNAP_COMMON}/ceph"
+    ln -snf "${SNAP_COMMON}/ceph" /etc/ceph
+else
+    ln -snf /var/lib/snapd/hostfs/etc/ceph /etc/ceph
+fi


### PR DESCRIPTION
There's 2 changes here relative to the previous implementation:

1) There are added entries in `snapcraft.yaml` for the hooks `connect-plug-ceph-conf` and `disconnect-plug-ceph-conf` which add the `lxd-support` and `system-observe` plugs, allowing super-privileged access to call `aa-exec -p unconfined`. 

2) MicroCeph handling is removed from `daemon.start` since we have confirmed that autoconnection to the microceph snap does indeed work.

On point 1, I think there was a bit of user-error in my final attempt last night. I've been installing the snaps in a VM with 

```
snap remove lxd --purge ; snap install lxd ; snap install --dangerous /root/lxd.broken.snap
``` 
but I may have used the wrong snap last night, because rebuilding and trying again today, I can actually see the error:

```
error: cannot perform the following tasks:
- Run hook connect-plug-ceph-conf of snap "lxd" (run hook "connect-plug-ceph-conf":
-----
cat: /proc/self/attr/current: Permission denied
/snap/lxd/x1/snap/hooks/connect-plug-ceph-conf: 6: exec: aa-exec: Permission denied
-----)
```

Which means this one isn't actually hidden behind publishing like I thought. Can't say the same for the other errors, so I've still left out the `common` file handling until we can test that locally.

I've also confirmed that with the additional lines for `lxd-support` and `system-observe`, I don't get that error when the hooks fire.