### PR TITLE
Add `zfs` 2.2 to 5.0 snap (5.0-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1191,6 +1191,43 @@ parts:
       mv "${SNAPCRAFT_PART_INSTALL}.tmp/lib/"*so* "${SNAPCRAFT_PART_INSTALL}/zfs-2.1/lib/"
       rm -Rf "${SNAPCRAFT_PART_INSTALL}.tmp"
 
+  zfs-2-2:
+    source: https://github.com/openzfs/zfs
+    source-type: git
+    source-tag: zfs-2.2.2
+    source-depth: 1
+    plugin: autotools
+    autotools-configure-parameters:
+      - --prefix=/
+      - --with-config=user
+    build-packages:
+      - libblkid-dev
+      - libssl-dev
+      - uuid-dev
+      - zlib1g-dev
+    override-pull: |-
+      [ "$(uname -m)" != "x86_64" ] && \
+        [ "$(uname -m)" != "aarch64" ] && \
+        [ "$(uname -m)" != "s390x" ] && \
+        [ "$(uname -m)" != "ppc64le" ] && exit 0
+      snapcraftctl pull
+    override-build: |-
+      [ "$(uname -m)" != "x86_64" ] && \
+        [ "$(uname -m)" != "aarch64" ] && \
+        [ "$(uname -m)" != "s390x" ] && \
+        [ "$(uname -m)" != "ppc64le" ] && exit 0
+      snapcraftctl build
+      set -ex
+
+      ZFS_VER="2.2"
+
+      mv "${SNAPCRAFT_PART_INSTALL}" "${SNAPCRAFT_PART_INSTALL}.tmp"
+      mkdir -p "${SNAPCRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin" "${SNAPCRAFT_PART_INSTALL}/zfs-${ZFS_VER}/lib"
+      mv "${SNAPCRAFT_PART_INSTALL}.tmp/sbin/zfs" "${SNAPCRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin/"
+      mv "${SNAPCRAFT_PART_INSTALL}.tmp/sbin/zpool" "${SNAPCRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin/"
+      mv "${SNAPCRAFT_PART_INSTALL}.tmp/lib/udev/zvol_id" "${SNAPCRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin/"
+      mv "${SNAPCRAFT_PART_INSTALL}.tmp/lib/"*so* "${SNAPCRAFT_PART_INSTALL}/zfs-${ZFS_VER}/lib/"
+      rm -Rf "${SNAPCRAFT_PART_INSTALL}.tmp"
 
   zstd:
     build-attributes: [core22-step-dependencies]
@@ -1516,6 +1553,7 @@ parts:
       - zfs-0-8
       - zfs-2-0
       - zfs-2-1
+      - zfs-2-2
       - zstd
       - lxc
       - lxcfs

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -336,7 +336,11 @@ else
     VERSION=$(nsenter -t 1 -m modinfo -F version zfs 2>/dev/null || true)
 fi
 
-if echo "${VERSION}" | grep -q ^2\.1; then
+if echo "${VERSION}" | grep -q ^2\.2; then
+    echo "==> Setting up ZFS (2.2)"
+    export LD_LIBRARY_PATH="${SNAP_CURRENT}/zfs-2.2/lib/:${LD_LIBRARY_PATH}"
+    export PATH="${SNAP_CURRENT}/zfs-2.2/bin:${PATH}"
+elif echo "${VERSION}" | grep -q ^2\.1; then
     echo "==> Setting up ZFS (2.1)"
     export LD_LIBRARY_PATH="${SNAP_CURRENT}/zfs-2.1/lib/:${LD_LIBRARY_PATH}"
     export PATH="${SNAP_CURRENT}/zfs-2.1/bin:${PATH}"

--- a/snapcraft/commands/lxd-migrate
+++ b/snapcraft/commands/lxd-migrate
@@ -18,7 +18,10 @@ else
     VERSION=$(nsenter -t 1 -m modinfo -F version zfs 2>/dev/null || true)
 fi
 
-if echo "${VERSION}" | grep -q ^2\.1; then
+if echo "${VERSION}" | grep -q ^2\.2; then
+    export LD_LIBRARY_PATH="${SNAP_CURRENT}/zfs-2.2/lib/:${LD_LIBRARY_PATH}"
+    export PATH="${SNAP_CURRENT}/zfs-2.2/bin:${PATH}"
+elif echo "${VERSION}" | grep -q ^2\.1; then
     export LD_LIBRARY_PATH="${SNAP_CURRENT}/zfs-2.1/lib/:${LD_LIBRARY_PATH}"
     export PATH="${SNAP_CURRENT}/zfs-2.1/bin:${PATH}"
 elif echo "${VERSION}" | grep -q ^2\.0; then


### PR DESCRIPTION
On a Jammy host, if one installs `linux-image-generic-hwe-22.04-edge` a 6.5 kernel will be installed. That kernel comes with:

```
$ journalctl -b-1 -k | head -n1
Jan 05 17:54:55 c2d kernel: Linux version 6.5.0-14-generic (buildd@lcy02-amd64-110) (x86_64-linux-gnu-gcc-12 (Ubuntu 12.3.0-1ubuntu1~22.04) 12.3.0, GNU ld (GNU Binutils for Ubuntu) 2.38) #14~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Mon Nov 20 18:15:30 UTC 2 (Ubuntu 6.5.0-14.14~22.04.1-generic 6.5.3)

$ zfs --version
zfs-2.1.5-1ubuntu6~22.04.2
zfs-kmod-2.2.0-0ubuntu1~23.10
```

This prevents LXD from finding the 2.2 version of the `zfs` tooling:

```
Jan 05 17:55:23 c2d lxd.daemon[1444]: time="2024-01-05T17:55:23Z" level=error msg="Failed loading storage pool" err="Required tool 'zpool' is missing" pool=default
```
