### PR TITLE
snapcraft: add libSegFault.so to the prime step (5.0-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1296,6 +1296,8 @@ parts:
       - bin/fusermount3
       - lib/*/libfuse3.so.*
 
+      - lib/*/libSegFault.so
+
       - bin/lxcfs
       - lib/liblxcfs.so
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1278,6 +1278,7 @@ parts:
       - ninja-build
     stage-packages:
       - fuse3
+      - glibc-tools
     plugin: meson
     meson-parameters:
       - --prefix=/

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -547,7 +547,7 @@ else
         [ "${lxcfs_debug:-"false"}" = "true" ] && lxcfs_args="${lxcfs_args} -d"
 
         # Preload libSegFault.so to catch crashes
-        export LD_PRELOAD="${LD_PRELOAD:+${LD_PRELOAD}:}/lib/${ARCH}/libSegFault.so"
+        export LD_PRELOAD="${LD_PRELOAD:+${LD_PRELOAD}:}${SNAP_CURRENT}/lib/${ARCH}/libSegFault.so"
         export SEGFAULT_USE_ALTSTACK=1
         export SEGFAULT_SIGNALS="all"
 


### PR DESCRIPTION
My previous fix was insufficient, unfortunately.
Let's add libSegFault.so to the prime step and adjust path to it in LD_PRELOAD env variable.

Signed-off-by: Alexander Mikhalitsyn <aleksandr.mikhalitsyn@canonical.com>
(cherry picked from commit b64f7d760ff2a23713229dcbc23128e121535193)

This was spotted as being missing in https://pipelinesghubeus26.actions.githubusercontent.com/RaTUQgnrzMCyE9b8RNBMZagHyJLjwknfXr8Ulc7z4giu241RNO/_apis/pipelines/1/runs/426/signedlogcontent/36?urlExpires=2024-02-19T16%3A12%3A43.3488332Z&urlSigningMethod=HMACV1&urlSignature=YIez%2FRCzZ2siEs7r1EmBvf3XO70F5ynvsykek3MyZlI%3D:

```
2024-02-19T09:43:25.4978734Z Feb 19 09:42:11 lxd.daemon[3382]: => Starting LXCFS
2024-02-19T09:43:25.4980949Z Feb 19 09:42:11 lxd.daemon[3545]: ERROR: ld.so: object '/lib/x86_64-linux-gnu/libSegFault.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
2024-02-19T09:43:25.4983349Z Feb 19 09:42:11 lxd.daemon[3544]: ERROR: ld.so: object '/lib/x86_64-linux-gnu/libSegFault.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
2024-02-19T09:43:25.4984797Z Feb 19 09:42:11 lxd.daemon[3545]: Running constructor lxcfs_init to reload liblxcfs
```