### PR TITLE
snapcraft: stop priming nasm

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -582,8 +582,6 @@ parts:
       - --prefix=
     organize:
       usr/bin/: bin/
-    prime:
-      - bin/nasm
     override-pull: |-
       [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
       craftctl default

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1569,6 +1569,7 @@ parts:
       rm -rf "${CRAFT_PRIME}/lib/udev/"
       rm -rf "${CRAFT_PRIME}/usr/local/"
       rm -rf "${CRAFT_PRIME}/usr/share/"
+      rm -f "${CRAFT_PRIME}/bin/nasm"
 
       # Strip binaries (excluding shell scripts)
       find "${CRAFT_PRIME}"/bin -type f \


### PR DESCRIPTION
For reasons unclear to me, the nasm binary was still in the end snap despite not being primed anymore. I can only guess that since edk2 used it, snapcraft assumed it was needed somehow? Anyhow, it's not being removed during the `strip` part.