### PR TITLE
lxd-ui: Bump to 0.5 (latest-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1533,7 +1533,7 @@ parts:
   lxd-ui:
     source: https://github.com/canonical/lxd-ui
     source-type: git
-    source-tag: 0.4
+    source-tag: 0.5
     plugin: nil
     override-pull: |
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
Pulling in a bunch of fixes (see https://github.com/canonical/lxd-ui/releases) for the upcoming 5.20 release