### PR TITLE
snapcraft/commands/daemon.start: use ethertypes and protocols files from base snap

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -231,14 +231,9 @@ for entry in hostid hostname hosts nsswitch.conf os-release passwd group localti
     ln -s "/var/lib/snapd/hostfs/etc/${entry}" "/etc/${entry}"
 done
 
-## And the bits we need from the core snap
-for entry in alternatives apparmor apparmor.d; do
+## And the bits we need from the base/core snap
+for entry in alternatives apparmor apparmor.d ethertypes protocols; do
     ln -s "/snap/${SNAP_BASE}/current/etc/${entry}" "/etc/${entry}"
-done
-
-## And those we directly ship in the snap
-for entry in ethertypes protocols; do
-    ln -s "${SNAP}/etc/${entry}" "/etc/${entry}"
 done
 
 ## Setup mtab


### PR DESCRIPTION
Since commit d5c604a1b8dd998f220, those files are no longer duplicated with the base snap so we need to stop creating symlinks to our copy that is no more.

This was noticed by `tests/network-bridge-firewal`:

```
 + lxc config device override c1 eth0 security.mac_filtering=true security.ipv4_filtering=true security.ipv6_filtering=true
=> Performing faked source IP ping tests with filtering
Error: Failed to update device "eth0": Failed to run: ebtables -t filter -A INPUT -p ARP -i vethe6ea1bab --arp-mac-src ! 00:16:3e:d1:59:2f -j DROP: exit status 255 (Problem with the specified Ethernet protocol 'ARP', perhaps /etc/ethertypes is missing.)
```

After inspection, those files were dangling symlinks to do the code that's now dropped by that PR.