### PR TITLE
snapcraft: don't prime anything from the nasm part

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -582,6 +582,10 @@ parts:
       - --prefix=
     organize:
       usr/bin/: bin/
+    override-prime:
+      # no need to prime anything as the nasm binary is only used by edk2
+      # and is not needed in the final snap artifact
+      exit 0
     override-pull: |-
       [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
       craftctl default
@@ -1569,7 +1573,6 @@ parts:
       rm -rf "${CRAFT_PRIME}/lib/udev/"
       rm -rf "${CRAFT_PRIME}/usr/local/"
       rm -rf "${CRAFT_PRIME}/usr/share/"
-      rm -f "${CRAFT_PRIME}/bin/nasm"
 
       # Strip binaries (excluding shell scripts)
       find "${CRAFT_PRIME}"/bin -type f \


### PR DESCRIPTION
After tweaking the nasm part in #287, it had the unintended effect of priming all the binaries produced by that part minus nasm itself that was removed in the strip part.

Now the better fix is to simply override the priming step to not copy anything.

`x2` being from PR #287, and `x3` from this PR:

```
# ll /snap/lxd/x2/bin/n*asm
-rwxr-xr-x 1 root root 1452456 Jan 26 17:44 /snap/lxd/x2/bin/ndisasm*
# ll /snap/lxd/x3/bin/n*asm
ls: cannot access '/snap/lxd/x3/bin/n*asm': No such file or directory
```

We see that the disassembler binary is no longer shipped.

Note: the disasemble is still being compiled as not doing so would require a bit more plumbing in the override-build section.