### PR TITLE
snapcraft/wrappers/editor: fix EDIT_PATH_HOST mangling

### DIFF
--- a/snapcraft/wrappers/editor
+++ b/snapcraft/wrappers/editor
@@ -39,7 +39,7 @@ fi
 if [ -n "${EDIT_CMD}" ] && [ "${USERNS}" = 1 ]; then
     exec 9< /tmp/
     # Replace "/tmp/" prefix by exec'ed FD 9.
-    EDIT_PATH_HOST="/proc/self/fd/9/$(echo "${EDIT_PATH}" | cut -d/ -f2)"
+    EDIT_PATH_HOST="/proc/self/fd/9/$(echo "${EDIT_PATH}" | cut -d/ -f3)"
     find_and_spawn "${EDIT_CMD}" "${EDIT_PATH_HOST}"
 fi
 


### PR DESCRIPTION
Tested with `mount -o bind,ro "/home/$USER/git/lxd-pkg-snap/snapcraft/wrappers/editor" /snap/lxd/current/bin/editor` and `EDITOR=vi lxc profile edit default`.