### PR TITLE
Allow apparmor exception for microovn

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -155,6 +155,22 @@ hooks:
     plugs:
       - lxd-support
       - system-observe
+  connect-plug-ovn-api:
+    plugs:
+      - lxd-support
+      - system-observe
+  disconnect-plug-ovn-api:
+    plugs:
+      - lxd-support
+      - system-observe
+  connect-plug-ovn-chassis:
+    plugs:
+      - lxd-support
+      - system-observe
+  disconnect-plug-ovn-chassis:
+    plugs:
+      - lxd-support
+      - system-observe
   configure:
     plugs:
       - lxd-support


### PR DESCRIPTION
#275 introduced connections to the microovn content interfaces, but I missed adding apparmor exceptions for the hooks.