### PR TITLE
snapcraft: add python-uefivars

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -602,6 +602,7 @@ parts:
     autotools-configure-parameters:
       - --prefix=
       - --with-json
+      - --disable-man-doc
     build-packages:
       - libedit-dev
       - libjansson-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1378,6 +1378,17 @@ parts:
 
       patch -p1 "${CRAFT_PART_INSTALL}/snap/lxd/current/lxcfs/lxc.mount.hook" < "${CRAFT_PROJECT_DIR}/patches/lxcfs-0001-hook.patch"
 
+  uefivars:
+    after:
+      - spice-server
+      - qemu-ovmf-secureboot
+      - nftables
+    source: https://github.com/awslabs/python-uefivars
+    source-depth: 1
+    source-tag: v1.0.0
+    source-type: git
+    plugin: python
+
   lxd:
     source: https://github.com/canonical/lxd
     source-depth: 1
@@ -1585,6 +1596,7 @@ parts:
         -not -path "${CRAFT_PRIME}/bin/snap-query" \
         -not -path "${CRAFT_PRIME}/bin/sshfs" \
         -not -path "${CRAFT_PRIME}/bin/xfs_admin" \
+        -not -path "${CRAFT_PRIME}/bin/uefivars.py" \
         -exec strip -s {} +
 
       # Strip binaries not under bin/ due to being dynamically


### PR DESCRIPTION
We need it for "lxc config uefi <...>" extension

There is some trickiness around this thing, because for some reason snapcraft is going crazy and everything that builds after "uefivars" starts to fail with some Python errors (failed to find package XYZ).

I have workarounded it by adding "after" specifier for uefivars part.