### PR TITLE
Remove minio

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -525,36 +525,6 @@ parts:
       - lib/*/liblvm*
       - lib/*/libreadline.so*
 
-  minio:
-    source: https://github.com/minio/minio
-    source-depth: 1
-    source-tag: RELEASE.2023-11-20T22-40-07Z
-    source-type: git
-    plugin: nil
-    build-snaps:
-      - go
-    override-prime: |-
-      [ "$(uname -m)" = "riscv64" ] && exit 0
-      craftctl default
-    override-pull: |-
-      [ "$(uname -m)" = "riscv64" ] && exit 0
-      craftctl default
-    override-build: |-
-      [ "$(uname -m)" = "riscv64" ] && exit 0
-      set -ex
-
-      # Setup build environment
-      export GOPATH="$(realpath ./.go)"
-
-      # Build the binaries
-      make build
-
-      # Install minio command
-      mkdir -p "${CRAFT_PART_INSTALL}/bin/"
-      cp minio "${CRAFT_PART_INSTALL}/bin/minio"
-    prime:
-      - bin/minio*
-
   nano:
     plugin: nil
     stage-packages:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -49,6 +49,7 @@ description: |-
    - openvswitch.external: Use the system's OVS tools (ignores openvswitch.builtin) [default=false]
    - ovn.builtin: Use snap-specific OVN configuration [default=false]
    - ui.enable: Enable the web interface [default=true]
+   - minio.path: Path to the minio binary to use with LXD [default=""]
 
  For system-wide configuration of the CLI, place your configuration in
  /var/snap/lxd/common/global-conf/ (config.yml and servercerts)

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -606,6 +606,13 @@ if [ -x "${SNAP_COMMON}/lxd.debug" ]; then
     echo "==> WARNING: Using a custom debug LXD binary!"
 fi
 
+# Note: Snaps disallow running binaries from certain paths (for example paths under home directories).
+# These will show `permission denied` when trying to run the executable.
+if [ -n "${minio_path}" ] ; then
+  minio_dir="$(dirname "/var/lib/snapd/hostfs${minio_path}")"
+  export PATH="${PATH}:${minio_dir}"
+fi
+
 CMD="${LXD} --logfile ${SNAP_COMMON}/lxd/logs/lxd.log"
 
 if getent group "${daemon_group}" >/dev/null 2>&1; then

--- a/snapcraft/hooks/configure
+++ b/snapcraft/hooks/configure
@@ -56,6 +56,7 @@ openvswitch_builtin=$(get_bool "$(snapctl get openvswitch.builtin)")
 openvswitch_external=$(get_bool "$(snapctl get openvswitch.external)")
 ovn_builtin=$(get_bool "$(snapctl get ovn.builtin)")
 ui_enable=$(get_bool "$(snapctl get ui.enable)")
+minio_path="$(snapctl get minio.path)"
 
 # Special-handling of daemon.preseed
 daemon_preseed=$(snapctl get daemon.preseed)
@@ -85,6 +86,7 @@ config="${SNAP_COMMON}/config"
     echo "openvswitch_external=${openvswitch_external:-"false"}"
     echo "ovn_builtin=${ovn_builtin:-"false"}"
     echo "ui_enable=${ui_enable:-"true"}"
+    echo "minio_path=${minio_path:-}"
 } > "${config}"
 
 # Set socket ownership in case it changed


### PR DESCRIPTION
Removes `minio` so that it is no longer included with the LXD snap.

Introduces a `minio.path` snap config key which can be user specified to point to the locally installed `minio`. This will get included in `PATH` by the snap. One thing to note is that the snap won't work with just any path, for example the snap won't allow executing a binary from a path that includes a user's home directory.

---

~~Currently, LXD calls `minio` directly from `PATH`. I wanted to preserve this so that we don't need to have special cases depending on the method of installation of LXD (snap or otherwise).~~

~~I first tried to just symlink `/var/lib/snapd/hostfs/usr/bin/minio` to `/usr/bin/minio` in the snap, but this doesn't work because `/usr` is read-only. It's also limiting in case the user has `minio` in their `PATH` but not in `/usr/bin`.~~

~~So instead, I opted to iterate over `PATH` in the snap confinement, ignoring any snap-specific directories, and checking if an executable `minio` exists in the equivalent directory on the hostfs. If so, then it's symlinked to `/var/snap/lxd/common/bin` which is included in LXD's `PATH` now.~~

~~This means that if LXD is installed via the snap, `minio` will be accessible from any of the following paths, and symlinked to `/var/snap/lxd/common/bin`:~~
```
  /usr/local/sbin
  /usr/local/bin
  /usr/sbin
  /usr/bin
  /sbin
  /bin
  /usr/games
  /usr/local/games
```


~~One note is that I see `/run/bin` is already a custom directory included in `PATH` in the snap. I wasn't sure if I should re-use this directory or not, and instead opted to add a new directory at `/var/snap/lxd/common/bin` which is a bit more visible.~~