### PR TITLE
Disable Apparmor unprivileged userns mediation

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -418,6 +418,13 @@ if [ "$(stat -c '%u' /proc)" = 0 ]; then
         fi
     fi
 
+    if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+        if [ "$(cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" = "1" ]; then
+            echo "==> Disabling Apparmor unprivileged userns mediation"
+            echo 0 > /proc/sys/kernel/apparmor_restrict_unprivileged_userns || true
+        fi
+    fi
+
     if [ -e /proc/sys/kernel/unprivileged_userns_clone ]; then
         if [ "$(cat /proc/sys/kernel/unprivileged_userns_clone)" = "0" ]; then
             echo "==> Enabling unprivileged containers kernel support"

--- a/snapcraft/wrappers/editor
+++ b/snapcraft/wrappers/editor
@@ -16,7 +16,8 @@ run_cmd() {
 }
 
 USERNS=1
-[ -e /proc/sys/kernel/unprivileged_userns_clone ] && grep -q 0 /proc/sys/kernel/unprivileged_userns_clone && USERNS=0
+[ -e /proc/sys/kernel/unprivileged_userns_clone ] && grep -qxF 0 /proc/sys/kernel/unprivileged_userns_clone && USERNS=0
+[ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ] && grep -qxF 1 /proc/sys/kernel/apparmor_restrict_unprivileged_userns && USERNS=0
 
 find_and_spawn() {
     for path in / /usr/ /usr/local/; do

--- a/snapcraft/wrappers/remote-viewer
+++ b/snapcraft/wrappers/remote-viewer
@@ -15,7 +15,8 @@ run_cmd() {
 }
 
 USERNS=1
-[ -e /proc/sys/kernel/unprivileged_userns_clone ] && grep -q 0 /proc/sys/kernel/unprivileged_userns_clone && USERNS=0
+[ -e /proc/sys/kernel/unprivileged_userns_clone ] && grep -qxF 0 /proc/sys/kernel/unprivileged_userns_clone && USERNS=0
+[ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ] && grep -qxF 1 /proc/sys/kernel/apparmor_restrict_unprivileged_userns && USERNS=0
 
 find_and_spawn() {
     for path in / /usr/ /usr/local/; do


### PR DESCRIPTION
Implement the short-term solution for [#11920](https://github.com/canonical/lxd/issues/11920)

Tests done:

The snap built from this PR effectively disables the AA mediation if need be:
```
root@ma:~# echo 1 > /proc/sys/kernel/apparmor_restrict_unprivileged_userns
root@ma:~# snap start lxd
Started.
root@ma:~# cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns
0
root@ma:~# journalctl -b0 -u snap.lxd.daemon.service --grep Apparmor
Oct 03 16:13:27 ma lxd.daemon[7351]: ==> Disabling Apparmor unprivileged userns mediation
```

And this allows using the EDITOR:

```
root@ma:~# export EDITOR=vim
root@ma:~# lxc config edit c1
```

```
root@ma:~# ps faux
...
root         336  0.1  1.8 1240108 17668 ?       Ssl  16:06   0:01 /run/lxd_agent/lxd-agent
root        1222  0.0  0.3   9696  3072 pts/0    Ss   16:06   0:00  \_ su -l
root        1246  0.0  0.4   9152  4480 pts/0    S    16:06   0:00  |   \_ -bash
root        4460  0.0  0.6  34852  6272 pts/0    S    16:09   0:00  |       \_ journalctl -fu snap.lxd.daemon
root       11268  1.2  1.7 1538916 17152 pts/0   Sl+  16:19   0:00  |       \_ /snap/lxd/x2/bin/lxc config edit c1
root       11289  0.0  0.1   3208  1664 pts/0    S+   16:19   0:00  |           \_ unshare --kill-child -U -m -p -r -f -R /var/lib/snapd/hostfs/ /bin/sh -c mount -t proc proc /proc 2>/dev/null || true; exec "vim" "/proc/self/fd/9/lxd_editor_1580859729.yaml"
root       11295  2.1  1.3  24244 12928 pts/0    Sl+  16:19   0:00  |               \_ vim /proc/self/fd/9/lxd_editor_1580859729.yaml
```

If one re-enables the AA mediation after LXD started, it will use `vim.tiny` from the snap:

```
root@ma:~# echo 1 > /proc/sys/kernel/apparmor_restrict_unprivileged_userns
root@ma:~# export EDITOR=vim
root@ma:~# lxc config edit c1
```

```
root@ma:~# ps faux
...
root         336  0.1  1.8 1240108 17668 ?       Ssl  16:06   0:01 /run/lxd_agent/lxd-agent
root        1222  0.0  0.3   9696  3072 pts/0    Ss   16:06   0:00  \_ su -l
root        1246  0.0  0.4   9152  4480 pts/0    S    16:06   0:00  |   \_ -bash
root        4460  0.0  0.6  34852  6272 pts/0    S    16:09   0:00  |       \_ journalctl -fu snap.lxd.daemon
root       10536  1.7  1.7 1538916 17280 pts/0   Sl+  16:18   0:00  |       \_ /snap/lxd/x2/bin/lxc config edit c1
root       10557  0.0  0.4   5960  3968 pts/0    S+   16:18   0:00  |           \_ vim.tiny /tmp/lxd_editor_2465608817.yaml
```


**Note**: the Apparmor mediation bits in the kernel are broken until kernel `6.5.0-6.6`. While not relevant for this test/PR, you might want to use the `-proposed` kernel:

```
root@ma:~# echo "deb http://archive.ubuntu.com/ubuntu mantic-proposed main" > /etc/apt/sources.list.d/proposed.list
root@ma:~# apt-get update
root@ma:~# apt-get install linux-image-virtual -V -t mantic-proposed
root@ma:~# reboot
```