### PR TITLE
Apparmor unprivileged restrictions disable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,39 @@
+name: Tests
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    # Make sure bash is always invoked with `-eo pipefail`
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    shell: bash
+
+jobs:
+  code-tests:
+    name: Code
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - id: ShellCheck
+        name: Differential ShellCheck
+        uses: redhat-plumbers-in-action/differential-shellcheck@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+        if: github.event_name == 'pull_request'
+
+      - name: Upload artifact with ShellCheck defects in SARIF format
+        uses: actions/upload-artifact@v4
+        with:
+          name: Differential ShellCheck SARIF
+          path: ${{ steps.ShellCheck.outputs.sarif }}
+        if: github.event_name == 'pull_request'

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -45,11 +45,11 @@ description: |-
    - lxcfs.loadavg: Start tracking per-container load average [default=false]
    - lxcfs.cfs: Consider CPU shares for CPU usage [default=false]
    - lxcfs.debug: Increase logging to debug level [default=false]
+   - minio.path: Path to the minio binary to use with LXD [default=""]
    - openvswitch.builtin: Run a snap-specific OVS daemon [default=false]
    - openvswitch.external: Use the system's OVS tools (ignores openvswitch.builtin) [default=false]
    - ovn.builtin: Use snap-specific OVN configuration [default=false]
    - ui.enable: Enable the web interface [default=true]
-   - minio.path: Path to the minio binary to use with LXD [default=""]
 
  For system-wide configuration of the CLI, place your configuration in
  /var/snap/lxd/common/global-conf/ (config.yml and servercerts)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -31,6 +31,7 @@ description: |-
 
  Supported configuration options for the snap (snap set lxd [<key>=<value>...]):
 
+   - apparmor.unprivileged-restrictions-disable: Whether to disable restrictions on unprivileged user namespaces [default=true]
    - ceph.builtin: Use snap-specific Ceph configuration [default=false]
    - ceph.external: Use the system's ceph tools (ignores ceph.builtin) [default=false]
    - criu.enable: Enable experimental live-migration support [default=false]

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -420,6 +420,22 @@ if [ "$(stat -c '%u' /proc)" = 0 ]; then
             echo 1 > /proc/sys/kernel/unprivileged_userns_clone || true
         fi
     fi
+
+    if [ "${apparmor_unprivileged_restrictions_disable:-"true"}" = "true" ]; then
+        if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+            if [ "$(cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" = "1" ]; then
+                echo "==> Disabling Apparmor unprivileged userns mediation"
+                echo 0 > /proc/sys/kernel/apparmor_restrict_unprivileged_userns || true
+            fi
+        fi
+
+        if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_unconfined ]; then
+            if [ "$(cat /proc/sys/kernel/apparmor_restrict_unprivileged_unconfined)" = "1" ]; then
+                echo "==> Disabling Apparmor unprivileged unconfined mediation"
+                echo 0 > /proc/sys/kernel/apparmor_restrict_unprivileged_unconfined || true
+            fi
+        fi
+    fi
 fi
 
 # Setup CRIU

--- a/snapcraft/hooks/configure
+++ b/snapcraft/hooks/configure
@@ -39,6 +39,7 @@ if [ ! -e /run/snapd-snap.socket ]; then
 fi
 
 # Get the current config
+apparmor_unprivileged_restrictions_disable=$(get_bool "$(snapctl get apparmor.unprivileged-restrictions-disable)")
 ceph_builtin=$(get_bool "$(snapctl get ceph.builtin)")
 ceph_external=$(get_bool "$(snapctl get ceph.external)")
 criu_enable=$(get_bool "$(snapctl get criu.enable)")
@@ -69,6 +70,7 @@ config="${SNAP_COMMON}/config"
 
 cat << EOC > "${config}"
 # This file is auto-generated, do NOT manually edit
+apparmor_unprivileged_restrictions_disable=${apparmor_unprivileged_restrictions_disable:-"true"}
 ceph_builtin=${ceph_builtin:-"false"}
 ceph_external=${ceph_external:-"false"}
 criu_enable=${criu_enable:-"false"}

--- a/snapcraft/hooks/configure
+++ b/snapcraft/hooks/configure
@@ -67,27 +67,27 @@ fi
 # Generate the config
 config="${SNAP_COMMON}/config"
 
-{
-    echo "# This file is auto-generated, do NOT manually edit"
-    echo "ceph_builtin=${ceph_builtin:-"false"}"
-    echo "ceph_external=${ceph_external:-"false"}"
-    echo "criu_enable=${criu_enable:-"false"}"
-    echo "daemon_debug=${daemon_debug:-"false"}"
-    echo "daemon_group=${daemon_group:-"lxd"}"
-    echo "daemon_user_group=${daemon_user_group:-"lxd"}"
-    echo "daemon_syslog=${daemon_syslog:-"false"}"
-    echo "daemon_verbose=${daemon_verbose:-"false"}"
-    echo "lvm_external=${lvm_external:-"false"}"
-    echo "lxcfs_loadavg=${lxcfs_loadavg:-"false"}"
-    echo "lxcfs_pidfd=${lxcfs_pidfd:-"false"}"
-    echo "lxcfs_cfs=${lxcfs_cfs:-"false"}"
-    echo "lxcfs_debug=${lxcfs_debug:-"false"}"
-    echo "minio_path=${minio_path:-""}"
-    echo "openvswitch_builtin=${openvswitch_builtin:-"false"}"
-    echo "openvswitch_external=${openvswitch_external:-"false"}"
-    echo "ovn_builtin=${ovn_builtin:-"false"}"
-    echo "ui_enable=${ui_enable:-"true"}"
-} > "${config}"
+cat << EOC > "${config}"
+# This file is auto-generated, do NOT manually edit
+ceph_builtin=${ceph_builtin:-"false"}
+ceph_external=${ceph_external:-"false"}
+criu_enable=${criu_enable:-"false"}
+daemon_debug=${daemon_debug:-"false"}
+daemon_group=${daemon_group:-"lxd"}
+daemon_syslog=${daemon_syslog:-"false"}
+daemon_user_group=${daemon_user_group:-"lxd"}
+daemon_verbose=${daemon_verbose:-"false"}
+lvm_external=${lvm_external:-"false"}
+lxcfs_cfs=${lxcfs_cfs:-"false"}
+lxcfs_debug=${lxcfs_debug:-"false"}
+lxcfs_loadavg=${lxcfs_loadavg:-"false"}
+lxcfs_pidfd=${lxcfs_pidfd:-"false"}
+minio_path=${minio_path:-""}
+openvswitch_builtin=${openvswitch_builtin:-"false"}
+openvswitch_external=${openvswitch_external:-"false"}
+ovn_builtin=${ovn_builtin:-"false"}
+ui_enable=${ui_enable:-"true"}
+EOC
 
 # Set socket ownership in case it changed
 if getent group "${daemon_group}" >/dev/null 2>&1; then

--- a/snapcraft/hooks/configure
+++ b/snapcraft/hooks/configure
@@ -52,11 +52,11 @@ lxcfs_loadavg=$(get_bool "$(snapctl get lxcfs.loadavg)")
 lxcfs_pidfd=$(get_bool "$(snapctl get lxcfs.pidfd)")
 lxcfs_cfs=$(get_bool "$(snapctl get lxcfs.cfs)")
 lxcfs_debug=$(get_bool "$(snapctl get lxcfs.debug)")
+minio_path="$(snapctl get minio.path)"
 openvswitch_builtin=$(get_bool "$(snapctl get openvswitch.builtin)")
 openvswitch_external=$(get_bool "$(snapctl get openvswitch.external)")
 ovn_builtin=$(get_bool "$(snapctl get ovn.builtin)")
 ui_enable=$(get_bool "$(snapctl get ui.enable)")
-minio_path="$(snapctl get minio.path)"
 
 # Special-handling of daemon.preseed
 daemon_preseed=$(snapctl get daemon.preseed)
@@ -82,11 +82,11 @@ config="${SNAP_COMMON}/config"
     echo "lxcfs_pidfd=${lxcfs_pidfd:-"false"}"
     echo "lxcfs_cfs=${lxcfs_cfs:-"false"}"
     echo "lxcfs_debug=${lxcfs_debug:-"false"}"
+    echo "minio_path=${minio_path:-""}"
     echo "openvswitch_builtin=${openvswitch_builtin:-"false"}"
     echo "openvswitch_external=${openvswitch_external:-"false"}"
     echo "ovn_builtin=${ovn_builtin:-"false"}"
     echo "ui_enable=${ui_enable:-"true"}"
-    echo "minio_path=${minio_path:-""}"
 } > "${config}"
 
 # Set socket ownership in case it changed


### PR DESCRIPTION
At the distro level, Ubuntu 24.04 LTS should ship with additional restrictions preventing unconfined processes from creating userns by default.

The long term goal is for LXD to play nice with those additional restrictions but since a lots of moving parts are involved (kernel, kernel config, apparmor parser, core24 snap, snapd and LXD itself) and not fully ready yet, we decided on disabling those restrictions globally by default in the short term. This decision also took into consideration that LXD needs to work across many distros and versions (Debian w/ Apparmor, old Ubuntu version, old Ubuntu version with HWE kernel, etc).

This PR thus introduce a new `snap config` key (`apparmor.unprivileged-restrictions-disable`) that in its default value (`true`) causes LXD to set `kernel.apparmor_restrict_unprivileged_userns=0` and `kernel.apparmor_restrict_unprivileged_unconfined=0` thus disabling the new restrictions.

For additional information on those new restrictions, see https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces and https://discourse.ubuntu.com/t/spec-unprivileged-user-namespace-restrictions-via-apparmor-in-ubuntu-23-10/37626.

This PR reintroduced bits of #175.
