### PR TITLE
lxd: Cherry-pick upstream bugfixes (5.0-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1523,7 +1523,7 @@ parts:
     build-attributes: [core22-step-dependencies]
     source: snap-query/
     build-snaps:
-      - go
+      - go/1.21/stable
     plugin: nil
     override-build: |
       set -ex

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1398,6 +1398,12 @@ parts:
       git config user.email "noreply@lists.canonical.com"
       git config user.name "LXD snap builder"
 
+      git cherry-pick -x 827f1fce57898467b6b5d6eb909a5eb639e95c3c # lxd/storage/drivers/ceph: Restore the filesystems UUID on the volume
+      git cherry-pick -x 53e017a1db6a7f0667c55855b50220479f6fb827 # test/suites/storage: Add check for UUID generation on restore
+      git cherry-pick -x b737ae50e2590c7aa367254237f89ddc4d388ffb # lxd/storage/drivers/ceph: Restore the VM block filesystem volume too
+      git cherry-pick -x b61ffddda691d553eab3fbf23fb25ef2185ed6de # lxd/storage/drivers/lvm: Restore the VM block filesystem volume for thin-pools too
+      git cherry-pick -x 59cdc0a758b627083f729cd4b81dbb69035cb04d # lxd/storage/drivers/ceph: Double check the volumes content type
+
       # Setup build environment
       export GOPATH=$(realpath ./.go)
       export CGO_CFLAGS="-I${SNAPCRAFT_STAGE}/include/ -I${SNAPCRAFT_STAGE}/usr/local/include/"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -48,7 +48,7 @@ description: |-
    - openvswitch.external: Use the system's OVS tools (ignores openvswitch.builtin) [default=false]
    - ovn.builtin: Use snap-specific OVN configuration [default=false]
    - shiftfs.enable: Enable shiftfs support [default=auto]
-   - ui.enable: Enable the tech preview web interface [default=false]
+   - ui.enable: Enable the web interface [default=false]
 
  For system-wide configuration of the CLI, place your configuration in
  /var/snap/lxd/common/global-conf/ (config.yml and servercerts)


### PR DESCRIPTION
Lands fixes from:

 https://github.com/canonical/lxd/pull/12745
 https://github.com/canonical/lxd/pull/12777
 https://github.com/canonical/lxd/pull/12805 (partial)

And change description of `ui.enable` setting.

And pin go version fully.