### PR TITLE
Revert "snapcraft: 20 is the new LTS stream for node"

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1529,7 +1529,7 @@ parts:
     override-pull: |
       [ "$(uname -m)" = "riscv64" ] && exit 0
 
-      snap install node --channel=20/stable --classic || true
+      snap install node --channel=18/stable --classic || true
       craftctl default
     override-build: |
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
nodejs upstream still supports `ppc64le` but the snap dropped this arch for the `20/stable` branch. https://github.com/nodejs/snap/issues/59 asks for a `20/stable` snap for `ppc64le`.

This reverts commit e401b49488b039c6efac05abd4f8526671ed9b65.