### PR TITLE
lxd-migrate: remove support for upstart

### DIFF
--- a/lxd-migrate/lxd.go
+++ b/lxd-migrate/lxd.go
@@ -218,10 +218,6 @@ func (d *lxdDaemon) reload() error {
 		return systemdCtl("reload", "snap.lxd.daemon.service")
 	}
 
-	if osInit() == "upstart" {
-		return upstartCtl("restart", "lxd")
-	}
-
 	return systemdCtl("restart", "lxd.service", "lxd.socket")
 }
 
@@ -229,10 +225,6 @@ func (d *lxdDaemon) start() error {
 	// Start the relevant systemd units
 	if strings.HasPrefix(d.path, "/var/snap") {
 		return systemdCtl("start", "snap.lxd.daemon.service")
-	}
-
-	if osInit() == "upstart" {
-		return upstartCtl("start", "lxd")
 	}
 
 	return systemdCtl("start", "lxd.service", "lxd.socket")
@@ -246,10 +238,6 @@ func (d *lxdDaemon) stop() error {
 		}
 
 		return systemdCtl("stop", "snap.lxd.daemon.service")
-	}
-
-	if osInit() == "upstart" {
-		return upstartCtl("stop", "lxd")
 	}
 
 	return systemdCtl("stop", "lxd.service", "lxd.socket")

--- a/lxd-migrate/utils.go
+++ b/lxd-migrate/utils.go
@@ -72,16 +72,6 @@ func systemdCtl(action string, units ...string) error {
 	return err
 }
 
-func upstartCtl(action string, units ...string) error {
-	args := []string{}
-	args = append(args, action)
-	args = append(args, units...)
-
-	// Run initctl
-	_, err := shared.RunCommand("initctl", args...)
-	return err
-}
-
 func convertPath(path string, src string, dst string) string {
 	// Relative paths are handled by LXD
 	if !strings.HasPrefix(path, "/") {
@@ -133,10 +123,6 @@ func osInit() string {
 
 	fields := strings.Split(initExe, " ")
 	init := filepath.Base(fields[0])
-
-	if init == "init" {
-		init = "upstart"
-	}
 
 	return init
 }


### PR DESCRIPTION
AFAIK, upstart was used by CentOS before 7 and Ubuntu before 15.10. According to https://en.wikipedia.org/wiki/Upstart_(software) only ChromeOS and ChromiumOS are still using upstart but those are not something distrobuilder support building.

Same was done a while ago in distrobuilder (https://github.com/lxc/distrobuilder/pull/734).