### PR TITLE
prime missing libs for riscv64

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -193,6 +193,7 @@ parts:
       - lib/*/libcephfs*
       - lib/python3
 
+      - lib/*/libatomic.so*
       - lib/*/libboost_context.so*
       - lib/*/libboost_filesystem.so*
       - lib/*/libboost_iostreams.so*

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -198,6 +198,8 @@ parts:
       - lib/*/libboost_iostreams.so*
       - lib/*/libboost_program_options.so*
       - lib/*/libboost_thread.so*
+      - lib/*/libbrotlicommon.so*
+      - lib/*/libbrotlidec.so*
       - lib/*/libcurl-gnutls.so*
       - lib/*/libdaxctl.so*
       - lib/*/libibverbs.so*


### PR DESCRIPTION
https://launchpadlibrarian.net/713452201/buildlog_snap_ubuntu_jammy_riscv64_lxd-latest-edge_BUILDING.txt.gz contains those linter warnings:

```
Lint warnings:
- library: bin/pzstd: missing dependency 'libatomic.so.1'. (provided by 'libatomic1') (https://snapcraft.io/docs/linters-library)
- library: bin/radosgw-admin: missing dependency 'libatomic.so.1'. (provided by 'libatomic1') (https://snapcraft.io/docs/linters-library)
- library: bin/radosgw-admin: missing dependency 'libbrotlicommon.so.1'. (provided by 'libbrotli1') (https://snapcraft.io/docs/linters-library)
- library: bin/radosgw-admin: missing dependency 'libbrotlidec.so.1'. (provided by 'libbrotli1') (https://snapcraft.io/docs/linters-library)
- library: bin/rbd: missing dependency 'libatomic.so.1'. (provided by 'libatomic1') (https://snapcraft.io/docs/linters-library)
- library: lib/python3/dist-packages/rbd.cpython-310-riscv64-linux-gnu.so: missing dependency 'libatomic.so.1'. (provided by 'libatomic1') (https://snapcraft.io/docs/linters-library)
- library: lib/riscv64-linux-gnu/ceph/denc/denc-mod-osd.so: missing dependency 'libatomic.so.1'. (provided by 'libatomic1') (https://snapcraft.io/docs/linters-library)
- library: lib/riscv64-linux-gnu/ceph/denc/denc-mod-rgw.so: missing dependency 'libatomic.so.1'. (provided by 'libatomic1') (https://snapcraft.io/docs/linters-library)
- library: lib/riscv64-linux-gnu/ceph/denc/denc-mod-rgw.so: missing dependency 'libbrotlicommon.so.1'. (provided by 'libbrotli1') (https://snapcraft.io/docs/linters-library)
- library: lib/riscv64-linux-gnu/ceph/denc/denc-mod-rgw.so: missing dependency 'libbrotlidec.so.1'. (provided by 'libbrotli1') (https://snapcraft.io/docs/linters-library)
- library: lib/riscv64-linux-gnu/libcurl-gnutls.so.4.7.0: missing dependency 'libbrotlicommon.so.1'. (provided by 'libbrotli1') (https://snapcraft.io/docs/linters-library)
- library: lib/riscv64-linux-gnu/libcurl-gnutls.so.4.7.0: missing dependency 'libbrotlidec.so.1'. (provided by 'libbrotli1') (https://snapcraft.io/docs/linters-library)
- library: lib/riscv64-linux-gnu/librbd.so.1.17.0: missing dependency 'libatomic.so.1'. (provided by 'libatomic1') (https://snapcraft.io/docs/linters-library)
```

Contrary to the other linter warnings we always get (`unused library`), those `missing dependency` ones are a bigger worry because when the loader fails to load the missing .so, it aborts the execution.

Fortunately for us, it seems the population of LXD users on riscv64 using ceph (or `pzstd`) is rather minimal.