### PR TITLE
Remove doc build artifacts

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1413,7 +1413,7 @@ parts:
         rm -rf doc/html/_sphinx_design_static/
         rm -rf doc/html/_sources/
 
-        # Copy the static website
+        # Stage the static website
         mkdir -p "${CRAFT_STAGE}/share/lxd-documentation"
         cp -a doc/html/. "${CRAFT_STAGE}/share/lxd-documentation/"
       fi

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1406,6 +1406,13 @@ parts:
         # Build the static website
         make doc
 
+        # Remove unneeded bits
+        rm doc/html/objects.inv    # only objects.inv.txt is used
+        # not needed once built
+        rm doc/html/.buildinfo
+        rm -rf doc/html/_sphinx_design_static/
+        rm -rf doc/html/_sources/
+
         # Copy the static website
         mkdir -p "${CRAFT_STAGE}/share/lxd-documentation"
         cp -a doc/html/. "${CRAFT_STAGE}/share/lxd-documentation/"


### PR DESCRIPTION
The files/dirs being removed:

```
$ du -sc /snap/lxd/current/share/lxd-documentation/{.buildinfo,objects.inv,_sphinx_design_static/,_sources/}
1	/snap/lxd/current/share/lxd-documentation/.buildinfo
18	/snap/lxd/current/share/lxd-documentation/objects.inv
49	/snap/lxd/current/share/lxd-documentation/_sphinx_design_static/
1162	/snap/lxd/current/share/lxd-documentation/_sources/
1229	total
```

Without the above, the UI and the builtin doc still worked fine.