### PR TITLE
snapcraft: prime just the nvme binary (into bin/)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1574,7 +1574,7 @@ parts:
       set -x
 
       # XXX: remove unneeded files/directories
-      rm -rf "${CRAFT_PRIME}/lib/python3/dist-packages/*.egg-info/"
+      find "${CRAFT_PRIME}/lib/python3/dist-packages/" -name "*.egg-info" -type d -exec rm -rf {} +
       rm -rf "${CRAFT_PRIME}/lib/systemd/"
       rm -rf "${CRAFT_PRIME}/lib/udev/"
       rm -rf "${CRAFT_PRIME}/usr/local/"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -673,6 +673,10 @@ parts:
     plugin: nil
     stage-packages:
       - nvme-cli
+    organize:
+      usr/sbin/: bin/
+    prime:
+      - bin/nvme
 
   openvswitch:
     source: https://github.com/openvswitch/ovs

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1546,7 +1546,9 @@ parts:
       - nvidia-container
       - openvswitch
       - ovn
+      - qemu-ovmf-secureboot
       - raft
+      - spice-server
       - sqlite
       - squashfs-tools-ng
       - swtpm


### PR DESCRIPTION
This has the (desired) side effect of no longer including the following in the snap:

* `etc/nvme` which only contained a commented out config file
* `usr/` which contained `usr/bin/uuid*` and `usr/sbin/nvme` and `usr/sbin/uuidd`

While comparing the snaps, I also noticed the Python egg-info directories were not properly cleaned up so this was fixed too.