### PR TITLE
Bump ovs and ovn (5.0-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -645,7 +645,7 @@ parts:
       - openvswitch
     source: https://github.com/ovn-org/ovn
     source-type: git
-    source-tag: v23.06.2
+    source-tag: v23.09.1
     source-depth: 1
     plugin: autotools
     autotools-configure-parameters:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -611,7 +611,7 @@ parts:
     build-attributes: [core22-step-dependencies]
     source: https://github.com/openvswitch/ovs
     source-type: git
-    source-tag: v3.1.3
+    source-tag: v3.2.1
     source-depth: 1
     plugin: autotools
     autotools-configure-parameters:


### PR DESCRIPTION
Using same combination as used in https://github.com/canonical/lxd-pkg-snap/blob/latest-edge to fix build errors.