### PR TITLE
snapcraft: (re)prime usb.ids

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1410,7 +1410,7 @@ parts:
       - pci.ids
       - pigz
       - rsync
-      - usbutils
+      - usb.ids
       - xdelta3
     plugin: nil
     override-pull: |

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1490,6 +1490,7 @@ parts:
       - etc/bash_completion.d/snap.lxd.lxc
 
       - share/misc/pci.ids
+      - share/misc/usb.ids
 
       - bin/lxc
       - bin/lxc-to-lxd


### PR DESCRIPTION
In commit 3b35370d53489d8ede56490522, only the pci.ids was primed to be explicit in what we needed but that missed the fact that usb.ids which comes from another package (deps of lshw) was also needed.