### PR TITLE
snapcraft: make bios-256k.bin optional at prime step

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -875,6 +875,11 @@ parts:
 
       set +ex
       craftctl default
+
+      set -ex
+      # we don't want to take this file from the qemu tree, but instead from the seabios package
+      rm "${CRAFT_PART_INSTALL}/usr/local/share/qemu/bios-256k.bin"
+      set +ex
     organize:
       usr/bin/: bin/
       usr/lib/: lib/
@@ -882,6 +887,7 @@ parts:
       usr/local/lib/: lib/
       usr/local/libexec/: bin/
       usr/local/share/: share/
+      usr/share/seabios/bios-256k.bin: share/qemu/
     prime:
       - bin/genisoimage*
       - bin/mkisofs*
@@ -899,7 +905,7 @@ parts:
       - share/qemu/s390-*.img*
       - share/qemu/slof.bin*
       - share/qemu/vgabios-*.bin*
-      - share/qemu/bios-256k.bin
+      - share/qemu/bios-256k.bin*
 
   qemu-ovmf-secureboot:
     after:


### PR DESCRIPTION
Unfortunately, we have to use this hack to make armhf/riscv builds to succeed, as on these two architectures we don't support QEMU at all. But prime step is still being executed which makes a whole snap build to fail [1], [2].

Also, let's always use bios-256k.bin SeaBIOS from the seabios package instead of from the QEMU tree.

[1] https://launchpadlibrarian.net/710544674/buildlog_snap_ubuntu_jammy_armhf_lxd-latest-edge_BUILDING.txt.gz
[2] https://launchpadlibrarian.net/710258725/buildlog_snap_ubuntu_jammy_riscv64_lxd-latest-edge_BUILDING.txt.gz