### PR TITLE
snapcraft.yaml: enable unconfined mode in lxd-support interface

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: lxd
 base: core22
 assumes:
-  - snapd2.39
+  - snapd2.62
 version: git
 grade: devel
 summary: LXD - container and VM manager
@@ -71,6 +71,9 @@ plugs:
  ovn-chassis:
    interface: content
    target: "$SNAP_DATA/microovn/chassis"
+ lxd-support-with-unconfined-mode:
+   interface: lxd-support
+   enable-unconfined-mode: true
 
 apps:
   # Main commands
@@ -78,7 +81,7 @@ apps:
     command: commands/daemon.activate
     daemon: oneshot
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
 
   daemon:
@@ -91,7 +94,7 @@ apps:
     slots:
       - lxd
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - network-bind
       - system-observe
     sockets:
@@ -105,7 +108,7 @@ apps:
     restart-condition: on-failure
     daemon: simple
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - network-bind
       - system-observe
     sockets:
@@ -117,60 +120,60 @@ apps:
     command: commands/lxc
     completer: etc/bash_completion.d/snap.lxd.lxc
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
 
   lxd:
     command: commands/lxd
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
 
   # Sub-commands
   buginfo:
     command: commands/buginfo
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
   check-kernel:
     command: commands/lxd-check-kernel
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
 
 hooks:
   connect-plug-ceph-conf:
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
   disconnect-plug-ceph-conf:
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
   connect-plug-ovn-certificates:
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
   disconnect-plug-ovn-certificates:
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
   connect-plug-ovn-chassis:
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
   disconnect-plug-ovn-chassis:
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
   configure:
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - network
       - system-observe
   remove:
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
 
 parts:


### PR DESCRIPTION
The associated PR for snapd is still open in https://github.com/snapcore/snapd/pull/13514 but opening this one against the lxd snap so the two can be reviewed in tandem.

This should not be merged until at least the snapd one has been AND the correct assumes syntax has been decided upon.


--

The old `lxd-support` interface allowed lxd to set itself to be unconfined - ie to not have any apparmor profile associated with it - but when the userns restrictions are enabled it would then still be blocked from using userns - so we then instead added the unconfined mode which allows a profile to essentially be the equivalent of the unconfined profile (ie no profile) - but then to also add in extra permissions (like the use of userns).

ie. the only way to use userns when the restrictions are enabled is to have an apparmor profile which grants the userns permission in apparmor - AND for the case of lxd which wants to be unconfined we then use the new unconfined profile mode as well

Signed-off-by: Alex Murray <alex.murray@canonical.com>