### PR TITLE
snapcraft: strip criu binary (5.9M -> 1.6M)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1591,6 +1591,10 @@ parts:
         -not -path "${CRAFT_PRIME}/bin/xfs_admin" \
         -exec strip -s {} +
 
+      # Strip binaries not under bin/ due to being dynamically
+      # added to the path with `snap set lxd`
+      strip -s "${CRAFT_PRIME}/criu/criu"  # snap set lxd criu.enable=true
+
       # Strip all versions of zfs utils
       for v in "${CRAFT_PRIME}"/zfs-*; do
         [ -d "${v}" ] || continue


### PR DESCRIPTION
`criu` wasn't being stripped because it is not under `bin/` due to being optionally added to $PATH when `snap set lxd criu.enable=true`.