### PR TITLE
snapcraft: do not error out if no zfs tooling is present

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1627,8 +1627,10 @@ parts:
         -exec strip -s {} +
 
       # Strip all versions of zfs utils
-      find "${CRAFT_PRIME}"/zfs-*/ -type f \
-        -exec strip -s {} +
+      for v in "${CRAFT_PRIME}"/zfs-*; do
+        [ -d "${v}" ] || continue
+        find "${v}/" -type f -exec strip -s {} +
+      done
 
       # Strip libraries (excluding python3 scripts)
       find "${CRAFT_PRIME}"/lib -type f \


### PR DESCRIPTION
Should fixes snap building on `armhf`.