### PR TITLE
Dynamically lookup the base snap name

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -31,6 +31,9 @@ export PYTHONPATH=/snap/lxd/current/lib/python3/dist-packages/
 # Detect model
 SNAP_MODEL="$(nsenter -t 1 -m snap model --assertion | sed -n 's/^model: \(.\+\)/\1/p')"
 
+# Detect base name
+SNAP_BASE="$(sed -n '/^name:/ s/^name:\s*\(core[0-9]\{2\}\)/\1/p' /meta/snap.yaml)"
+
 # Wait for appliance configuration
 if echo "${SNAP_MODEL}" | grep -q "^lxd-core"; then
     while :; do
@@ -229,7 +232,7 @@ done
 
 ## And the bits we need from the core snap
 for entry in alternatives apparmor apparmor.d; do
-    ln -s "/snap/core22/current/etc/${entry}" "/etc/${entry}"
+    ln -s "/snap/${SNAP_BASE}/current/etc/${entry}" "/etc/${entry}"
 done
 
 ## And those we directly ship in the snap
@@ -245,7 +248,7 @@ if [ -e "/var/lib/snapd/hostfs/etc/ssl" ] && [ -e "/var/lib/snapd/hostfs/usr/sha
     ln -s "/var/lib/snapd/hostfs/etc/ssl" "/etc/ssl"
     mountpoint -q "/usr/share/ca-certificates" || mount -o ro,bind "/var/lib/snapd/hostfs/usr/share/ca-certificates" "/usr/share/ca-certificates"
 else
-    ln -s "/snap/core22/current/etc/ssl" "/etc/ssl"
+    ln -s "/snap/${SNAP_BASE}/current/etc/ssl" "/etc/ssl"
 fi
 
 ## Try to handle special /etc/resolv.conf setups

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -495,7 +495,7 @@ if [ -e "${SNAP_COMMON}/var/lib/lxcfs/cgroup" ]; then
     CURRENT_FUSE="${NEW_FUSE}"
 
     ## Get the name of the base (core2X) used by the new snap
-    NEW_BASE="$(grep ^name /meta/snap.yaml)"
+    NEW_BASE="${SNAP_BASE}"
     CURRENT_BASE="${NEW_BASE}"
 
     ## Use the old lxcfs instance to get the libfuse soname and old base it uses
@@ -503,7 +503,7 @@ if [ -e "${SNAP_COMMON}/var/lib/lxcfs/cgroup" ]; then
         read -r CURRENT_PID < "${SNAP_COMMON}/lxcfs.pid"
         if [ -e "/proc/${CURRENT_PID}" ]; then
             CURRENT_FUSE="$(ldd "/proc/${CURRENT_PID}/exe" | sed -n "/libfuse3\?\.so/ s/.*libfuse3\?\.so\.\([^ ]\+\) .*/\1/p")"
-            CURRENT_BASE="$(grep ^name "/proc/${CURRENT_PID}/root/meta/snap.yaml")"
+            CURRENT_BASE="$(sed -n '/^name:/ s/^name:\s*\(core[0-9]\{2\}\)/\1/p' "/proc/${CURRENT_PID}/root/meta/snap.yaml")"
         fi
     fi
 

--- a/snapcraft/wrappers/editor
+++ b/snapcraft/wrappers/editor
@@ -15,6 +15,9 @@ run_cmd() {
     exec unshare --kill-child -U -m -p -r -f -R "/var/lib/snapd/hostfs/" "/bin/sh" -c "mount -t proc proc /proc 2>/dev/null || true; exec \"${CMD}\" \"$@\""
 }
 
+# Detect base name
+SNAP_BASE="$(sed -n '/^name:/ s/^name:\s*\(core[0-9]\{2\}\)/\1/p' /meta/snap.yaml)"
+
 USERNS=1
 [ -e /proc/sys/kernel/unprivileged_userns_clone ] && grep -qxF 0 /proc/sys/kernel/unprivileged_userns_clone && USERNS=0
 
@@ -56,7 +59,7 @@ fi
 # Setup for VIM.
 if [ "$EDIT_CMD" != "nano" ]; then
     # Find the base use by the LXD snap.
-    for vimrc in "${SNAP_USER_COMMON}/.vimrc" "/snap/core22/current/etc/vim/vimrc"; do
+    for vimrc in "${SNAP_USER_COMMON}/.vimrc" "/snap/${SNAP_BASE}/current/etc/vim/vimrc"; do
         [ -r "${vimrc}" ] || continue
         export VIMINIT="source ${vimrc}"
     done

--- a/snapcraft/wrappers/kmod
+++ b/snapcraft/wrappers/kmod
@@ -5,7 +5,7 @@ NAME="$(basename "${0}")"
 SNAP_BASE="$(sed -n '/^name:/ s/^name:\s*\(core[0-9]\{2\}\)/\1/p' /meta/snap.yaml)"
 
 if [ "$(id -u)" != "0" ] && [ "${NAME}" = "modinfo" ]; then
-    TMPDIR=$(mktemp -d)
+    TMPDIR="$(mktemp -d)"
     ln -s "/snap/${SNAP_BASE}/current/bin/kmod" "${TMPDIR}/modinfo"
     "${TMPDIR}/modinfo" "$@"
     RET=$?

--- a/snapcraft/wrappers/kmod
+++ b/snapcraft/wrappers/kmod
@@ -1,9 +1,12 @@
 #!/bin/sh
 NAME="$(basename "${0}")"
 
+# Detect base name
+SNAP_BASE="$(sed -n '/^name:/ s/^name:\s*\(core[0-9]\{2\}\)/\1/p' /meta/snap.yaml)"
+
 if [ "$(id -u)" != "0" ] && [ "${NAME}" = "modinfo" ]; then
     TMPDIR=$(mktemp -d)
-    ln -s "/snap/core22/current/bin/kmod" "${TMPDIR}/modinfo"
+    ln -s "/snap/${SNAP_BASE}/current/bin/kmod" "${TMPDIR}/modinfo"
     "${TMPDIR}/modinfo" "$@"
     RET=$?
     rm -Rf "${TMPDIR}"
@@ -11,7 +14,7 @@ if [ "$(id -u)" != "0" ] && [ "${NAME}" = "modinfo" ]; then
 fi
 
 if [ "${NAME}" = "lsmod" ]; then
-    exec "/snap/core22/current/bin/kmod" "list" "$@"
+    exec "/snap/${SNAP_BASE}/current/bin/kmod" "list" "$@"
 fi
 
 for i in "/bin/${NAME}" "/sbin/${NAME}" "/usr/bin/${NAME}" "/usr/sbin/${NAME}"; do


### PR DESCRIPTION
Rather than hardcode the core base name, look it up where/when needed. This was tested locally:

`daemon.start`:

```
$ sudo ls -l /var/snap/lxd/common/mntns/etc/ | grep core
lrwxrwxrwx 1 root root   37 Jan  9 12:48 alternatives -> /snap/core22/current/etc/alternatives
lrwxrwxrwx 1 root root   33 Jan  9 12:48 apparmor -> /snap/core22/current/etc/apparmor
lrwxrwxrwx 1 root root   35 Jan  9 12:48 apparmor.d -> /snap/core22/current/etc/apparmor.d
```

`editor`:

```
$ EDITOR=foo lxc config edit &
$ grep -a 'core[0-9]*' "/proc/$(pgrep vim.tiny)/environ"
LESSOPEN=| /usr/bin/lesspipe %s
HISTTIMEFORMAT=%F %T 
LANGUAGE=en_CA:en
LC_TIME=C.UTF-8
SNAP_COMMON=/var/snap/lxd/common
SNAP_INSTANCE_KEY=USER=sdeziel
XDG_SESSION_TYPE=x11
LXD_CONF=/home/sdeziel/snap/lxd/common/config
LD_LIBRARY_PATH=/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void:/snap/lxd/x1/lib:/snap/lxd/x1/lib/x86_64-linux-gnu
SHLVL=0
SNAP_UID=1000
TEMPDIR=/tmp
HOME=/home/sdeziel/snap/lxd/x1
SNAP_LIBRARY_PATH=/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void
DESKTOP_SESSION=ubuntu
SNAP_USER_DATA=/home/sdeziel/snap/lxd/x1
...
VIMINIT=source /snap/core22/current/etc/vim/vimrc
...
EDITOR=/snap/lxd/x1/bin/editor foo
```

`kmod`:

```
# nsenter -m -t "$(lxc info | awk '/server_pid:/ {print $2}')" sh -x /usr/sbin/lsmod | grep ^+
+ basename /usr/sbin/lsmod
+ NAME=lsmod
+ sed -n /^name:/ s/^name:\s*\(core[0-9]\{2\}\)/\1/p /meta/snap.yaml
+ SNAP_BASE=core22
+ id -u
+ [ 0 != 0 ]
+ [ lsmod = lsmod ]
+ exec /snap/core22/current/bin/kmod list
```