### PR TITLE
Add libatomic part

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -210,7 +210,6 @@ parts:
       - lib/*/libcephfs*
       - lib/python3
 
-      - lib/*/libatomic.so*
       - lib/*/libboost_context.so*
       - lib/*/libboost_filesystem.so*
       - lib/*/libboost_iostreams.so*

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -196,6 +196,8 @@ parts:
       - bin/mkfs.btrfs
 
   ceph:
+    after:
+      - libatomic
     plugin: nil
     stage-packages:
       - ceph-common
@@ -415,6 +417,15 @@ parts:
       rm "${CRAFT_PART_INSTALL}/share/qemu/OVMF_VARS.4MB.debug.fd"
     prime:
       - share/qemu/*
+
+  libatomic:
+    plugin: nil
+    stage-packages:
+      - libatomic1
+    organize:
+      usr/lib/: lib/
+    prime:
+      - lib/*/libatomic.so*
 
   libmnl:
     source: https://git.netfilter.org/libmnl
@@ -799,6 +810,7 @@ parts:
 
   qemu:
     after:
+      - libatomic
       - liburing
       - libusb
       - spice-protocol
@@ -862,7 +874,6 @@ parts:
     stage-packages:
       - genisoimage
       - ipxe-qemu # This is needed due to --disable-install-blobs.
-      - libatomic1
       - libfdt1
       - libmagic1
       - libnuma1
@@ -1243,8 +1254,9 @@ parts:
       mv "${CRAFT_PART_INSTALL}.tmp/lib/"*so* "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/lib/"
       rm -Rf "${CRAFT_PART_INSTALL}.tmp"
 
-
   zstd:
+    after:
+      - libatomic
     plugin: nil
     stage-packages:
       - zstd


### PR DESCRIPTION
Suggested by @tompoline (https://github.com/canonical/lxd-pkg-snap/pull/317#issuecomment-1936040100) to make it easier to reason about this lib that multiple parts depend on, some of them ubiquitous (ceph and zstd) but others being only on some arches (QEMU).