### PR TITLE
Apparmor restrict unpriv editor (5.0-edge)

### DIFF
--- a/snapcraft/wrappers/editor
+++ b/snapcraft/wrappers/editor
@@ -17,8 +17,6 @@ run_cmd() {
 
 USERNS=1
 [ -e /proc/sys/kernel/unprivileged_userns_clone ] && grep -qxF 0 /proc/sys/kernel/unprivileged_userns_clone && USERNS=0
-[ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ] && grep -qxF 1 /proc/sys/kernel/apparmor_restrict_unprivileged_userns && USERNS=0
-[ -e /proc/sys/kernel/apparmor_restrict_unprivileged_unconfined ] && grep -qxF 1 /proc/sys/kernel/apparmor_restrict_unprivileged_unconfined && USERNS=0
 
 find_and_spawn() {
     for path in / /usr/ /usr/local/; do


### PR DESCRIPTION
Ubuntu Mantic `23.10` kernels before `6.5.0-14` (and maybe earlier) have `/proc/sys/kernel/apparmor_restrict_unprivileged_userns` and `/proc/sys/kernel/apparmor_restrict_unprivileged_unconfined` only root accessible.

While LXD can disable those restrictions to make unpriv containers work, the builtin editors used as fallback through unshare might trip into those files and cause noisy errors. Since the updated kernels have the restriction disabled by default and LXD disable them anyway, let's avoid the noisy errors and stop trying to read them in the fallback editor.

This is a cherry-pick from `latest-edge`:

```
$ git cherry-pick be91e3426d120430ab7d42ba4c579c2784362787
[apparmor-restrict-unpriv-editor-5.0-edge 0f91f91] wrappers/editor: don't try to read Apparmor unpriv userns/unconfined files
 Date: Tue Oct 10 17:07:01 2023 -0400
 1 file changed, 2 deletions(-)
```