### PR TITLE
Minimize snap staging and restricted fallback editors

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1477,7 +1477,6 @@ parts:
       - bin/rsync
       - bin/setfacl
       - bin/sgdisk
-      - bin/unsquashfs
       - bin/xdelta3
 
       - lib/*/libidn.so.*

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1024,18 +1024,6 @@ parts:
       - bin/tar2sqfs
       - lib/libsquashfs.so*
 
-  vim:
-    plugin: nil
-    stage-packages:
-      - vim-common
-      - vim-tiny
-    organize:
-      usr/bin/: bin/
-      usr/share/vim/vim*/debian.vim: etc/vimrc
-    prime:
-      - bin/vim.tiny
-      - etc/vimrc
-
   virtiofsd:
     source: https://gitlab.com/virtio-fs/virtiofsd
     source-type: git
@@ -1585,7 +1573,6 @@ parts:
       - sqlite
       - squashfs-tools-ng
       - swtpm
-      - vim
       - virtiofsd
       - xfs
       - xz

--- a/snapcraft/wrappers/editor
+++ b/snapcraft/wrappers/editor
@@ -38,7 +38,8 @@ fi
 # Try running the editor through the host.
 if [ -n "${EDIT_CMD}" ] && [ "${USERNS}" = 1 ]; then
     exec 9< /tmp/
-    EDIT_PATH_HOST="$(echo "${EDIT_PATH}" | sed "s#/tmp/#/proc/self/fd/9/#g")"
+    # Replace "/tmp/" prefix by exec'ed FD 9.
+    EDIT_PATH_HOST="/proc/self/fd/9/$(echo "${EDIT_PATH}" | cut -d/ -f2)"
     find_and_spawn "${EDIT_CMD}" "${EDIT_PATH_HOST}"
 fi
 

--- a/snapcraft/wrappers/editor
+++ b/snapcraft/wrappers/editor
@@ -42,21 +42,30 @@ if [ -n "${EDIT_CMD}" ] && [ "${USERNS}" = 1 ]; then
     find_and_spawn "${EDIT_CMD}" "${EDIT_PATH_HOST}"
 fi
 
+# If the editor's rcfile is not readable, ignore it.
+EDIT_IGNORE_RC=""
+
 # Default to built-in nano.
 if [ -z "${EDIT_CMD}" ]; then
     EDIT_CMD="nano"
+    [ -r "${SNAP}/etc/nanorc" ] || EDIT_IGNORE_RC="--ignorercfiles"
 fi
 
 # Setup for VIM.
 if [ "$EDIT_CMD" != "nano" ]; then
-    if [ -e "${SNAP_USER_COMMON}/.vimrc" ]; then
-        export VIMINIT="source ${SNAP_USER_COMMON}/.vimrc"
-    else
-        export VIMINIT="source ${SNAP}/etc/vimrc"
+    # Find the base use by the LXD snap.
+    for vimrc in "${SNAP_USER_COMMON}/.vimrc" "/snap/core22/current/etc/vim/vimrc"; do
+        [ -r "${vimrc}" ] || continue
+        export VIMINIT="source ${vimrc}"
+    done
+
+    # Ignore vimrc if none was found to be readable.
+    if [ -z "${VIMINIT:-""}" ]; then
+        EDIT_IGNORE_RC="--clean"
     fi
 
     EDIT_CMD="vim.tiny"
 fi
 
 # Run the editor.
-exec "${EDIT_CMD}" "${EDIT_PATH}"
+exec "${EDIT_CMD}" ${EDIT_IGNORE_RC} "${EDIT_PATH}"

--- a/snapcraft/wrappers/editor
+++ b/snapcraft/wrappers/editor
@@ -45,10 +45,11 @@ fi
 
 # If the editor's rcfile is not readable, ignore it.
 EDIT_IGNORE_RC=""
-
+EDIT_RESTRICT=""
 # Default to built-in nano.
 if [ -z "${EDIT_CMD}" ]; then
     EDIT_CMD="nano"
+    EDIT_RESTRICT="--restricted"
     [ -r "${SNAP}/etc/nanorc" ] || EDIT_IGNORE_RC="--ignorercfiles"
 fi
 
@@ -66,7 +67,8 @@ if [ "$EDIT_CMD" != "nano" ]; then
     fi
 
     EDIT_CMD="vim.tiny"
+    EDIT_RESTRICT="-Z"
 fi
 
 # Run the editor.
-exec "${EDIT_CMD}" ${EDIT_IGNORE_RC} "${EDIT_PATH}"
+exec "${EDIT_CMD}" ${EDIT_RESTRICT} ${EDIT_IGNORE_RC} "${EDIT_PATH}"


### PR DESCRIPTION
Stop priming binaries that are already available in the base/core snap.  In the case of `vim`, this required to rework how the fallback editor is provided with a `vimrc`.

Not relying on primed binaries means those will be provided by the base snap (`core20` or `core22` ATM) which hopefully will benefit from regular maintenance.

In the case of `vim` and for the `5.0/stable` channel, this would have saved us from using a known vulnerable version:

```
$ grep vim-tiny /snap/core20/current/usr/share/snappy/dpkg.list 
ii  vim-tiny                       2:8.1.2269-1ubuntu5.15       amd64        Vi IMproved - enhanced vi editor - compact version

$ grep '^- vim-tiny' /snap/lxd/current/snap/manifest.yaml 
- vim-tiny=2:8.1.2269-1ubuntu5.11
```

In the above, `core20` ships `... .15` while the `5.0/stable` one has `... .11`.


While in there, I added a restricted mode to our 2 fallback editors. This is a weak security guard rail but has no visible downside from a user's perspective.

This was tested locally to be working.