### PR TITLE
snapcraft/commands/daemon.start: always remount /bin/kmod

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -136,7 +136,8 @@ fi
 
 # Fix lsmod/modprobe
 echo "==> Setting up kmod wrapper"
-mountpoint -q /bin/kmod || mount -o ro,bind "${SNAP}/wrappers/kmod" "/bin/kmod"
+mountpoint -q /bin/kmod && umount -l /bin/kmod
+mount -o ro,bind "${SNAP}/wrappers/kmod" "/bin/kmod"
 
 # Setup /boot
 if [ -e /var/lib/snapd/hostfs/boot ]; then


### PR DESCRIPTION
Upon update, the `daemon.start` would keep any existing mountbind of `/bin/kmod` rather than remount a fresh one. This lead to such situation:

```
root@sdeziel-lemur:~# nsenter -m -t "$(lxc info | awk '/server_pid:/ {print $2}')"
root@sdeziel-lemur:/# mount | grep kmod
/var/lib/snapd/snaps/lxd_26615.snap (deleted) on /usr/bin/kmod type squashfs (ro,relatime,errors=continue,threads=single
```

Always remounting that script should avoid holding onto old snap data.