### PR TITLE
Revert "snapcraft: Switch to core24 devel"

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: lxd
-base: core24
+base: core22
 assumes:
   - snapd2.39
 version: git


### PR DESCRIPTION
This reverts commit 1680fb59d75d41d4c52a4ecfab78ede4c2b0bca8.

Although it built OK locally, I realised I was using an equivalent of a core22 container and snapcraft didnt flag that this was a mismatch so wasn't a true test.

There is more that is needed to switch to cor24, so this will unblock the latest/edge builds for now.