### PR TITLE
snapcraft: prime fusermount3 binary

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1348,6 +1348,7 @@ parts:
       usr/lib/: lib/
     prime:
       - bin/fusermount
+      - bin/fusermount3
       - lib/*/libfuse3.so.*
 
       - lib/*/libSegFault.so


### PR DESCRIPTION
With the move from `fuse` to `fuse3`, the package content changed:

from `fuse`:

```
/bin/fusermount (binary)
```

to `fuse3`:

```
/bin/fusermount -> fusermount (compat symlink)
/bin/fusermount3 (binary)
```

However, the snapcraft.yaml wasn't updated accordingly meaning that we only shipped the (broken) symlink:

```
$ ll /snap/lxd/current/bin/fusermount*
lrwxrwxrwx 1 root root 11 Mar 23  2022 /snap/lxd/current/bin/fusermount -> fusermount3
```

Note: this also affects the 5.0 branch (I'll send another PR after this one gets merged).