### PR TITLE
snapcraft: Do not remove  the `.egg-info` folder as at least one is indirectly used by the `ceph` admin python tool

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1568,7 +1568,6 @@ parts:
       set -x
 
       # XXX: remove unneeded files/directories
-      find "${CRAFT_PRIME}/lib/python3/dist-packages/" -name "*.egg-info" -type d -exec rm -rf {} +
       rm -rf "${CRAFT_PRIME}/lib/systemd/"
       rm -rf "${CRAFT_PRIME}/lib/udev/"
       rm -rf "${CRAFT_PRIME}/usr/local/"


### PR DESCRIPTION
Removing the `.egg-info` folders in an attempt to strip down the snap size end up in indirect python issues while calling the `ceph` python utility that needs to resolve a python package metadata through `importlib.metadata` (justifying the need for the `.egg-info` folders)

```
root@ceph01:~# lxd init
Would you like to use LXD clustering? (yes/no) [default=no]: yes
What IP address or DNS name should be used to reach this server? [default=10.104.79.150]: 
Are you joining an existing cluster? (yes/no) [default=no]: 
What member name should be used to identify this server in the cluster? [default=ceph01]: 
Do you want to configure a new local storage pool? (yes/no) [default=yes]: 
Name of the storage backend to use (lvm, zfs, btrfs, dir) [default=zfs]: 
Create a new ZFS pool? (yes/no) [default=yes]: 
Would you like to use an existing empty block device (e.g. a disk or partition)? (yes/no) [default=no]: 
Size in GiB of the new loop device (1GiB minimum) [default=5GiB]: 
Do you want to configure a new remote storage pool? (yes/no) [default=no]: yes
Name of the storage backend to use (ceph, cephfs, cephobject) [default=ceph]: 
Create a new CEPH pool? (yes/no) [default=yes]: 
Name of the existing CEPH cluster [default=ceph]: 
Name of the OSD storage pool [default=lxd]: 
Number of placement groups [default=32]: 
Would you like to connect to a MAAS server? (yes/no) [default=no]: 
Would you like to configure LXD to use an existing bridge or host interface? (yes/no) [default=no]: 
Would you like to create a new Fan overlay network? (yes/no) [default=yes]: 
What subnet should be used as the Fan underlay? [default=auto]: 
Would you like stale cached images to be updated automatically? (yes/no) [default=yes]: 
Would you like a YAML "lxd init" preseed to be printed? (yes/no) [default=no]: 
Error: Failed to create storage pool "remote": Failed checking the existence of the ceph "lxd" osd pool while attempting to create it because of an internal error: Failed to run: ceph --name client.admin --cluster ceph osd pool get lxd size: exit status 1 (Traceback (most recent call last):
  File "/snap/lxd/26781/bin/ceph", line 162, in <module>
    from ceph_daemon import admin_socket, DaemonWatcher, Termsize
  File "/snap/lxd/current/lib/python3/dist-packages/ceph_daemon.py", line 21, in <module>
    from prettytable import PrettyTable, HEADER
  File "/snap/lxd/current/lib/python3/dist-packages/prettytable/__init__.py", line 52, in <module>
    __version__ = importlib_metadata.version(__name__)
  File "/usr/lib/python3.10/importlib/metadata/__init__.py", line 996, in version
    return distribution(distribution_name).version
  File "/usr/lib/python3.10/importlib/metadata/__init__.py", line 969, in distribution
    return Distribution.from_name(distribution_name)
  File "/usr/lib/python3.10/importlib/metadata/__init__.py", line 548, in from_name
    raise PackageNotFoundError(name)
importlib.metadata.PackageNotFoundError: No package metadata was found for prettytable)
```

___

This was not detected in the `latest-candidate` branch, because the `rm -rf "${CRAFT_PRIME}/lib/python3/dist-packages/*.egg-info/"` **does not** delete the `.egg-info` because this command is interpreted litteraly (the wildcard logic was not working in the first place) 

After a `lxd init` test with a microceph installation, this fix should avoid this issue.