### PR TITLE
snapcraft/commands/daemon.start: have LXD warn if a lxc debug binary is found (latest-candidate)

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -611,6 +611,11 @@ if [ -L "${SNAP_COMMON}/lxd/lxd.db" ]; then
     mv "${SNAP_DATA}/lxd/lxd.db" "${SNAP_COMMON}/lxd/lxd.db"
 fi
 
+# Warn the user if a debug LXC binary is found
+if [ -x "${SNAP_COMMON}/lxc.debug" ]; then
+    echo "==> WARNING: A custom debug LXC binary was found!"
+fi
+
 ## Start lxd
 echo "=> Starting LXD"
 


### PR DESCRIPTION
Having the daemon warn about a debug client binary isn't ideal but the lxc wrapper shall not emit warnings on every use. This warning should be infrequent enough to not be spammy yet still provide a useful reminder to eventually remove the debug client binary.