### PR TITLE
snapcraft: Change description of ui.enable (latest-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -48,7 +48,7 @@ description: |-
    - openvswitch.builtin: Run a snap-specific OVS daemon [default=false]
    - openvswitch.external: Use the system's OVS tools (ignores openvswitch.builtin) [default=false]
    - ovn.builtin: Use snap-specific OVN configuration [default=false]
-   - ui.enable: Enable the experimental web interface [default=false]
+   - ui.enable: Enable the web interface [default=false]
 
  For system-wide configuration of the CLI, place your configuration in
  /var/snap/lxd/common/global-conf/ (config.yml and servercerts)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -545,7 +545,7 @@ parts:
     source-depth: 1
     plugin: nil
     build-snaps:
-      - go
+      - go/1.21/stable
     override-pull: |
       [ "$(uname -m)" = "riscv64" ] && exit 0
 
@@ -1356,7 +1356,7 @@ parts:
       - python3-dev
       - python3-venv
     build-snaps:
-      - go
+      - go/1.21/stable
     stage-packages:
       - acl
       - attr
@@ -1470,7 +1470,7 @@ parts:
       - lxd
       - sqlite
     build-snaps:
-      - go
+      - go/1.21/stable
     plugin: nil
     override-pull: |
       craftctl default
@@ -1529,7 +1529,7 @@ parts:
   snap-query:
     source: snap-query/
     build-snaps:
-      - go
+      - go/1.21/stable
     plugin: nil
     override-build: |
       set -ex


### PR DESCRIPTION
UI is no longer preview/experimental.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>
(cherry picked from commit 038295972cd10805e3142993b597397e2f00bb27)

And pin go version.