### PR TITLE
Strip binaries and libraries

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1604,17 +1604,21 @@ parts:
     override-prime: |
       set -x
 
-      # Strip some of the heavy bits
-      strip -s "${CRAFT_PRIME}"/bin/lxc
-      strip -s "${CRAFT_PRIME}"/bin/lxd*
-      strip -s "${CRAFT_PRIME}"/bin/snap*
-      strip -s "${CRAFT_PRIME}"/lib/libdqlite*
-      strip -s "${CRAFT_PRIME}"/lib/libsqlite*
+      # Strip binaries (excluding shell scripts)
+      find "${CRAFT_PRIME}"/bin -type f \
+        -not -path "${CRAFT_PRIME}/bin/ceph" \
+        -not -path "${CRAFT_PRIME}/bin/editor" \
+        -not -path "${CRAFT_PRIME}/bin/lxc-checkconfig" \
+        -not -path "${CRAFT_PRIME}/bin/nvidia-container-cli" \
+        -not -path "${CRAFT_PRIME}/bin/remote-viewer" \
+        -not -path "${CRAFT_PRIME}/bin/sshfs" \
+        -not -path "${CRAFT_PRIME}/bin/xfs_admin" \
+        -exec strip -s {} +
 
-      for zfs in zfs-0.8 zfs-2.0 zfs-2.1 zfs-2.2; do
-          [ ! -d "${CRAFT_PRIME}/${zfs}" ] && continue
-          strip -s "${CRAFT_PRIME}/${zfs}"/bin/* "${CRAFT_PRIME}/${zfs}"/lib/*
-      done
+      # Strip libraries (excluding python3 scripts)
+      find "${CRAFT_PRIME}"/lib -type f \
+        -not -path "${CRAFT_PRIME}/lib/python3/*" \
+        -exec strip -s {} +
 
       if [ "$(uname -m)" != "riscv64" ]; then
           # Prime the documentation only if the arch is not riscv64.
@@ -1622,8 +1626,6 @@ parts:
           # Not worth the effort for now.
           cp -r "${CRAFT_STAGE}/share/lxd-documentation" "${CRAFT_PRIME}/share/"
       fi
-
-      [ -e "${CRAFT_PRIME}/criu/criu" ] && strip -s "${CRAFT_PRIME}/criu/criu"
 
       exit 0
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1133,12 +1133,14 @@ parts:
       craftctl default
       set -ex
 
+      ZFS_VER="0.8"
+
       mv "${CRAFT_PART_INSTALL}" "${CRAFT_PART_INSTALL}.tmp"
-      mkdir -p "${CRAFT_PART_INSTALL}/zfs-0.8/bin" "${CRAFT_PART_INSTALL}/zfs-0.8/lib"
-      mv "${CRAFT_PART_INSTALL}.tmp/sbin/zfs" "${CRAFT_PART_INSTALL}/zfs-0.8/bin/"
-      mv "${CRAFT_PART_INSTALL}.tmp/sbin/zpool" "${CRAFT_PART_INSTALL}/zfs-0.8/bin/"
-      mv "${CRAFT_PART_INSTALL}.tmp/lib/udev/zvol_id" "${CRAFT_PART_INSTALL}/zfs-0.8/bin/"
-      mv "${CRAFT_PART_INSTALL}.tmp/lib/"*so* "${CRAFT_PART_INSTALL}/zfs-0.8/lib/"
+      mkdir -p "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin" "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/lib"
+      mv "${CRAFT_PART_INSTALL}.tmp/sbin/zfs" "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin/"
+      mv "${CRAFT_PART_INSTALL}.tmp/sbin/zpool" "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin/"
+      mv "${CRAFT_PART_INSTALL}.tmp/lib/udev/zvol_id" "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin/"
+      mv "${CRAFT_PART_INSTALL}.tmp/lib/"*so* "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/lib/"
       rm -Rf "${CRAFT_PART_INSTALL}.tmp"
 
   zfs-2-0:
@@ -1169,12 +1171,14 @@ parts:
       craftctl default
       set -ex
 
+      ZFS_VER="2.0"
+
       mv "${CRAFT_PART_INSTALL}" "${CRAFT_PART_INSTALL}.tmp"
-      mkdir -p "${CRAFT_PART_INSTALL}/zfs-2.0/bin" "${CRAFT_PART_INSTALL}/zfs-2.0/lib"
-      mv "${CRAFT_PART_INSTALL}.tmp/sbin/zfs" "${CRAFT_PART_INSTALL}/zfs-2.0/bin/"
-      mv "${CRAFT_PART_INSTALL}.tmp/sbin/zpool" "${CRAFT_PART_INSTALL}/zfs-2.0/bin/"
-      mv "${CRAFT_PART_INSTALL}.tmp/lib/udev/zvol_id" "${CRAFT_PART_INSTALL}/zfs-2.0/bin/"
-      mv "${CRAFT_PART_INSTALL}.tmp/lib/"*so* "${CRAFT_PART_INSTALL}/zfs-2.0/lib/"
+      mkdir -p "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin" "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/lib"
+      mv "${CRAFT_PART_INSTALL}.tmp/sbin/zfs" "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin/"
+      mv "${CRAFT_PART_INSTALL}.tmp/sbin/zpool" "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin/"
+      mv "${CRAFT_PART_INSTALL}.tmp/lib/udev/zvol_id" "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin/"
+      mv "${CRAFT_PART_INSTALL}.tmp/lib/"*so* "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/lib/"
       rm -Rf "${CRAFT_PART_INSTALL}.tmp"
 
   zfs-2-1:
@@ -1205,12 +1209,14 @@ parts:
       craftctl default
       set -ex
 
+      ZFS_VER="2.1"
+
       mv "${CRAFT_PART_INSTALL}" "${CRAFT_PART_INSTALL}.tmp"
-      mkdir -p "${CRAFT_PART_INSTALL}/zfs-2.1/bin" "${CRAFT_PART_INSTALL}/zfs-2.1/lib"
-      mv "${CRAFT_PART_INSTALL}.tmp/sbin/zfs" "${CRAFT_PART_INSTALL}/zfs-2.1/bin/"
-      mv "${CRAFT_PART_INSTALL}.tmp/sbin/zpool" "${CRAFT_PART_INSTALL}/zfs-2.1/bin/"
-      mv "${CRAFT_PART_INSTALL}.tmp/lib/udev/zvol_id" "${CRAFT_PART_INSTALL}/zfs-2.1/bin/"
-      mv "${CRAFT_PART_INSTALL}.tmp/lib/"*so* "${CRAFT_PART_INSTALL}/zfs-2.1/lib/"
+      mkdir -p "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin" "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/lib"
+      mv "${CRAFT_PART_INSTALL}.tmp/sbin/zfs" "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin/"
+      mv "${CRAFT_PART_INSTALL}.tmp/sbin/zpool" "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin/"
+      mv "${CRAFT_PART_INSTALL}.tmp/lib/udev/zvol_id" "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin/"
+      mv "${CRAFT_PART_INSTALL}.tmp/lib/"*so* "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/lib/"
       rm -Rf "${CRAFT_PART_INSTALL}.tmp"
 
   zfs-2-2:
@@ -1241,12 +1247,14 @@ parts:
       craftctl default
       set -ex
 
+      ZFS_VER="2.2"
+
       mv "${CRAFT_PART_INSTALL}" "${CRAFT_PART_INSTALL}.tmp"
-      mkdir -p "${CRAFT_PART_INSTALL}/zfs-2.2/bin" "${CRAFT_PART_INSTALL}/zfs-2.2/lib"
-      mv "${CRAFT_PART_INSTALL}.tmp/sbin/zfs" "${CRAFT_PART_INSTALL}/zfs-2.2/bin/"
-      mv "${CRAFT_PART_INSTALL}.tmp/sbin/zpool" "${CRAFT_PART_INSTALL}/zfs-2.2/bin/"
-      mv "${CRAFT_PART_INSTALL}.tmp/lib/udev/zvol_id" "${CRAFT_PART_INSTALL}/zfs-2.2/bin/"
-      mv "${CRAFT_PART_INSTALL}.tmp/lib/"*so* "${CRAFT_PART_INSTALL}/zfs-2.2/lib/"
+      mkdir -p "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin" "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/lib"
+      mv "${CRAFT_PART_INSTALL}.tmp/sbin/zfs" "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin/"
+      mv "${CRAFT_PART_INSTALL}.tmp/sbin/zpool" "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin/"
+      mv "${CRAFT_PART_INSTALL}.tmp/lib/udev/zvol_id" "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin/"
+      mv "${CRAFT_PART_INSTALL}.tmp/lib/"*so* "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/lib/"
       rm -Rf "${CRAFT_PART_INSTALL}.tmp"
 
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -379,8 +379,8 @@ parts:
           (
           cat << EOF
               . ./edksetup.sh
-              make -C BaseTools ARCH=${ARCH}
-              build -a ${ARCH} -t GCC5 -b RELEASE -p ${PKG} \
+              make -C BaseTools ARCH="${ARCH}"
+              build -a "${ARCH}" -t GCC5 -b RELEASE -p "${PKG}" \
                 -DSMM_REQUIRE=FALSE \
                 -DSECURE_BOOT_ENABLE=TRUE \
                 -DNETWORK_IP4_ENABLE=TRUE \
@@ -416,8 +416,8 @@ parts:
         "${CRAFT_PART_INSTALL}/share/qemu/OVMF_CODE.2MB.fd" \
         "${CRAFT_PART_INSTALL}/share/qemu/OVMF_VARS.2MB.fd" \
         -DFD_SIZE_2MB
-      ln -s OVMF_CODE.2MB.fd ${CRAFT_PART_INSTALL}/share/qemu/OVMF_CODE.fd
-      ln -s OVMF_VARS.2MB.fd ${CRAFT_PART_INSTALL}/share/qemu/OVMF_VARS.fd
+      ln -s OVMF_CODE.2MB.fd "${CRAFT_PART_INSTALL}/share/qemu/OVMF_CODE.fd"
+      ln -s OVMF_VARS.2MB.fd "${CRAFT_PART_INSTALL}/share/qemu/OVMF_VARS.fd"
 
       # Legacy firmware (4MB, CSM)
       if [ "$(uname -m)" = "x86_64" ]; then
@@ -586,14 +586,14 @@ parts:
       set -ex
 
       # Setup build environment
-      export GOPATH=$(realpath ./.go)
+      export GOPATH="$(realpath ./.go)"
 
       # Build the binaries
       make build
 
       # Install minio command
-      mkdir -p ${CRAFT_PART_INSTALL}/bin/
-      cp minio ${CRAFT_PART_INSTALL}/bin/minio
+      mkdir -p "${CRAFT_PART_INSTALL}/bin/"
+      cp minio "${CRAFT_PART_INSTALL}/bin/minio"
     prime:
       - bin/minio*
 
@@ -938,7 +938,7 @@ parts:
     override-build: |-
       [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
 
-      export ARCH="$(basename $(readlink -f ${CRAFT_STAGE}/lib/*-linux-gnu*/))"
+      export ARCH="$(basename "$(readlink -f "${CRAFT_STAGE}"/lib/*-linux-gnu*/)")"
       export LD_LIBRARY_PATH="${CRAFT_STAGE}/lib:${CRAFT_STAGE}/lib/${ARCH}"
 
       set -ex
@@ -967,7 +967,7 @@ parts:
         -V "${CRAFT_STAGE}/share/qemu/OVMF_VARS.2MB.fd" \
         -C "$(cat ubuntu-sb.crt)" \
         -o "${CRAFT_PART_INSTALL}/share/qemu/OVMF_VARS.2MB.ms.fd"
-      ln -s OVMF_VARS.2MB.ms.fd ${CRAFT_PART_INSTALL}/share/qemu/OVMF_VARS.ms.fd
+      ln -s OVMF_VARS.2MB.ms.fd "${CRAFT_PART_INSTALL}/share/qemu/OVMF_VARS.ms.fd"
     prime:
       - share/qemu/*
 
@@ -1410,7 +1410,7 @@ parts:
       set -ex
 
       # Setup build environment
-      export GOPATH=$(realpath ./.go)
+      export GOPATH="$(realpath ./.go)"
 
       # Setup the GOPATH
       rm -Rf "${GOPATH}"
@@ -1428,7 +1428,7 @@ parts:
       git config user.name "LXD snap builder"
 
       # Setup build environment
-      export GOPATH=$(realpath ./.go)
+      export GOPATH="$(realpath ./.go)"
       export CGO_CFLAGS="-I${CRAFT_STAGE}/include/ -I${CRAFT_STAGE}/usr/local/include/"
       export CGO_LDFLAGS="-L${CRAFT_STAGE}/lib/ -L${CRAFT_STAGE}/usr/local/lib/"
       export CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
@@ -1498,7 +1498,7 @@ parts:
       set -ex
 
       # Setup build environment
-      export GOPATH=$(realpath ./.go)
+      export GOPATH="$(realpath ./.go)"
 
       # Download the dependencies
       go get -d -v ./...
@@ -1506,7 +1506,7 @@ parts:
       set -ex
 
       # Setup build environment
-      export GOPATH=$(realpath ./.go)
+      export GOPATH="$(realpath ./.go)"
       export CGO_CFLAGS="-I${CRAFT_STAGE}/include/ -I${CRAFT_STAGE}/usr/local/include/"
       export CGO_LDFLAGS="-L${CRAFT_STAGE}/lib/ -L${CRAFT_STAGE}/usr/local/lib/"
 
@@ -1555,7 +1555,7 @@ parts:
       set -ex
 
       # Setup build environment
-      export GOPATH=$(realpath ./.go)
+      export GOPATH="$(realpath ./.go)"
 
       # Build the binaries
       go build -o "${CRAFT_PART_INSTALL}/bin/snap-query" snap-query.go
@@ -1597,11 +1597,11 @@ parts:
       set -x
 
       # Strip some of the heavy bits
-      strip -s ${CRAFT_PRIME}/bin/lxc
-      strip -s ${CRAFT_PRIME}/bin/lxd*
-      strip -s ${CRAFT_PRIME}/bin/snap*
-      strip -s ${CRAFT_PRIME}/lib/libdqlite*
-      strip -s ${CRAFT_PRIME}/lib/libsqlite*
+      strip -s "${CRAFT_PRIME}"/bin/lxc
+      strip -s "${CRAFT_PRIME}"/bin/lxd*
+      strip -s "${CRAFT_PRIME}"/bin/snap*
+      strip -s "${CRAFT_PRIME}"/lib/libdqlite*
+      strip -s "${CRAFT_PRIME}"/lib/libsqlite*
 
       for zfs in zfs-0.8 zfs-2.0 zfs-2.1 zfs-2.2; do
           [ ! -d "${CRAFT_PRIME}/${zfs}" ] && continue


### PR DESCRIPTION
Most binaries and a few libs were already being stripped but many big ones were not:

|Bin/lib|Orig size (M)|Stripped size (M)|
|--------|-----------------|-----------------------|
|qemu-system-x86_64|64|18|
|qemu-img|11|1.9|
|virtiofsd|8.1|2.2|
|sqlite3|6.7|1.5|
|lxc-to-lxd|29|21|
|ovn-sbctl|4.4|3.6|

Unfortunately, the 'biggest offender" (`minio`'s binary) was already stripped so no gain there.

This PR assumes it's OK to be more liberal in what is `strip`'ed because the main binaries (`lxc`, `lxd`, `zfs-*`) were already being stripped. That of course needs to be validate before merging.

Here what it looks when all is packaged up in snaps:

```
root@v1:~# df -ha | grep -wF /snap/lxd
/dev/loop1      112M  112M     0 100% /snap/lxd/24322  # snap from 5.0/stable
/dev/loop4      149M  149M     0 100% /snap/lxd/x1     # snap from this PR
/dev/loop5      182M  182M     0 100% /snap/lxd/25880  # snap from latest/edge
```

So that'd save ~33M compared to `latest/edge` while still being much bigger than `5.0/stable`.