### PR TITLE
snapcraft: use libseccomp from the base snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -422,21 +422,6 @@ parts:
 
       sed -i "s# /lib/libmnl.la# ${CRAFT_STAGE}/lib/libmnl.la#g" "${CRAFT_PART_INSTALL}/lib/libnftnl.la"
 
-  libseccomp:
-    source: https://github.com/seccomp/libseccomp
-    source-depth: 1
-    source-tag: v2.5.5
-    source-type: git
-    plugin: autotools
-    autotools-configure-parameters:
-      - --prefix=
-    build-packages:
-      - gperf
-    organize:
-      usr/lib/: lib/
-    prime:
-      - lib/libseccomp*so*
-
   libtpms:
     source: https://github.com/stefanberger/libtpms
     source-depth: 1
@@ -626,8 +611,6 @@ parts:
       - lib/libnftables*so*
 
   nvidia-container:
-    after:
-      - libseccomp
     source: https://github.com/NVIDIA/libnvidia-container
     source-depth: 1
     source-tag: v1.14.3
@@ -637,6 +620,7 @@ parts:
       - bmake
       - curl
       - libelf-dev
+      - libseccomp-dev
       - lsb-release
     override-pull: |-
       [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
@@ -773,7 +757,6 @@ parts:
 
   swtpm:
     after:
-      - libseccomp
       - libtpms
     source: https://github.com/stefanberger/swtpm
     source-depth: 1
@@ -790,6 +773,7 @@ parts:
       - gawk
       - iproute2
       - libjson-glib-dev
+      - libseccomp-dev
       - python3-cryptography
       - python3-setuptools
       - socat
@@ -806,7 +790,6 @@ parts:
 
   qemu:
     after:
-      - libseccomp
       - liburing
       - libusb
       - spice-protocol
@@ -862,6 +845,7 @@ parts:
       - libnuma-dev
       - libpixman-1-dev
       - librbd-dev
+      - libseccomp-dev
       - libusbredirhost-dev
     stage-packages:
       - genisoimage
@@ -1220,8 +1204,6 @@ parts:
 
   # Core components
   lxc:
-    after:
-      - libseccomp
     source: https://github.com/lxc/lxc
     source-depth: 1
     source-type: git
@@ -1231,6 +1213,7 @@ parts:
       - libcap-dev
       - libdbus-1-dev
       - libgnutls28-dev
+      - libseccomp-dev
       - libselinux1-dev
       - pkg-config
       - meson
@@ -1496,7 +1479,6 @@ parts:
       - btrfs
       - ceph
       - dqlite
-      - libseccomp
       - logrotate
       - lvm
       - nano


### PR DESCRIPTION
In 2019, when commit cddfdfc76f4d46a0 was added, LXD used core (16) as base which probably came with a rather old libseccomp not adequate for modern kernels at that time (4.15+).  Now that we are on core22, we get 2.5.3 instead of pulling 2.5.5 from upstream. With core24, we will get 2.5.4 or maybe newer.

For some reason, virtiofsd used the libseccomp-dev package despite having a newer lib shipped in the snap.

With the intention of using QEMU from deb sources, using the same libseccomp version makes even more sense.