### PR TITLE
Expect directory for `minio.path`

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -51,6 +51,7 @@ description: |-
    - openvswitch.external: Use the system's OVS tools (ignores openvswitch.builtin) [default=false]
    - ovn.builtin: Use snap-specific OVN configuration [default=false]
    - ui.enable: Enable the web interface [default=true]
+   - minio.path: Path to the directory containing the minio and mc binaries to use with LXD [default=""]
 
  For system-wide configuration of the CLI, place your configuration in
  /var/snap/lxd/common/global-conf/ (config.yml and servercerts)

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -620,7 +620,7 @@ fi
 # Note: Snaps disallow running binaries from certain paths (for example paths under home directories).
 # These will show `permission denied` when trying to run the executable.
 if [ -n "${minio_path:-""}" ] ; then
-  minio_dir="$(dirname "/var/lib/snapd/hostfs${minio_path}")"
+  minio_dir="/var/lib/snapd/hostfs${minio_path}"
   export PATH="${PATH}:${minio_dir}"
 fi
 


### PR DESCRIPTION
Expects a directory containing `minio` and `mc` to be appended to the path, instead of parsing the containing directory from the literal path to the binary as before. 