### PR TITLE
Revert "Revert "snapcraft: 20 is the new LTS stream for node""

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1532,7 +1532,7 @@ parts:
     override-pull: |
       [ "$(uname -m)" = "riscv64" ] && exit 0
 
-      snap install node --channel=18/stable --classic || true
+      snap install node --channel=20/stable --classic || true
       craftctl default
     override-build: |
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
This reverts commit 32f96e9c484ba479466d13fd95ed84bfb3d1d525.

Upstream now publishes `ppc64le` builds for the `20/stable` and `21/stable` branches too (https://github.com/nodejs/snap/issues/59).