### PR TITLE
Bring known to be missing libs (5.0-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1339,7 +1339,7 @@ parts:
       - pigz
       - rsync
       - squashfs-tools
-      - usbutils
+      - usb.ids
       - xdelta3
     plugin: nil
     override-pull: |

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -178,39 +178,35 @@ parts:
       - bin/radosgw-admin
       - bin/rbd
       - lib/*/ceph
-      - lib/*/libasn1.so*
-      - lib/*/libatomic.so*
+      - lib/*/libcephfs*
+      - lib/python3
+
       - lib/*/libboost_context.so*
+      - lib/*/libboost_filesystem.so*
       - lib/*/libboost_iostreams.so*
       - lib/*/libboost_program_options.so*
       - lib/*/libboost_thread.so*
-      - lib/*/libbrotlicommon.so*
-      - lib/*/libbrotlidec.so*
-      - lib/*/libcephfs*
-      - lib/*/libcurl-gnutls*
-      - lib/*/libgssapi.so*
-      - lib/*/libhcrypto.so*
-      - lib/*/libheimbase.so*
-      - lib/*/libheimntlm.so*
-      - lib/*/libhx509.so*
+      - lib/*/libcurl-gnutls.so*
+      - lib/*/libdaxctl.so*
       - lib/*/libibverbs.so*
-      - lib/*/libkrb5.so*
-      - lib/*/liblber-2.4.so*
-      - lib/*/libldap_r-2.4.so*
+      - lib/*/libicudata.so*
+      - lib/*/libicuuc.so*
+      - lib/*/liblber-2.5.so*
+      - lib/*/libldap-2.5.so*
+      - lib/*/liblua5.3.so*
+      - lib/*/libndctl.so*
       - lib/*/libnghttp2.so*
+      - lib/*/liboath.so*
+      - lib/*/libpmemobj.so*
+      - lib/*/libpmem.so*
       - lib/*/libpsl.so*
       - lib/*/librabbitmq.so*
       - lib/*/librados.so*
       - lib/*/librbd.so*
       - lib/*/librdmacm.so*
-      - lib/*/libroken.so*
       - lib/*/librtmp.so*
       - lib/*/libsasl2.so*
       - lib/*/libsnappy.so*
-      - lib/*/libssh.so*
-      - lib/*/libwind.so*
-      - lib/liboath.so*
-      - lib/python3
 
   criu:
     source: https://github.com/checkpoint-restore/criu

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -946,6 +946,7 @@ parts:
       - bin/xfs_repair
       - bin/mkfs.xfs
       - lib/*/libinih.so*
+      - lib/*/liburcu.so*
 
   xtables:
     source: snapcraft/empty

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -936,6 +936,7 @@ parts:
     stage-packages:
       - xfsprogs
     organize:
+      usr/lib/: lib/
       usr/sbin/: bin/
       sbin/: bin/
     prime:
@@ -944,6 +945,7 @@ parts:
       - bin/xfs_growfs
       - bin/xfs_repair
       - bin/mkfs.xfs
+      - lib/*/libinih.so*
 
   xtables:
     source: snapcraft/empty


### PR DESCRIPTION
Addresses those linter warnings (https://launchpadlibrarian.net/714311607/buildlog_snap_ubuntu_jammy_amd64_lxd-5.0-edge_BUILDING.txt.gz):
```
Lint warnings:
- library: bin/mkfs.xfs: missing dependency 'libinih.so.1'. (https://snapcraft.io/docs/linters-library)
- library: bin/radosgw-admin: missing dependency 'libicudata.so.70'. (provided by 'libicu70') (https://snapcraft.io/docs/linters-library)
- library: bin/radosgw-admin: missing dependency 'libicuuc.so.70'. (provided by 'libicu70') (https://snapcraft.io/docs/linters-library)
- library: bin/radosgw-admin: missing dependency 'liblber-2.5.so.0'. (provided by 'libldap-2.5-0') (https://snapcraft.io/docs/linters-library)
- library: bin/radosgw-admin: missing dependency 'libldap-2.5.so.0'. (provided by 'libldap-2.5-0') (https://snapcraft.io/docs/linters-library)
- library: bin/radosgw-admin: missing dependency 'libboost_filesystem.so.1.74.0'. (https://snapcraft.io/docs/linters-library)
- library: bin/radosgw-admin: missing dependency 'liblua5.3.so.0'. (https://snapcraft.io/docs/linters-library)
- library: bin/radosgw-admin: missing dependency 'liboath.so.0'. (https://snapcraft.io/docs/linters-library)
- library: lib/x86_64-linux-gnu/ceph/denc/denc-mod-cephfs.so: missing dependency 'liblua5.3.so.0'. (https://snapcraft.io/docs/linters-library)
- library: lib/x86_64-linux-gnu/ceph/denc/denc-mod-osd.so: missing dependency 'libdaxctl.so.1'. (provided by 'libdaxctl1') (https://snapcraft.io/docs/linters-library)
- library: lib/x86_64-linux-gnu/ceph/denc/denc-mod-osd.so: missing dependency 'libndctl.so.6'. (provided by 'libndctl6') (https://snapcraft.io/docs/linters-library)
- library: lib/x86_64-linux-gnu/ceph/denc/denc-mod-osd.so: missing dependency 'libpmem.so.1'. (provided by 'libpmem1') (https://snapcraft.io/docs/linters-library)
- library: lib/x86_64-linux-gnu/ceph/denc/denc-mod-rgw.so: missing dependency 'libicudata.so.70'. (provided by 'libicu70') (https://snapcraft.io/docs/linters-library)
- library: lib/x86_64-linux-gnu/ceph/denc/denc-mod-rgw.so: missing dependency 'libicuuc.so.70'. (provided by 'libicu70') (https://snapcraft.io/docs/linters-library)
- library: lib/x86_64-linux-gnu/ceph/denc/denc-mod-rgw.so: missing dependency 'liblber-2.5.so.0'. (provided by 'libldap-2.5-0') (https://snapcraft.io/docs/linters-library)
- library: lib/x86_64-linux-gnu/ceph/denc/denc-mod-rgw.so: missing dependency 'libldap-2.5.so.0'. (provided by 'libldap-2.5-0') (https://snapcraft.io/docs/linters-library)
- library: lib/x86_64-linux-gnu/ceph/librbd/libceph_librbd_pwl_cache.so.1.0.0: missing dependency 'libdaxctl.so.1'. (provided by 'libdaxctl1') (https://snapcraft.io/docs/linters-library)
- library: lib/x86_64-linux-gnu/ceph/librbd/libceph_librbd_pwl_cache.so.1.0.0: missing dependency 'libndctl.so.6'. (provided by 'libndctl6') (https://snapcraft.io/docs/linters-library)
- library: lib/x86_64-linux-gnu/ceph/librbd/libceph_librbd_pwl_cache.so.1.0.0: missing dependency 'libpmem.so.1'. (provided by 'libpmem1') (https://snapcraft.io/docs/linters-library)
- library: lib/x86_64-linux-gnu/ceph/librbd/libceph_librbd_pwl_cache.so.1.0.0: missing dependency 'libpmemobj.so.1'. (provided by 'libpmemobj1') (https://snapcraft.io/docs/linters-library)
- library: lib/x86_64-linux-gnu/libcurl-gnutls.so.4.7.0: missing dependency 'liblber-2.5.so.0'. (provided by 'libldap-2.5-0') (https://snapcraft.io/docs/linters-library)
- library: lib/x86_64-linux-gnu/libcurl-gnutls.so.4.7.0: missing dependency 'libldap-2.5.so.0'. (provided by 'libldap-2.5-0') (https://snapcraft.io/docs/linters-library)
```