### PR TITLE
snapcraft/commands/daemon.start: have LXD warn if a lxc debug binary is found

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -611,6 +611,11 @@ if [ -L "${SNAP_COMMON}/lxd/lxd.db" ]; then
     mv "${SNAP_DATA}/lxd/lxd.db" "${SNAP_COMMON}/lxd/lxd.db"
 fi
 
+# Warn the user if a debug LXC binary is found
+if [ -x "${SNAP_COMMON}/lxc.debug" ]; then
+    echo "==> WARNING: A custom debug LXC binary was found!"
+fi
+
 ## Start lxd
 echo "=> Starting LXD"
 


### PR DESCRIPTION
Having the daemon warn about a debug client binary isn't ideal but the lxc wrapper shall not emit warnings on every use. This warning should be infrequent enough to not be spammy yet still provide a useful reminder to eventually remove the debug client binary.

Here's the journal output when such `lxc.debug` is found when `snap start lxd` is run:

```
Nov 15 11:14:34 lxd.daemon[50727]: api_extensions:
Nov 15 11:14:34 lxd.daemon[50727]: - cgroups
...
Nov 15 11:14:34 lxd.daemon[50727]: - pidfds
Nov 15 11:14:35 lxd.daemon[50586]: ==> WARNING: A custom debug LXC binary was found!
Nov 15 11:14:35 lxd.daemon[50586]: => Starting LXD
Nov 15 11:14:35 lxd.daemon[50743]: time="2023-11-15T11:14:35-05:00" level=warning msg=" - Couldn't find the CGroup network priority controller, per-instance network priority will be ignored. Please use per-device limits.priority instead"
Nov 15 11:14:41 lxd.daemon[50586]: => LXD is ready
```