### PR TITLE
Reduce snap size

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1603,6 +1603,10 @@ parts:
     override-prime: |
       set -x
 
+      # XXX: remove unneeded files/directories
+      rm -rf "${CRAFT_PRIME}/lib/systemd/"
+      rm -rf "${CRAFT_PRIME}/lib/udev/"
+
       # Strip binaries (excluding shell scripts)
       find "${CRAFT_PRIME}"/bin -type f \
         -not -path "${CRAFT_PRIME}/bin/ceph" \

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1624,8 +1624,6 @@ parts:
       # Strip libraries (excluding python3 scripts)
       find "${CRAFT_PRIME}"/lib -type f \
         -not -path "${CRAFT_PRIME}/lib/python3/*" \
-        -not -path "${CRAFT_PRIME}/lib/udev/rules.d/*" \
-        -not -path "${CRAFT_PRIME}/lib/systemd/system/*" \
         -exec strip -s {} +
 
       if [ "$(uname -m)" != "riscv64" ]; then
@@ -1637,8 +1635,7 @@ parts:
 
       # XXX: look for broken symlinks indicating missing/invalid prime
       broken_symlinks="$(find "${CRAFT_PRIME}/" -xtype l \
-                           -not -path "${CRAFT_PRIME}/lxc/config/common.conf.d/*" \
-                           -not -path "${CRAFT_PRIME}/usr/share/doc/uuid-runtime/*")"
+                           -not -path "${CRAFT_PRIME}/lxc/config/common.conf.d/*")"
       if [ -n "${broken_symlinks}" ]; then
           echo "Found broken symlinks:"
           echo "${broken_symlinks}"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1604,6 +1604,7 @@ parts:
       set -x
 
       # XXX: remove unneeded files/directories
+      rm -rf "${CRAFT_PRIME}/lib/python3/dist-packages/*.egg-info/"
       rm -rf "${CRAFT_PRIME}/lib/systemd/"
       rm -rf "${CRAFT_PRIME}/lib/udev/"
       rm -rf "${CRAFT_PRIME}/usr/local/"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1585,13 +1585,18 @@ parts:
       - raft
       - sqlite
       - squashfs-tools-ng
+      - swtpm
       - vim
+      - virtiofsd
       - xfs
       - xz
+      - wrappers
+      - xtables
       - zfs-0-8
       - zfs-2-0
       - zfs-2-1
       - zfs-2-2
+      - zstd
       - lxc
       - lxcfs
       - criu

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1606,6 +1606,7 @@ parts:
       # XXX: remove unneeded files/directories
       rm -rf "${CRAFT_PRIME}/lib/systemd/"
       rm -rf "${CRAFT_PRIME}/lib/udev/"
+      rm -rf "${CRAFT_PRIME}/usr/local/"
       rm -rf "${CRAFT_PRIME}/usr/share/"
 
       # Strip binaries (excluding shell scripts)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1606,6 +1606,7 @@ parts:
       # XXX: remove unneeded files/directories
       rm -rf "${CRAFT_PRIME}/lib/systemd/"
       rm -rf "${CRAFT_PRIME}/lib/udev/"
+      rm -rf "${CRAFT_PRIME}/usr/share/"
 
       # Strip binaries (excluding shell scripts)
       find "${CRAFT_PRIME}"/bin -type f \

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1626,6 +1626,10 @@ parts:
         -not -path "${CRAFT_PRIME}/bin/xfs_admin" \
         -exec strip -s {} +
 
+      # Strip all versions of zfs utils
+      find "${CRAFT_PRIME}"/zfs-*/ -type f \
+        -exec strip -s {} +
+
       # Strip libraries (excluding python3 scripts)
       find "${CRAFT_PRIME}"/lib -type f \
         -not -path "${CRAFT_PRIME}/lib/python3/*" \


### PR DESCRIPTION
This was tested in a local VM:

```
$ lxc shell v1
root@v1:~# snap install --dangerous /dev/shm/lxd_0+git.51efcdf_amd64.snap 
Ensure prerequisites for "lxd" are available                                                                                             /Ensure prerequisites for "lxd" are available                                                                                             -Ensure prerequisites for "lxd" are available                                                                                             -Download snap "core22" (864) from channel "stable"                                                                                       -lxd 0+git.51efcdf installed
root@v1:~# snap alias lxd.lxc lxc
Added:
  - lxd.lxc as lxc

root@v1:~# file /snap/lxd/current/zfs-2.2/bin/*
/snap/lxd/current/zfs-2.2/bin/zfs:     ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=b9382230c390017d2dc339b819632aa5d7787132, for GNU/Linux 3.2.0, stripped
/snap/lxd/current/zfs-2.2/bin/zpool:   ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=3ed172a0f4a0546b3204a005d36f45615afc2335, for GNU/Linux 3.2.0, stripped
/snap/lxd/current/zfs-2.2/bin/zvol_id: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=7340404dca1357741cf5960415ab4268aebe7162, for GNU/Linux 3.2.0, stripped
```

Those binaries were previously `not stripped`.