### PR TITLE
snapcraft: make it clear that lz4 lib isn't primed

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -978,6 +978,7 @@ parts:
     prime:
       - lib/libraft*so*
       - lib/*/libuv.so*
+      #- lib/*/liblz4.so*  # use liblz4.so from the base snap
 
   sqlite:
     source: https://github.com/sqlite/sqlite


### PR DESCRIPTION
snapcraft deduplication is not applied to files from packages listed in
stage-packages.  To avoid duplicating lz4's .so, make it explicit that we don't
want to prime it and instead relying on the one provided in the base snap.
