### PR TITLE
Revert "snapcraft: Switch to core24 devel"

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: lxd
-base: core24
-build-base: devel
+base: core22
 assumes:
   - snapd2.39
 version: git


### PR DESCRIPTION
This reverts commit e98630f5c67f228a4dadfc94e0f41044d6164312.

We need to discuss further with the snapcraft team as to why the local builds aren't showing these issues, but launchpad is:

```
- classic: bin/arptables-legacy: ELF interpreter should be set to '/snap/lxd/current/lib64/ld-linux-x86-64.so.2'. (https://snapcraft.io/docs/linters-classic)
- classic: bin/arptables-legacy: ELF rpath should be set to '$ORIGIN/../lib/x86_64-linux-gnu'. (https://snapcraft.io/docs/linters-classic)
...
 ```

https://launchpadlibrarian.net/707712920/buildlog_snap_ubuntu_noble_amd64_lxd-latest-edge_BUILDING.txt.gz

Which is then manifesting itself in a built snap that doesn't work with LXD failing to start due to linker issues.
