### PR TITLE
daemon.start: enable cephfs idmapped mounts support for old MDS

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -424,6 +424,15 @@ if [ "$(stat -c '%u' /proc)" = 0 ]; then
             echo 1 > /proc/sys/kernel/unprivileged_userns_clone || true
         fi
     fi
+
+    # enable cephfs idmapped mounts support for old versions of ceph MDS
+    modprobe ceph || true
+    if [ -e /sys/module/ceph/parameters/enable_unsafe_idmap ]; then
+        if [ "$(cat /sys/module/ceph/parameters/enable_unsafe_idmap)" = "N" ]; then
+            echo "==> Enabling ceph's unsafe idmap feature"
+            echo Y > /sys/module/ceph/parameters/enable_unsafe_idmap || true
+        fi
+    fi
 fi
 
 # Setup CRIU


### PR DESCRIPTION
If ceph MDS version is old and lacks support of CEPHFS_FEATURE_HAS_OWNER_UIDGID then idmapped mounts won't work. We have special fallback mechanism in the kernel cephfs client called "unsafe_idmap". In fact, this thing is absolutely safe the only problem is that it's incompatible with MDS-side UIG/GID-based path restrictions which is rarely used thing especially with workloads like LXD.

Let's enable this thing by default. We also need to preload ceph LKM.

ToDo: we can remove this thing entirely after a few years.