### PR TITLE
snapcraft: Switch to core24 devel

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: lxd
-base: core22
+base: core24
 assumes:
   - snapd2.39
 version: git


### PR DESCRIPTION
Currently this is based on 23.10 see https://snapcraft.io/core24

 > The base snap based on the Ubuntu 23.10 release.