### PR TITLE
snapcraft: go build -trimpath

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1442,12 +1442,12 @@ parts:
       export CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
 
       # Build the binaries
-      go build -o "${CRAFT_PART_INSTALL}/bin/lxc" github.com/canonical/lxd/lxc
-      go build -o "${CRAFT_PART_INSTALL}/bin/lxc-to-lxd" github.com/canonical/lxd/lxc-to-lxd
-      go build -o "${CRAFT_PART_INSTALL}/bin/lxd" -tags=libsqlite3 github.com/canonical/lxd/lxd
-      CGO_ENABLED=0 go build -o "${CRAFT_PART_INSTALL}/bin/lxd-agent" -tags=agent,netgo github.com/canonical/lxd/lxd-agent
-      go build -o "${CRAFT_PART_INSTALL}/bin/lxd-benchmark" github.com/canonical/lxd/lxd-benchmark
-      go build -o "${CRAFT_PART_INSTALL}/bin/lxd-user" github.com/canonical/lxd/lxd-user
+      go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/lxc" github.com/canonical/lxd/lxc
+      go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/lxc-to-lxd" github.com/canonical/lxd/lxc-to-lxd
+      go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/lxd" -tags=libsqlite3 github.com/canonical/lxd/lxd
+      CGO_ENABLED=0 go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/lxd-agent" -tags=agent,netgo github.com/canonical/lxd/lxd-agent
+      go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/lxd-benchmark" github.com/canonical/lxd/lxd-benchmark
+      go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/lxd-user" github.com/canonical/lxd/lxd-user
 
       if [ "$(uname -m)" != "riscv64" ]; then
         # Build the static website
@@ -1519,7 +1519,7 @@ parts:
       export CGO_LDFLAGS="-L${CRAFT_STAGE}/lib/ -L${CRAFT_STAGE}/usr/local/lib/"
 
       # Build the binaries
-      go build -o "${CRAFT_PART_INSTALL}/bin/lxd-migrate" -tags=libsqlite3 ./
+      go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/lxd-migrate" -tags=libsqlite3 ./
 
       mkdir -p "${CRAFT_PART_INSTALL}/bin/"
     prime:
@@ -1566,7 +1566,7 @@ parts:
       export GOPATH="$(realpath ./.go)"
 
       # Build the binaries
-      go build -o "${CRAFT_PART_INSTALL}/bin/snap-query" snap-query.go
+      go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/snap-query" snap-query.go
     prime:
       - bin/snap-query
 


### PR DESCRIPTION
https://go.dev/doc/go1.13#go-command:
> The new go build flag -trimpath removes all file system paths
> from the compiled executable, to improve build reproducibility.

Another benefit is the resulting snap is smaller:

```
# df -ha | grep -wF /snap/lxd
/dev/loop5      152M  152M     0 100% /snap/lxd/25899  # latest-edge
/dev/loop0      149M  149M     0 100% /snap/lxd/x2        # snap from this PR
```

Some of those ~3M saved are due to not including the path to go's snap nor the build directory:

```
# strings /snap/lxd/25899/bin/lx* | grep -E '^/(snap|build/lxd)/' | sort -R | tail
/snap/go/10339/src/internal/poll/sendfile_linux.go
/snap/go/10339/src/internal/poll/sendfile_linux.go
/snap/go/10339/src/internal/poll/sendfile_linux.go
/snap/go/10339/src/internal/poll/sendfile_linux.go
/snap/go/10339/src/internal/poll/sendfile_linux.go
/snap/go/10339/src/internal/poll/sendfile_linux.go
/snap/go/10339/src/internal/poll/sendfile_linux.go
/build/lxd/parts/lxd-migrate/build/.go/pkg/mod/golang.org/x/crypto@v0.13.0/internal/poly1305/sum_generic.go
/build/lxd/parts/lxd/src/lxd/db/cluster/snapshots.mapper.go
/build/lxd/parts/lxd/src/lxd/db/cluster/snapshots.mapper.go

# ll /snap/lxd/{25899,x2}/bin/lx{c,d} | sort
-rwxr-xr-x 1 root root 16111912 Oct  6 02:42 /snap/lxd/x2/bin/lxc*
-rwxr-xr-x 1 root root 16144880 Oct  5 13:58 /snap/lxd/25899/bin/lxc*
-rwxr-xr-x 1 root root 44666280 Oct  6 02:42 /snap/lxd/x2/bin/lxd*
-rwxr-xr-x 1 root root 44736112 Oct  5 13:58 /snap/lxd/25899/bin/lxd*

# strings /snap/lxd/25899/bin/lx* | grep -E '^/(snap|build/lxd)/' | wc -c
687812

# strings /snap/lxd/x2/bin/lx* | grep -E '^/(snap|build/lxd)/' | wc -c
0
```
