### PR TITLE
snapcraft: qemu: start shipping SeaBIOS 256k image

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -898,6 +898,7 @@ parts:
       - libpixman-1-0
       - libusbredirhost1
       - libusbredirparser1
+      - seabios
     override-pull: |-
       [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "ppc64le" ] && [ "$(uname -m)" != "s390x" ] && exit 0
       craftctl default
@@ -921,6 +922,7 @@ parts:
       usr/local/lib/: lib/
       usr/local/libexec/: bin/
       usr/local/share/: share/
+      usr/share/seabios/bios-256k.bin: share/qemu/seabios.bin
     prime:
       - bin/genisoimage*
       - bin/mkisofs*
@@ -938,6 +940,7 @@ parts:
       - share/qemu/s390-*.img*
       - share/qemu/slof.bin*
       - share/qemu/vgabios-*.bin*
+      - share/qemu/seabios.bin
 
   qemu-ovmf-secureboot:
     after:


### PR DESCRIPTION
Let's start shipping a SeaBIOS 256k image in the snap. It's needed for a CSM mode support in LXD.

Unfortunately, EDKII CSM module was removed:
https://bugzilla.tianocore.org/show_bug.cgi?id=4588

It means that for all new VMs in LXD we will start to use SeaBIOS directly without EDKII/CSM module. For the compatibility sake we are not removing EDKII-based CSM firmware right now, but we will do that a little bit later.

Fixes https://github.com/canonical/lxd/issues/12730