### PR TITLE
Minimize snap staging and restricted fallback editors (5.0-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1539,12 +1539,27 @@ parts:
       strip -s ${SNAPCRAFT_PRIME}/lib/libdqlite*
       strip -s ${SNAPCRAFT_PRIME}/lib/libsqlite*
 
-      for zfs in zfs-0.6 zfs-0.7 zfs-0.8 zfs-2.0 zfs-2.1; do
-          [ ! -d "${SNAPCRAFT_PRIME}/${zfs}" ] && continue
-          strip -s ${SNAPCRAFT_PRIME}/${zfs}/bin/* ${SNAPCRAFT_PRIME}/${zfs}/lib/*
+      # Strip binaries (excluding shell scripts)
+      find "${SNAPCRAFT_PRIME}"/bin -type f \
+        -not -path "${SNAPCRAFT_PRIME}/bin/ceph" \
+        -not -path "${SNAPCRAFT_PRIME}/bin/editor" \
+        -not -path "${SNAPCRAFT_PRIME}/bin/lxc-checkconfig" \
+        -not -path "${SNAPCRAFT_PRIME}/bin/nvidia-container-cli" \
+        -not -path "${SNAPCRAFT_PRIME}/bin/remote-viewer" \
+        -not -path "${SNAPCRAFT_PRIME}/bin/sshfs" \
+        -not -path "${SNAPCRAFT_PRIME}/bin/xfs_admin" \
+        -exec strip -s {} +
+
+      # Strip all versions of zfs utils
+      for v in "${SNAPCRAFT_PRIME}"/zfs-*; do
+        [ -d "${v}" ] || continue
+        find "${v}/" -type f -exec strip -s {} +
       done
 
-      [ -e "${SNAPCRAFT_PRIME}/criu/criu" ] && strip -s ${SNAPCRAFT_PRIME}/criu/criu
+      # Strip libraries (excluding python3 scripts)
+      find "${SNAPCRAFT_PRIME}"/lib -type f \
+        -not -path "${SNAPCRAFT_PRIME}/lib/python3/*" \
+        -exec strip -s {} +
 
       # XXX: look for broken symlinks indicating missing/invalid prime
       broken_symlinks="$(find "${SNAPCRAFT_PRIME}/" -xtype l \

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1505,13 +1505,18 @@ parts:
       - raft
       - sqlite
       - squashfs-tools-ng
+      - swtpm
+      - virtiofsd
       - xfs
       - xz
+      - wrappers
+      - xtables
       - zfs-0-6
       - zfs-0-7
       - zfs-0-8
       - zfs-2-0
       - zfs-2-1
+      - zstd
       - lxc
       - lxcfs
       - criu

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1404,7 +1404,6 @@ parts:
       - bin/rsync
       - bin/setfacl
       - bin/sgdisk
-      - bin/unsquashfs
       - bin/xdelta3
 
       - lib/*/libidn.so.*

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1547,6 +1547,7 @@ parts:
         -not -path "${SNAPCRAFT_PRIME}/bin/nvidia-container-cli" \
         -not -path "${SNAPCRAFT_PRIME}/bin/remote-viewer" \
         -not -path "${SNAPCRAFT_PRIME}/bin/sshfs" \
+        -not -path "${SNAPCRAFT_PRIME}/bin/upgrade-bridge" \
         -not -path "${SNAPCRAFT_PRIME}/bin/xfs_admin" \
         -exec strip -s {} +
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1523,6 +1523,9 @@ parts:
     override-prime: |
       set -x
 
+      # XXX: remove unneeded files/directories
+      rm -rf "${SNAPCRAFT_PRIME}/usr/local/"
+
       # Strip some of the heavy bits
       strip -s ${SNAPCRAFT_PRIME}/bin/lxc
       strip -s ${SNAPCRAFT_PRIME}/bin/lxd*

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -940,20 +940,6 @@ parts:
       - bin/tar2sqfs
       - lib/libsquashfs.so*
 
-  vim:
-    build-attributes: [core22-step-dependencies]
-    source: snapcraft/empty
-    plugin: nil
-    stage-packages:
-      - vim-common
-      - vim-tiny
-    organize:
-      usr/bin/: bin/
-      usr/share/vim/vim*/debian.vim: etc/vimrc
-    prime:
-      - bin/vim.tiny
-      - etc/vimrc
-
   virtiofsd:
     build-attributes: [core22-step-dependencies]
     source: https://gitlab.com/virtio-fs/virtiofsd
@@ -1519,7 +1505,6 @@ parts:
       - raft
       - sqlite
       - squashfs-tools-ng
-      - vim
       - xfs
       - xz
       - zfs-0-6

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1524,6 +1524,7 @@ parts:
       set -x
 
       # XXX: remove unneeded files/directories
+      rm -rf "${SNAPCRAFT_PRIME}/lib/python3/dist-packages/*.egg-info/"
       rm -rf "${SNAPCRAFT_PRIME}/usr/local/"
 
       # Strip some of the heavy bits

--- a/snapcraft/wrappers/editor
+++ b/snapcraft/wrappers/editor
@@ -44,21 +44,30 @@ if [ -n "${EDIT_CMD}" ] && [ "${USERNS}" = 1 ]; then
     find_and_spawn "${EDIT_CMD}" "${EDIT_PATH_HOST}"
 fi
 
+# If the editor's rcfile is not readable, ignore it.
+EDIT_IGNORE_RC=""
+
 # Default to built-in nano.
 if [ -z "${EDIT_CMD}" ]; then
     EDIT_CMD="nano"
+    [ -r "${SNAP}/etc/nanorc" ] || EDIT_IGNORE_RC="--ignorercfiles"
 fi
 
 # Setup for VIM.
 if [ "$EDIT_CMD" != "nano" ]; then
-    if [ -e "${SNAP_USER_COMMON}/.vimrc" ]; then
-        export VIMINIT="source ${SNAP_USER_COMMON}/.vimrc"
-    else
-        export VIMINIT="source ${SNAP}/etc/vimrc"
+    # Find the base use by the LXD snap.
+    for vimrc in "${SNAP_USER_COMMON}/.vimrc" "/snap/core20/current/etc/vim/vimrc"; do
+        [ -r "${vimrc}" ] || continue
+        export VIMINIT="source ${vimrc}"
+    done
+
+    # Ignore vimrc if none was found to be readable.
+    if [ -z "${VIMINIT:-""}" ]; then
+        EDIT_IGNORE_RC="--clean"
     fi
 
     EDIT_CMD="vim.tiny"
 fi
 
 # Run the editor.
-exec "${EDIT_CMD}" "${EDIT_PATH}"
+exec "${EDIT_CMD}" ${EDIT_IGNORE_RC} "${EDIT_PATH}"

--- a/snapcraft/wrappers/editor
+++ b/snapcraft/wrappers/editor
@@ -40,7 +40,8 @@ fi
 # Try running the editor through the host.
 if [ -n "${EDIT_CMD}" ] && [ "${USERNS}" = 1 ]; then
     exec 9< /tmp/
-    EDIT_PATH_HOST="$(echo "${EDIT_PATH}" | sed "s#/tmp/#/proc/self/fd/9/#g")"
+    # Replace "/tmp/" prefix by exec'ed FD 9.
+    EDIT_PATH_HOST="/proc/self/fd/9/$(echo "${EDIT_PATH}" | cut -d/ -f2)"
     find_and_spawn "${EDIT_CMD}" "${EDIT_PATH_HOST}"
 fi
 

--- a/snapcraft/wrappers/editor
+++ b/snapcraft/wrappers/editor
@@ -41,7 +41,7 @@ fi
 if [ -n "${EDIT_CMD}" ] && [ "${USERNS}" = 1 ]; then
     exec 9< /tmp/
     # Replace "/tmp/" prefix by exec'ed FD 9.
-    EDIT_PATH_HOST="/proc/self/fd/9/$(echo "${EDIT_PATH}" | cut -d/ -f2)"
+    EDIT_PATH_HOST="/proc/self/fd/9/$(echo "${EDIT_PATH}" | cut -d/ -f3)"
     find_and_spawn "${EDIT_CMD}" "${EDIT_PATH_HOST}"
 fi
 

--- a/snapcraft/wrappers/editor
+++ b/snapcraft/wrappers/editor
@@ -47,10 +47,11 @@ fi
 
 # If the editor's rcfile is not readable, ignore it.
 EDIT_IGNORE_RC=""
-
+EDIT_RESTRICT=""
 # Default to built-in nano.
 if [ -z "${EDIT_CMD}" ]; then
     EDIT_CMD="nano"
+    EDIT_RESTRICT="--restricted"
     [ -r "${SNAP}/etc/nanorc" ] || EDIT_IGNORE_RC="--ignorercfiles"
 fi
 
@@ -68,7 +69,8 @@ if [ "$EDIT_CMD" != "nano" ]; then
     fi
 
     EDIT_CMD="vim.tiny"
+    EDIT_RESTRICT="-Z"
 fi
 
 # Run the editor.
-exec "${EDIT_CMD}" ${EDIT_IGNORE_RC} "${EDIT_PATH}"
+exec "${EDIT_CMD}" ${EDIT_RESTRICT} ${EDIT_IGNORE_RC} "${EDIT_PATH}"


### PR DESCRIPTION
Backport of #224, #237, #245 (follow-up fix) and #252 (not yet merged in `latest-edge`).

This ensures `vim` is provided by the `core20` base and also shrinks the snap size from 112MiB to 86MiB due to the additional stripping. Most of the size saving is due to stripping QEMU bits:

```
# 24322 is 5.0/stable on amd64
root@c2d:/snap/lxd# ll -h 24322/bin/qemu-* x1/bin/qemu-*
-rwxr-xr-x 1 root root  14M Jan 17  2023 24322/bin/qemu-img*
-rwxr-xr-x 1 root root  82M Jan 17  2023 24322/bin/qemu-system-x86_64*
-rwxr-xr-x 1 root root 1.9M Dec 15 21:43 x1/bin/qemu-img*
-rwxr-xr-x 1 root root  18M Dec 15 21:43 x1/bin/qemu-system-x86_64*
```

This also supersedes #248.

The locally built snap worked fine.