### PR TITLE
Staged package dedup

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1477,7 +1477,6 @@ parts:
       - bin/rsync
       - bin/setfacl
       - bin/sgdisk
-      - bin/unsquashfs
       - bin/xdelta3
 
       - lib/*/libidn.so.*

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1029,12 +1029,7 @@ parts:
     stage-packages:
       - vim-common
       - vim-tiny
-    organize:
-      usr/bin/: bin/
-      usr/share/vim/vim*/debian.vim: etc/vimrc
-    prime:
-      - bin/vim.tiny
-      - etc/vimrc
+    # XXX: vim-tiny is in the base/core snap, no need to prime it
 
   virtiofsd:
     source: https://gitlab.com/virtio-fs/virtiofsd


### PR DESCRIPTION
Stop priming binaries that are already available in the base/core snap. See https://snapcraft.io/docs/build-and-staging-dependencies#heading--filtering for the explanation.

In the case of vim and for the `5.0/stable` channel, this would have saved us from using a known vulnerable vim version:

```
$ grep vim-tiny /snap/core20/current/usr/share/snappy/dpkg.list 
ii  vim-tiny                       2:8.1.2269-1ubuntu5.15       amd64        Vi IMproved - enhanced vi editor - compact version

$ grep '^- vim-tiny' /snap/lxd/current/snap/manifest.yaml 
- vim-tiny=2:8.1.2269-1ubuntu5.11
```

In the above, `core20` ships `... .15` while the `5.0/stable` one has `... .11`.

The situation with differs for `latest/stable` as our snap's vim is ahead of what `core22` provides:

```
$ grep vim-tiny /snap/core22/current/usr/share/snappy/dpkg.list 
ii  vim-tiny                       2:8.2.3995-1ubuntu2.9                   amd64        Vi IMproved - enhanced vi editor - compact version

$ grep '^- vim-tiny' /snap/lxd/current/snap/manifest.yaml 
- vim-tiny=2:8.2.3995-1ubuntu2.13
```

Even then, I think we should rely on what's provided by the base/core snap so that another team is responsible for that "shared infrastructure bit".