### PR TITLE
dqlite: Bump to v1.16.2 (latest-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1383,9 +1383,10 @@ parts:
 
   lxd:
     source: https://github.com/canonical/lxd
-    source-depth: 1
-    source-type: git
+    # XXX: We often cherry-pick for candidate builds so don't do shallow clone
+    #source-depth: 1
     source-tag: lxd-5.20
+    source-type: git
     after:
       - lxc
       - dqlite

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -287,7 +287,7 @@ parts:
       - sqlite
     source: https://github.com/canonical/dqlite
     source-depth: 1
-    source-tag: v1.16.0
+    source-tag: v1.16.2
     source-type: git
     plugin: autotools
     autotools-configure-parameters:


### PR DESCRIPTION
Needed to work with SQLite versions greater than 3.45.0 