### PR TITLE
Newer Go (5.0-candidate)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
 
       - name: Test lxd-migrate build
         run: |

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
 
       - name: Trigger Launchpad snap build
         env:


### PR DESCRIPTION
Same as #304 but the `lxd-migrate` build action was already there in `5.0/candidate`.