### PR TITLE
snapcraft: remove bios-256k from organize step

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -882,7 +882,6 @@ parts:
       usr/local/lib/: lib/
       usr/local/libexec/: bin/
       usr/local/share/: share/
-      usr/share/seabios/bios-256k.bin: share/qemu/bios-256k.bin
     prime:
       - bin/genisoimage*
       - bin/mkisofs*


### PR DESCRIPTION
Remove
      usr/share/seabios/bios-256k.bin: share/qemu/bios-256k.bin
from the "organize" step as it's already in a right place. We will need this once we step on the Ubuntu QEMU builds.