### PR TITLE
Add support for PowerFlex storage driver

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -671,6 +671,12 @@ parts:
       - bin/nvidia-container-cli*
       - lib/libnvidia-container*.so*
 
+  nvme:
+    source: snapcraft/empty
+    plugin: nil
+    stage-packages:
+      - nvme-cli
+
   openvswitch:
     source: https://github.com/openvswitch/ovs
     source-type: git


### PR DESCRIPTION
Allow LXD to communicate with the NVMe/TCP tooling on the host as part of https://github.com/canonical/lxd/pull/12304