### PR TITLE
.github: Remove lxd-migrate build test for now (5.0-candidate)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -13,24 +13,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lxd-migrate:
-    name: Test lxd-migrate build
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.20.x
-
-      - name: Test lxd-migrate build
-        run: |
-          set -eux
-          cd ~/work/lxd-pkg-snap/lxd-pkg-snap/lxd-migrate
-          CGO_ENABLED=0 go build -v -tags netgo
-
   snap:
     name: Trigger snap build
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This is failing until we tag lxd 5.0.3 due to repo name change.