### PR TITLE
snapcraft: edk2: update to stable202311

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -319,7 +319,7 @@ parts:
       [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
       set -ex
       git config --global transfer.fsckobjects true
-      git clone https://github.com/tianocore/edk2 . -b edk2-stable202305
+      git clone https://github.com/tianocore/edk2 . -b edk2-stable202311
     override-build: |-
       [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
       set -ex


### PR DESCRIPTION
Have tested it with Ubuntu Bionic and it boots just fine. We still need to have all the custom workarounds for older kernels.