### PR TITLE
snapcraft: ensure logrotate.conf isn't group writable

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1644,6 +1644,8 @@ parts:
           exit 1
       fi
 
+      # Fixup logrotate.conf permissions to not be group writable
+      chmod g-w "${CRAFT_PRIME}/etc/logrotate.conf"
       exit 0
 
   wrappers:


### PR DESCRIPTION
Upon startup, LXD might complain during the `==> Rotating logs` part:

```
$ journalctl --no-hostname -b0 -u snap.lxd.daemon --grep logrotate
Jan 09 11:30:33 lxd.daemon[642189]: Potentially dangerous mode on /snap/lxd/x1/etc/logrotate.conf: 0664
Jan 09 11:30:33 lxd.daemon[642189]: error: Ignoring /snap/lxd/x1/etc/logrotate.conf because it is writable by group or others.
```

For some reasons (unknown to me), this only affected snaps I build locally, not those from the snapstore. Here's a debug build with `ls -l` surrounding the `chmod g-w` call:

```
2024-01-09 16:07:33.880 :: 2024-01-09 16:07:03.592 :: + broken_symlinks=
2024-01-09 16:07:33.880 :: 2024-01-09 16:07:03.592 :: + '[' -n '' ']'
2024-01-09 16:07:33.880 :: 2024-01-09 16:07:03.593 :: + ls -l /root/prime/etc/logrotate.conf
2024-01-09 16:07:33.880 :: 2024-01-09 16:07:03.600 :: -rw-rw-r-- 4 root root 145 Sep 22 21:11 /root/prime/etc/logrotate.conf
2024-01-09 16:07:33.880 :: 2024-01-09 16:07:03.600 :: + chmod g-w /root/prime/etc/logrotate.conf
2024-01-09 16:07:33.880 :: 2024-01-09 16:07:03.601 :: + ls -l /root/prime/etc/logrotate.conf
2024-01-09 16:07:33.880 :: 2024-01-09 16:07:03.602 :: -rw-r--r-- 4 root root 145 Sep 22 21:11 /root/prime/etc/logrotate.conf
2024-01-09 16:07:33.880 :: 2024-01-09 16:07:03.603 :: + exit 0
2024-01-09 16:07:33.880 :: 2024-01-09 16:07:03.729 patch_elf: not enabled for part 'strip'
```