### PR TITLE
Revert "snapcraft: Update libs used by ceph tooling for core24"

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -184,8 +184,6 @@ parts:
     plugin: nil
     stage-packages:
       - ceph-common
-      - libssh-dev
-      - libsnappy1v5
     organize:
       usr/bin/: bin/
       usr/lib/: lib/
@@ -207,10 +205,9 @@ parts:
       - lib/*/libibverbs.so*
       - lib/*/libicudata.so*
       - lib/*/libicuuc.so*
-      - lib/*/liblber*.so*
-      - lib/*/libldap*.so*
-      - lib/*/liblua*.so*
-      - lib/*/libncurses.so*
+      - lib/*/liblber-2.5.so*
+      - lib/*/libldap-2.5.so*
+      - lib/*/liblua5.3.so*
       - lib/*/libndctl.so*
       - lib/*/libnghttp2.so*
       - lib/*/liboath.so*
@@ -224,10 +221,6 @@ parts:
       - lib/*/librtmp.so*
       - lib/*/libsasl2.so*
       - lib/*/libsnappy.so*
-      - lib/*/libssh.so*
-      - lib/*/libtcmalloc.so*
-      - lib/*/libunistring.so*
-      - lib/*/libunwind.so*
 
   criu:
     source: https://github.com/checkpoint-restore/criu


### PR DESCRIPTION
This reverts commit 14889dd078b7400b2e379d7259d9b93c01f617f8 used as part of the core24 switch over and is preventing builds on core22.

core24 is not yet operational, see https://github.com/snapcore/snapcraft/issues/4508

This was tested using `snapcraft remote-build` to make sure launchpad was happy with it and then installed locally to check it ran.

