### PR TITLE
snapcraft/wrappers/run-host: use unshare --root instead of calling chroot

### DIFF
--- a/snapcraft/wrappers/editor
+++ b/snapcraft/wrappers/editor
@@ -12,7 +12,7 @@ run_cmd() {
     [ -z "${XDG_STATE_HOME:-}" ] && export XDG_STATE_HOME="${HOME}/.local/state/"
 
     # shellcheck disable=SC2145
-    exec unshare --kill-child -U -m -p -r -f -R "/var/lib/snapd/hostfs/" "/bin/sh" -c "mount -t proc proc /proc 2>/dev/null || true; exec \"${CMD}\" \"$@\""
+    exec unshare --kill-child -U -m -p -r -f --root="/var/lib/snapd/hostfs/" "/bin/sh" -c "mount -t proc proc /proc 2>/dev/null || true; exec \"${CMD}\" \"$@\""
 }
 
 # Detect base name

--- a/snapcraft/wrappers/run-host
+++ b/snapcraft/wrappers/run-host
@@ -9,4 +9,4 @@ if [ "$(id -u)" = "0" ]; then
     exec nsenter -t 1 -m "${CMD}" "$@"
 fi
 
-exec unshare -U -r chroot "/var/lib/snapd/hostfs/" "${CMD}" "$@"
+exec unshare -U -r --root="/var/lib/snapd/hostfs/" "${CMD}" "$@"


### PR DESCRIPTION
Both are equivalent and we already use unshare --root elsewhere so one less moving part and more consistency.