### PR TITLE
Faster snap builds

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -766,6 +766,13 @@ parts:
     stage-packages:
       - libjpeg-turbo8
       - libpixman-1-0
+    override-pull: |-
+      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "ppc64le" ] && [ "$(uname -m)" != "s390x" ] && exit 0
+      craftctl default
+
+    override-build: |-
+      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "ppc64le" ] && [ "$(uname -m)" != "s390x" ] && exit 0
+      craftctl default
     organize:
       sbin/: bin/
       usr/lib: lib/

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -407,6 +407,7 @@ parts:
 
   libmnl:
     source: https://git.netfilter.org/libmnl
+    source-depth: 1
     source-tag: libmnl-1.0.5
     source-type: git
     plugin: autotools
@@ -421,6 +422,7 @@ parts:
     after:
       - libmnl
     source: https://git.netfilter.org/libnftnl
+    source-depth: 1
     source-tag: libnftnl-1.2.6
     source-type: git
     plugin: autotools
@@ -605,6 +607,7 @@ parts:
       - libmnl
       - libnftnl
     source: https://git.netfilter.org/nftables
+    source-depth: 1
     source-tag: v1.0.9
     source-type: git
     plugin: autotools
@@ -1242,6 +1245,7 @@ parts:
     after:
       - libseccomp
     source: https://github.com/lxc/lxc
+    source-depth: 1
     source-type: git
     build-packages:
       - dpkg-dev
@@ -1296,6 +1300,7 @@ parts:
 
   lxcfs:
     source: https://github.com/lxc/lxcfs
+    source-depth: 1
     source-type: git
     build-packages:
       - libfuse3-dev
@@ -1347,6 +1352,7 @@ parts:
 
   lxd:
     source: https://github.com/canonical/lxd
+    source-depth: 1
     source-type: git
     after:
       - lxc
@@ -1495,6 +1501,7 @@ parts:
 
   lxd-ui:
     source: https://github.com/canonical/lxd-ui
+    source-depth: 1
     source-type: git
     plugin: nil
     override-pull: |

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -242,18 +242,10 @@ parts:
       - libnet1
       - libprotobuf-c1
     override-pull: |-
-      [ "$(uname -m)" != "x86_64" ] && \
-        [ "$(uname -m)" != "armv7l" ] && \
-        [ "$(uname -m)" != "aarch64" ] && \
-        [ "$(uname -m)" != "s390x" ] && \
-        [ "$(uname -m)" != "ppc64le" ] && exit 0
+      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "ppc64le" ] && [ "$(uname -m)" != "s390x" ] && [ "$(uname -m)" != "armv7l" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" != "x86_64" ] && \
-        [ "$(uname -m)" != "armv7l" ] && \
-        [ "$(uname -m)" != "aarch64" ] && \
-        [ "$(uname -m)" != "s390x" ] && \
-        [ "$(uname -m)" != "ppc64le" ] && exit 0
+      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "ppc64le" ] && [ "$(uname -m)" != "s390x" ] && [ "$(uname -m)" != "armv7l" ] && exit 0
       set -ex
 
       make USERCFLAGS=-Wno-error=format-truncation criu

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1584,8 +1584,11 @@ parts:
         -exec strip -s {} +
 
       # Strip binaries not under bin/ due to being dynamically
-      # added to the path with `snap set lxd`
-      strip -s "${CRAFT_PRIME}/criu/criu"  # snap set lxd criu.enable=true
+      # added to the path with `snap set lxd`, like `criu.enable=true`
+      for binary in "${CRAFT_PRIME}/criu/criu"; do
+        [ -e "${binary}" ] || continue
+        strip -s "${binary}"
+      done
 
       # Strip all versions of zfs utils
       for v in "${CRAFT_PRIME}"/zfs-*; do

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -732,6 +732,13 @@ parts:
     build-packages:
       - meson
       - ninja-build
+    override-pull: |-
+      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "ppc64le" ] && [ "$(uname -m)" != "s390x" ] && exit 0
+      craftctl default
+
+    override-build: |-
+      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "ppc64le" ] && [ "$(uname -m)" != "s390x" ] && exit 0
+      craftctl default
 
   spice-server:
     after:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -407,7 +407,8 @@ parts:
 
   libmnl:
     source: https://git.netfilter.org/libmnl
-    source-depth: 1
+    # XXX: git.netfilter.org does not support depth/shallow clones
+    #source-depth: 1
     source-tag: libmnl-1.0.5
     source-type: git
     plugin: autotools
@@ -422,7 +423,8 @@ parts:
     after:
       - libmnl
     source: https://git.netfilter.org/libnftnl
-    source-depth: 1
+    # XXX: git.netfilter.org does not support depth/shallow clones
+    #source-depth: 1
     source-tag: libnftnl-1.2.6
     source-type: git
     plugin: autotools
@@ -607,7 +609,8 @@ parts:
       - libmnl
       - libnftnl
     source: https://git.netfilter.org/nftables
-    source-depth: 1
+    # XXX: git.netfilter.org does not support depth/shallow clones
+    #source-depth: 1
     source-tag: v1.0.9
     source-type: git
     plugin: autotools

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -296,12 +296,8 @@ parts:
     plugin: nil
     build-packages:
       - g++
-      - on amd64:
-        - acpica-tools
-        - uuid-dev
-      - on arm64:
-        - acpica-tools
-        - uuid-dev
+      - acpica-tools
+      - uuid-dev
     override-pull: |-
       [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
       set -ex

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -592,7 +592,11 @@ parts:
       usr/bin/: bin/
     prime:
       - bin/nasm
+    override-pull: |-
+      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
+      craftctl default
     override-build: |
+      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
       patch -p1 < "${CRAFT_PROJECT_DIR}/patches/nasm-0000-disable-manpages.patch"
       craftctl default
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -256,7 +256,7 @@ parts:
         [ "$(uname -m)" != "ppc64le" ] && exit 0
       set -ex
 
-      make USERCFLAGS=-Wno-error=format-truncation
+      make USERCFLAGS=-Wno-error=format-truncation criu
       mkdir -p "${CRAFT_PART_INSTALL}/criu/"
       cp criu/criu "${CRAFT_PART_INSTALL}/criu/"
     organize:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1105,16 +1105,10 @@ parts:
       - uuid-dev
       - zlib1g-dev
     override-pull: |-
-      [ "$(uname -m)" != "x86_64" ] && \
-        [ "$(uname -m)" != "aarch64" ] && \
-        [ "$(uname -m)" != "s390x" ] && \
-        [ "$(uname -m)" != "ppc64le" ] && exit 0
+      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "ppc64le" ] && [ "$(uname -m)" != "s390x" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" != "x86_64" ] && \
-        [ "$(uname -m)" != "aarch64" ] && \
-        [ "$(uname -m)" != "s390x" ] && \
-        [ "$(uname -m)" != "ppc64le" ] && exit 0
+      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "ppc64le" ] && [ "$(uname -m)" != "s390x" ] && exit 0
       craftctl default
       set -ex
 
@@ -1143,16 +1137,10 @@ parts:
       - uuid-dev
       - zlib1g-dev
     override-pull: |-
-      [ "$(uname -m)" != "x86_64" ] && \
-        [ "$(uname -m)" != "aarch64" ] && \
-        [ "$(uname -m)" != "s390x" ] && \
-        [ "$(uname -m)" != "ppc64le" ] && exit 0
+      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "ppc64le" ] && [ "$(uname -m)" != "s390x" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" != "x86_64" ] && \
-        [ "$(uname -m)" != "aarch64" ] && \
-        [ "$(uname -m)" != "s390x" ] && \
-        [ "$(uname -m)" != "ppc64le" ] && exit 0
+      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "ppc64le" ] && [ "$(uname -m)" != "s390x" ] && exit 0
       craftctl default
       set -ex
 
@@ -1181,16 +1169,10 @@ parts:
       - uuid-dev
       - zlib1g-dev
     override-pull: |-
-      [ "$(uname -m)" != "x86_64" ] && \
-        [ "$(uname -m)" != "aarch64" ] && \
-        [ "$(uname -m)" != "s390x" ] && \
-        [ "$(uname -m)" != "ppc64le" ] && exit 0
+      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "ppc64le" ] && [ "$(uname -m)" != "s390x" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" != "x86_64" ] && \
-        [ "$(uname -m)" != "aarch64" ] && \
-        [ "$(uname -m)" != "s390x" ] && \
-        [ "$(uname -m)" != "ppc64le" ] && exit 0
+      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "ppc64le" ] && [ "$(uname -m)" != "s390x" ] && exit 0
       craftctl default
       set -ex
 
@@ -1219,16 +1201,10 @@ parts:
       - uuid-dev
       - zlib1g-dev
     override-pull: |-
-      [ "$(uname -m)" != "x86_64" ] && \
-        [ "$(uname -m)" != "aarch64" ] && \
-        [ "$(uname -m)" != "s390x" ] && \
-        [ "$(uname -m)" != "ppc64le" ] && exit 0
+      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "ppc64le" ] && [ "$(uname -m)" != "s390x" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" != "x86_64" ] && \
-        [ "$(uname -m)" != "aarch64" ] && \
-        [ "$(uname -m)" != "s390x" ] && \
-        [ "$(uname -m)" != "ppc64le" ] && exit 0
+      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "ppc64le" ] && [ "$(uname -m)" != "s390x" ] && exit 0
       craftctl default
       set -ex
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -224,9 +224,9 @@ parts:
 
   criu:
     source: https://github.com/checkpoint-restore/criu
+    source-depth: 1
     source-tag: v3.19
     source-type: git
-    source-depth: 1
     plugin: nil
     build-packages:
       - asciidoc
@@ -271,8 +271,8 @@ parts:
       - raft
       - sqlite
     source: https://github.com/canonical/dqlite
-    source-type: git
     source-depth: 1
+    source-type: git
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=
@@ -290,9 +290,9 @@ parts:
     after:
       - nasm
     source: https://github.com/tianocore/edk2
-    source-type: git
-    source-tag: IRRELEVANT
     source-depth: 1
+    source-tag: IRRELEVANT
+    source-type: git
     plugin: nil
     build-packages:
       - g++
@@ -407,8 +407,8 @@ parts:
 
   libmnl:
     source: https://git.netfilter.org/libmnl
-    source-type: git
     source-tag: libmnl-1.0.5
+    source-type: git
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=
@@ -421,8 +421,8 @@ parts:
     after:
       - libmnl
     source: https://git.netfilter.org/libnftnl
-    source-type: git
     source-tag: libnftnl-1.2.6
+    source-type: git
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=
@@ -437,9 +437,9 @@ parts:
 
   libseccomp:
     source: https://github.com/seccomp/libseccomp
-    source-type: git
-    source-tag: v2.5.5
     source-depth: 1
+    source-tag: v2.5.5
+    source-type: git
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=
@@ -452,9 +452,9 @@ parts:
 
   libtpms:
     source: https://github.com/stefanberger/libtpms
-    source-type: git
-    source-tag: v0.9.6
     source-depth: 1
+    source-tag: v0.9.6
+    source-type: git
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=
@@ -467,9 +467,9 @@ parts:
 
   liburing:
     source: https://github.com/axboe/liburing
-    source-type: git
-    source-tag: liburing-2.5
     source-depth: 1
+    source-tag: liburing-2.5
+    source-type: git
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=
@@ -486,9 +486,9 @@ parts:
 
   libusb:
     source: https://github.com/libusb/libusb
-    source-type: git
-    source-tag: v1.0.26
     source-depth: 1
+    source-tag: v1.0.26
+    source-type: git
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=
@@ -543,9 +543,9 @@ parts:
 
   minio:
     source: https://github.com/minio/minio
-    source-type: git
-    source-tag: RELEASE.2023-11-20T22-40-07Z
     source-depth: 1
+    source-tag: RELEASE.2023-11-20T22-40-07Z
+    source-type: git
     plugin: nil
     build-snaps:
       - go
@@ -582,9 +582,9 @@ parts:
 
   nasm:
     source: https://github.com/netwide-assembler/nasm
-    source-type: git
-    source-tag: nasm-2.16.01
     source-depth: 1
+    source-tag: nasm-2.16.01
+    source-type: git
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=
@@ -605,8 +605,8 @@ parts:
       - libmnl
       - libnftnl
     source: https://git.netfilter.org/nftables
-    source-type: git
     source-tag: v1.0.9
+    source-type: git
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=
@@ -638,9 +638,9 @@ parts:
     after:
       - libseccomp
     source: https://github.com/NVIDIA/libnvidia-container
-    source-type: git
-    source-tag: v1.14.3
     source-depth: 1
+    source-tag: v1.14.3
+    source-type: git
     plugin: make
     build-packages:
       - bmake
@@ -684,9 +684,9 @@ parts:
 
   openvswitch:
     source: https://github.com/openvswitch/ovs
-    source-type: git
-    source-tag: v3.2.1
     source-depth: 1
+    source-tag: v3.2.1
+    source-type: git
     plugin: autotools
     autotools-configure-parameters:
       - --enable-ssl
@@ -708,9 +708,9 @@ parts:
     after:
       - openvswitch
     source: https://github.com/ovn-org/ovn
-    source-type: git
-    source-tag: v23.09.1
     source-depth: 1
+    source-tag: v23.09.1
+    source-type: git
     plugin: autotools
     autotools-configure-parameters:
       - --enable-ssl
@@ -722,9 +722,9 @@ parts:
 
   spice-protocol:
     source: https://gitlab.freedesktop.org/spice/spice-protocol
-    source-type: git
-    source-tag: v0.14.4
     source-depth: 1
+    source-tag: v0.14.4
+    source-type: git
     plugin: meson
     prime: []
     build-packages:
@@ -735,9 +735,9 @@ parts:
     after:
       - spice-protocol
     source: https://gitlab.freedesktop.org/spice/spice
-    source-type: git
-    source-tag: v0.15.2
     source-depth: 1
+    source-tag: v0.15.2
+    source-type: git
     plugin: meson
     meson-parameters:
       - --prefix=/
@@ -771,9 +771,9 @@ parts:
       - libseccomp
       - libtpms
     source: https://github.com/stefanberger/swtpm
-    source-type: git
-    source-tag: v0.8.1
     source-depth: 1
+    source-tag: v0.8.1
+    source-type: git
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=
@@ -807,9 +807,9 @@ parts:
       - spice-protocol
       - spice-server
     source: https://gitlab.com/qemu-project/qemu
-    source-type: git
-    source-tag: v8.1.3
     source-depth: 1
+    source-tag: v8.1.3
+    source-type: git
     plugin: autotools
     autotools-configure-parameters:
       - --disable-bochs
@@ -957,8 +957,8 @@ parts:
 
   raft:
     source: https://github.com/canonical/raft
-    source-type: git
     source-depth: 1
+    source-type: git
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=
@@ -976,9 +976,9 @@ parts:
 
   sqlite:
     source: https://github.com/sqlite/sqlite
-    source-type: git
     source-depth: 1
     source-tag: version-3.44.2
+    source-type: git
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=
@@ -990,9 +990,9 @@ parts:
 
   squashfs-tools-ng:
     source: https://github.com/AgentD/squashfs-tools-ng
-    source-type: git
-    source-tag: v1.2.0
     source-depth: 1
+    source-tag: v1.2.0
+    source-type: git
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=
@@ -1005,9 +1005,9 @@ parts:
 
   virtiofsd:
     source: https://gitlab.com/virtio-fs/virtiofsd
-    source-type: git
-    source-tag: v1.8.0
     source-depth: 1
+    source-tag: v1.8.0
+    source-type: git
     plugin: rust
     build-packages:
       - cargo
@@ -1076,9 +1076,9 @@ parts:
 
   zfs-0-8:
     source: https://github.com/openzfs/zfs
-    source-type: git
-    source-tag: zfs-0.8.6
     source-depth: 1
+    source-tag: zfs-0.8.6
+    source-type: git
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=/
@@ -1114,9 +1114,9 @@ parts:
 
   zfs-2-0:
     source: https://github.com/openzfs/zfs
-    source-type: git
-    source-tag: zfs-2.0.7
     source-depth: 1
+    source-tag: zfs-2.0.7
+    source-type: git
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=/
@@ -1152,9 +1152,9 @@ parts:
 
   zfs-2-1:
     source: https://github.com/openzfs/zfs
-    source-type: git
-    source-tag: zfs-2.1.14
     source-depth: 1
+    source-tag: zfs-2.1.14
+    source-type: git
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=/
@@ -1190,9 +1190,9 @@ parts:
 
   zfs-2-2:
     source: https://github.com/openzfs/zfs
-    source-type: git
-    source-tag: zfs-2.2.2
     source-depth: 1
+    source-tag: zfs-2.2.2
+    source-type: git
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=/


### PR DESCRIPTION
This was tested on amd64 only where the speedup is minimal as the effective parts list is the same.

For arches for which we don't build QEMU (like the slow riscv64), it should be more visible as the `nasm`, `spice-protocol` and `spice-server` parts are now skipped.

Note: while making the "architecture lists" for skipping parts, I noticed there are 2 lists the QEMU-enabled list and the CRIU-enabled one. The CRIU one is the same as the QEMU except for armhf. That's OK, just something that caught my eye.