### PR TITLE
snapcraft/wrappers/editor: avoid bypassing nano restrict mode

### DIFF
--- a/snapcraft/wrappers/editor
+++ b/snapcraft/wrappers/editor
@@ -47,7 +47,7 @@ fi
 EDIT_IGNORE_RC=""
 EDIT_RESTRICT=""
 # Default to built-in nano.
-if [ -z "${EDIT_CMD}" ]; then
+if [ -z "${EDIT_CMD}" ] || [ "$EDIT_CMD" = "nano" ]; then
     EDIT_CMD="nano"
     EDIT_RESTRICT="--restricted"
     [ -r "${SNAP}/etc/nanorc" ] || EDIT_IGNORE_RC="--ignorercfiles"


### PR DESCRIPTION
Prior to that, this allowed bypassing the restricted mode:

```
sudo apt-get autoremove -y nano
EDITOR=nano lxc profile edit default
```