### PR TITLE
Disable Apparmor unprivileged unconfined mediation

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -431,6 +431,13 @@ if [ "$(stat -c '%u' /proc)" = 0 ]; then
             echo 0 > /proc/sys/kernel/apparmor_restrict_unprivileged_userns || true
         fi
     fi
+
+    if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_unconfined ]; then
+        if [ "$(cat /proc/sys/kernel/apparmor_restrict_unprivileged_unconfined)" = "1" ]; then
+            echo "==> Disabling Apparmor unprivileged unconfined mediation"
+            echo 0 > /proc/sys/kernel/apparmor_restrict_unprivileged_unconfined || true
+        fi
+    fi
 fi
 
 # Setup CRIU

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -418,17 +418,17 @@ if [ "$(stat -c '%u' /proc)" = 0 ]; then
         fi
     fi
 
-    if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
-        if [ "$(cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" = "1" ]; then
-            echo "==> Disabling Apparmor unprivileged userns mediation"
-            echo 0 > /proc/sys/kernel/apparmor_restrict_unprivileged_userns || true
-        fi
-    fi
-
     if [ -e /proc/sys/kernel/unprivileged_userns_clone ]; then
         if [ "$(cat /proc/sys/kernel/unprivileged_userns_clone)" = "0" ]; then
             echo "==> Enabling unprivileged containers kernel support"
             echo 1 > /proc/sys/kernel/unprivileged_userns_clone || true
+        fi
+    fi
+
+    if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+        if [ "$(cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" = "1" ]; then
+            echo "==> Disabling Apparmor unprivileged userns mediation"
+            echo 0 > /proc/sys/kernel/apparmor_restrict_unprivileged_userns || true
         fi
     fi
 fi

--- a/snapcraft/wrappers/editor
+++ b/snapcraft/wrappers/editor
@@ -18,6 +18,7 @@ run_cmd() {
 USERNS=1
 [ -e /proc/sys/kernel/unprivileged_userns_clone ] && grep -qxF 0 /proc/sys/kernel/unprivileged_userns_clone && USERNS=0
 [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ] && grep -qxF 1 /proc/sys/kernel/apparmor_restrict_unprivileged_userns && USERNS=0
+[ -e /proc/sys/kernel/apparmor_restrict_unprivileged_unconfined ] && grep -qxF 1 /proc/sys/kernel/apparmor_restrict_unprivileged_unconfined && USERNS=0
 
 find_and_spawn() {
     for path in / /usr/ /usr/local/; do

--- a/snapcraft/wrappers/remote-viewer
+++ b/snapcraft/wrappers/remote-viewer
@@ -17,6 +17,7 @@ run_cmd() {
 USERNS=1
 [ -e /proc/sys/kernel/unprivileged_userns_clone ] && grep -qxF 0 /proc/sys/kernel/unprivileged_userns_clone && USERNS=0
 [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ] && grep -qxF 1 /proc/sys/kernel/apparmor_restrict_unprivileged_userns && USERNS=0
+[ -e /proc/sys/kernel/apparmor_restrict_unprivileged_unconfined ] && grep -qxF 1 /proc/sys/kernel/apparmor_restrict_unprivileged_unconfined && USERNS=0
 
 find_and_spawn() {
     for path in / /usr/ /usr/local/; do


### PR DESCRIPTION
This was tested with the procedure outlined in the description of https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2038567 and:

```

root@ma:~# snap install --dangerous /dev/shm/lxd_0+git.504b745_amd64.snap 
root@ma:~# snap stop lxd
2023-10-06T18:40:53Z INFO Waiting for "snap.lxd.daemon.service" to stop.
root@ma:~# snap start lxd
Started.
root@ma:~# grep . /proc/sys/kernel/apparmor*
/proc/sys/kernel/apparmor_display_secid_mode:0
/proc/sys/kernel/apparmor_restrict_unprivileged_io_uring:0
/proc/sys/kernel/apparmor_restrict_unprivileged_unconfined:1
/proc/sys/kernel/apparmor_restrict_unprivileged_userns:0
/proc/sys/kernel/apparmor_restrict_unprivileged_userns_complain:0
/proc/sys/kernel/apparmor_restrict_unprivileged_userns_force:0
root@ma:~# lxc ls
+--------+---------+------+------+-----------+-----------+
|  NAME  |  STATE  | IPV4 | IPV6 |   TYPE    | SNAPSHOTS |
+--------+---------+------+------+-----------+-----------+
| mantic | STOPPED |      |      | CONTAINER | 0         |
+--------+---------+------+------+-----------+-----------+
root@ma:~# grep . /proc/sys/kernel/apparmor*
/proc/sys/kernel/apparmor_display_secid_mode:0
/proc/sys/kernel/apparmor_restrict_unprivileged_io_uring:0
/proc/sys/kernel/apparmor_restrict_unprivileged_unconfined:0
/proc/sys/kernel/apparmor_restrict_unprivileged_userns:0
/proc/sys/kernel/apparmor_restrict_unprivileged_userns_complain:0
/proc/sys/kernel/apparmor_restrict_unprivileged_userns_force:0
root@ma:~# lxc start mantic
root@ma:~# lxc exec mantic -- cloud-init status --wait
..........
```

Once `/proc/sys/kernel/apparmor_restrict_unprivileged_unconfined` is disabled, the apparmor denial log noise about `ptrace` being denied stops, as intended.