### PR TITLE
Apparmor unpriv quirk

### DIFF
--- a/snapcraft/wrappers/editor
+++ b/snapcraft/wrappers/editor
@@ -17,8 +17,6 @@ run_cmd() {
 
 USERNS=1
 [ -e /proc/sys/kernel/unprivileged_userns_clone ] && grep -qxF 0 /proc/sys/kernel/unprivileged_userns_clone && USERNS=0
-[ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ] && grep -qxF 1 /proc/sys/kernel/apparmor_restrict_unprivileged_userns && USERNS=0
-[ -e /proc/sys/kernel/apparmor_restrict_unprivileged_unconfined ] && grep -qxF 1 /proc/sys/kernel/apparmor_restrict_unprivileged_unconfined && USERNS=0
 
 find_and_spawn() {
     for path in / /usr/ /usr/local/; do

--- a/snapcraft/wrappers/remote-viewer
+++ b/snapcraft/wrappers/remote-viewer
@@ -16,8 +16,6 @@ run_cmd() {
 
 USERNS=1
 [ -e /proc/sys/kernel/unprivileged_userns_clone ] && grep -qxF 0 /proc/sys/kernel/unprivileged_userns_clone && USERNS=0
-[ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ] && grep -qxF 1 /proc/sys/kernel/apparmor_restrict_unprivileged_userns && USERNS=0
-[ -e /proc/sys/kernel/apparmor_restrict_unprivileged_unconfined ] && grep -qxF 1 /proc/sys/kernel/apparmor_restrict_unprivileged_unconfined && USERNS=0
 
 find_and_spawn() {
     for path in / /usr/ /usr/local/; do


### PR DESCRIPTION
Assume `unshare` won't work if `/proc/sys/kernel/apparmor_restrict_unprivileged_userns` or `/proc/sys/kernel/apparmor_restrict_unprivileged_unconfined` exist. Previously we tried to read their value but that fails because those are root-accessible only.