### PR TITLE
snapcraft: do not remove the `.egg-info` folder (5.0-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1567,7 +1567,6 @@ parts:
       set -x
 
       # XXX: remove unneeded files/directories
-      rm -rf "${SNAPCRAFT_PRIME}/lib/python3/dist-packages/*.egg-info/"
       rm -rf "${SNAPCRAFT_PRIME}/usr/local/"
 
       # Strip some of the heavy bits


### PR DESCRIPTION
similar to https://github.com/canonical/lxd-pkg-snap/pull/294 but for the **5.0-edge** branch.