### PR TITLE
snapcraft/{hooks,commands}: handle new AppArmor unconfined profile mode

### DIFF
--- a/snapcraft/commands/buginfo
+++ b/snapcraft/commands/buginfo
@@ -3,7 +3,7 @@ set -u
 
 # Re-exec outside of apparmor confinement
 if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current)"
+  label="$(cat /proc/self/attr/current 2>/dev/null)"
   if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
   fi

--- a/snapcraft/commands/buginfo
+++ b/snapcraft/commands/buginfo
@@ -2,8 +2,11 @@
 set -u
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" != "unconfined" ]; then
+if [ -d /sys/kernel/security/apparmor ]; then
+  label="$(cat /proc/self/attr/current)"
+  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
+  fi
 fi
 
 # Check that we're root

--- a/snapcraft/commands/daemon.activate
+++ b/snapcraft/commands/daemon.activate
@@ -2,7 +2,9 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current 2>/dev/null)" != "unconfined" ]; then
+if [ -d /sys/kernel/security/apparmor ]; then
+  label="$(cat /proc/self/attr/current)"
+  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     if ! aa-exec --help >/dev/null 2>&1; then
         echo "The LXD snap was unable to run aa-exec, this usually indicates a LXD sideload." >&2
         echo "When sideloading, make sure to manually connect all interfaces." >&2
@@ -10,6 +12,7 @@ if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current 2>/d
     fi
 
     exec aa-exec -p unconfined -- "$0" "$@" || true
+  fi
 fi
 
 # shellcheck disable=SC2155

--- a/snapcraft/commands/daemon.activate
+++ b/snapcraft/commands/daemon.activate
@@ -3,7 +3,7 @@ set -eu
 
 # Re-exec outside of apparmor confinement
 if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current)"
+  label="$(cat /proc/self/attr/current 2>/dev/null)"
   if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     if ! aa-exec --help >/dev/null 2>&1; then
         echo "The LXD snap was unable to run aa-exec, this usually indicates a LXD sideload." >&2

--- a/snapcraft/commands/daemon.reload
+++ b/snapcraft/commands/daemon.reload
@@ -2,8 +2,11 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" != "unconfined" ]; then
+if [ -d /sys/kernel/security/apparmor ]; then
+  label="$(cat /proc/self/attr/current)"
+  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
+  fi
 fi
 
 echo reload > "${SNAP_COMMON}/state"

--- a/snapcraft/commands/daemon.reload
+++ b/snapcraft/commands/daemon.reload
@@ -3,7 +3,7 @@ set -eu
 
 # Re-exec outside of apparmor confinement
 if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current)"
+  label="$(cat /proc/self/attr/current 2>/dev/null)"
   if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
   fi

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -3,7 +3,7 @@ set -eu
 
 # Re-exec outside of apparmor confinement
 if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current)"
+  label="$(cat /proc/self/attr/current 2>/dev/null)"
   if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
   fi

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -2,8 +2,11 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" != "unconfined" ]; then
+if [ -d /sys/kernel/security/apparmor ]; then
+  label="$(cat /proc/self/attr/current)"
+  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
+  fi
 fi
 
 echo "=> Preparing the system (${SNAP_REVISION})"

--- a/snapcraft/commands/daemon.stop
+++ b/snapcraft/commands/daemon.stop
@@ -2,8 +2,11 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" != "unconfined" ]; then
+if [ -d /sys/kernel/security/apparmor ]; then
+  label="$(cat /proc/self/attr/current)"
+  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
+  fi
 fi
 
 export LXD_DIR="${SNAP_COMMON}/lxd/"

--- a/snapcraft/commands/daemon.stop
+++ b/snapcraft/commands/daemon.stop
@@ -3,7 +3,7 @@ set -eu
 
 # Re-exec outside of apparmor confinement
 if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current)"
+  label="$(cat /proc/self/attr/current 2>/dev/null)"
   if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
   fi

--- a/snapcraft/commands/lxc
+++ b/snapcraft/commands/lxc
@@ -2,8 +2,11 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ] && [ "$(while read -r l; do echo "$l"; done < /proc/self/attr/current)" != "unconfined" ]; then
-    exec /usr/bin/aa-exec -p unconfined -- "$0" "$@"
+if [ -d /sys/kernel/security/apparmor ]; then
+  label="$(cat /proc/self/attr/current)"
+  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+    exec aa-exec -p unconfined -- "$0" "$@"
+  fi
 fi
 
 # Check if native and snap installed

--- a/snapcraft/commands/lxc
+++ b/snapcraft/commands/lxc
@@ -3,7 +3,7 @@ set -eu
 
 # Re-exec outside of apparmor confinement
 if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current)"
+  label="$(while read -r l; do echo "$l"; done < /proc/self/attr/current)"
   if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
   fi

--- a/snapcraft/commands/lxc
+++ b/snapcraft/commands/lxc
@@ -5,7 +5,7 @@ set -eu
 if [ -d /sys/kernel/security/apparmor ]; then
   label="$(while read -r l; do echo "$l"; done < /proc/self/attr/current)"
   if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
-    exec aa-exec -p unconfined -- "$0" "$@"
+    exec /usr/bin/aa-exec -p unconfined -- "$0" "$@"
   fi
 fi
 

--- a/snapcraft/commands/lxc-to-lxd
+++ b/snapcraft/commands/lxc-to-lxd
@@ -3,7 +3,7 @@ set -eu
 
 # Re-exec outside of apparmor confinement
 if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current)"
+  label="$(cat /proc/self/attr/current 2>/dev/null)"
   if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
   fi

--- a/snapcraft/commands/lxc-to-lxd
+++ b/snapcraft/commands/lxc-to-lxd
@@ -2,8 +2,11 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" != "unconfined" ]; then
+if [ -d /sys/kernel/security/apparmor ]; then
+  label="$(cat /proc/self/attr/current)"
+  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
+  fi
 fi
 
 # Check that we're root

--- a/snapcraft/commands/lxd
+++ b/snapcraft/commands/lxd
@@ -2,8 +2,11 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" != "unconfined" ]; then
+if [ -d /sys/kernel/security/apparmor ]; then
+  label="$(cat /proc/self/attr/current)"
+  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
+  fi
 fi
 
 # Check if native and snap installed

--- a/snapcraft/commands/lxd
+++ b/snapcraft/commands/lxd
@@ -3,7 +3,7 @@ set -eu
 
 # Re-exec outside of apparmor confinement
 if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current)"
+  label="$(cat /proc/self/attr/current 2>/dev/null)"
   if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
   fi

--- a/snapcraft/commands/lxd-benchmark
+++ b/snapcraft/commands/lxd-benchmark
@@ -2,8 +2,11 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" != "unconfined" ]; then
+if [ -d /sys/kernel/security/apparmor ]; then
+  label="$(cat /proc/self/attr/current)"
+  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
+  fi
 fi
 
 # Check if native and snap installed

--- a/snapcraft/commands/lxd-benchmark
+++ b/snapcraft/commands/lxd-benchmark
@@ -3,7 +3,7 @@ set -eu
 
 # Re-exec outside of apparmor confinement
 if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current)"
+  label="$(cat /proc/self/attr/current 2>/dev/null)"
   if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
   fi

--- a/snapcraft/commands/lxd-check-kernel
+++ b/snapcraft/commands/lxd-check-kernel
@@ -2,8 +2,11 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" != "unconfined" ]; then
+if [ -d /sys/kernel/security/apparmor ]; then
+  label="$(cat /proc/self/attr/current)"
+  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
+  fi
 fi
 
 exec lxc-checkconfig

--- a/snapcraft/commands/lxd-check-kernel
+++ b/snapcraft/commands/lxd-check-kernel
@@ -3,7 +3,7 @@ set -eu
 
 # Re-exec outside of apparmor confinement
 if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current)"
+  label="$(cat /proc/self/attr/current 2>/dev/null)"
   if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
   fi

--- a/snapcraft/commands/lxd-migrate
+++ b/snapcraft/commands/lxd-migrate
@@ -2,8 +2,11 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" != "unconfined" ]; then
+if [ -d /sys/kernel/security/apparmor ]; then
+  label="$(cat /proc/self/attr/current)"
+  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
+  fi
 fi
 
 # shellcheck disable=SC2155

--- a/snapcraft/commands/lxd-migrate
+++ b/snapcraft/commands/lxd-migrate
@@ -3,7 +3,7 @@ set -eu
 
 # Re-exec outside of apparmor confinement
 if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current)"
+  label="$(cat /proc/self/attr/current 2>/dev/null)"
   if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
   fi

--- a/snapcraft/commands/lxd-user
+++ b/snapcraft/commands/lxd-user
@@ -3,7 +3,7 @@ set -eu
 
 # Re-exec outside of apparmor confinement
 if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current)"
+  label="$(cat /proc/self/attr/current 2>/dev/null)"
   if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
   fi

--- a/snapcraft/commands/lxd-user
+++ b/snapcraft/commands/lxd-user
@@ -2,8 +2,11 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" != "unconfined" ]; then
+if [ -d /sys/kernel/security/apparmor ]; then
+  label="$(cat /proc/self/attr/current)"
+  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
+  fi
 fi
 
 # Set the environment

--- a/snapcraft/hooks/configure
+++ b/snapcraft/hooks/configure
@@ -3,7 +3,7 @@ set -eu
 
 # Re-exec outside of apparmor confinement
 if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current)"
+  label="$(cat /proc/self/attr/current 2>/dev/null)"
   if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
   fi

--- a/snapcraft/hooks/configure
+++ b/snapcraft/hooks/configure
@@ -2,8 +2,11 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" != "unconfined" ]; then
+if [ -d /sys/kernel/security/apparmor ]; then
+  label="$(cat /proc/self/attr/current)"
+  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
+  fi
 fi
 
 # Utility functions

--- a/snapcraft/hooks/connect-plug-ceph-conf
+++ b/snapcraft/hooks/connect-plug-ceph-conf
@@ -3,7 +3,7 @@ set -eu
 
 # Re-exec outside of apparmor confinement
 if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current)"
+  label="$(cat /proc/self/attr/current 2>/dev/null)"
   if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
   fi

--- a/snapcraft/hooks/connect-plug-ceph-conf
+++ b/snapcraft/hooks/connect-plug-ceph-conf
@@ -2,8 +2,11 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" != "unconfined" ]; then
+if [ -d /sys/kernel/security/apparmor ]; then
+  label="$(cat /proc/self/attr/current)"
+  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
+  fi
 fi
 
 # Utility functions

--- a/snapcraft/hooks/disconnect-plug-ceph-conf
+++ b/snapcraft/hooks/disconnect-plug-ceph-conf
@@ -3,7 +3,7 @@ set -eu
 
 # Re-exec outside of apparmor confinement
 if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current)"
+  label="$(cat /proc/self/attr/current 2>/dev/null)"
   if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
   fi

--- a/snapcraft/hooks/disconnect-plug-ceph-conf
+++ b/snapcraft/hooks/disconnect-plug-ceph-conf
@@ -2,8 +2,11 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" != "unconfined" ]; then
+if [ -d /sys/kernel/security/apparmor ]; then
+  label="$(cat /proc/self/attr/current)"
+  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
+  fi
 fi
 
 # Utility functions

--- a/snapcraft/hooks/remove
+++ b/snapcraft/hooks/remove
@@ -3,7 +3,7 @@ set -eu
 
 # Re-exec outside of apparmor confinement
 if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current)"
+  label="$(cat /proc/self/attr/current 2>/dev/null)"
   if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
   fi

--- a/snapcraft/hooks/remove
+++ b/snapcraft/hooks/remove
@@ -2,8 +2,11 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" != "unconfined" ]; then
+if [ -d /sys/kernel/security/apparmor ]; then
+  label="$(cat /proc/self/attr/current)"
+  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"
+  fi
 fi
 
 # Unmount potential LXD paths.


### PR DESCRIPTION
AppArmor supports a new unconfined profile mode which essentially acts like the unconfined label - when a profile is in this mode the label contains the suffix "(unconfined)" - so treat this the same as the "unconfined" label and don't try and break out of confinement in this case.

This is designed to go hand-in-hand with the proposed changes for snapd in https://github.com/snapcore/snapd/pull/13333