### PR TITLE
Drop ZFS 2.0 (5.0-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1092,40 +1092,6 @@ parts:
       mv "${SNAPCRAFT_PART_INSTALL}.tmp/lib/"*so* "${SNAPCRAFT_PART_INSTALL}/zfs-0.8/lib/"
       rm -Rf "${SNAPCRAFT_PART_INSTALL}.tmp"
 
-  zfs-2-0:
-    source: https://github.com/openzfs/zfs
-    source-type: git
-    source-tag: zfs-2.0.7
-    source-depth: 1
-    plugin: autotools
-    autotools-configure-parameters:
-      - --prefix=/
-      - --with-config=user
-    build-packages:
-      - libblkid-dev
-      - libssl-dev
-      - uuid-dev
-      - zlib1g-dev
-    override-build: |
-      set -ex
-
-      [ "$(uname -m)" != "x86_64" ] && \
-        [ "$(uname -m)" != "aarch64" ] && \
-        [ "$(uname -m)" != "s390x" ] && \
-        [ "$(uname -m)" != "ppc64le" ] && exit 0
-
-      set +ex
-      snapcraftctl build
-      set -ex
-
-      mv "${SNAPCRAFT_PART_INSTALL}" "${SNAPCRAFT_PART_INSTALL}.tmp"
-      mkdir -p "${SNAPCRAFT_PART_INSTALL}/zfs-2.0/bin" "${SNAPCRAFT_PART_INSTALL}/zfs-2.0/lib"
-      mv "${SNAPCRAFT_PART_INSTALL}.tmp/sbin/zfs" "${SNAPCRAFT_PART_INSTALL}/zfs-2.0/bin/"
-      mv "${SNAPCRAFT_PART_INSTALL}.tmp/sbin/zpool" "${SNAPCRAFT_PART_INSTALL}/zfs-2.0/bin/"
-      mv "${SNAPCRAFT_PART_INSTALL}.tmp/lib/udev/zvol_id" "${SNAPCRAFT_PART_INSTALL}/zfs-2.0/bin/"
-      mv "${SNAPCRAFT_PART_INSTALL}.tmp/lib/"*so* "${SNAPCRAFT_PART_INSTALL}/zfs-2.0/lib/"
-      rm -Rf "${SNAPCRAFT_PART_INSTALL}.tmp"
-
   zfs-2-1:
     source: https://github.com/openzfs/zfs
     source-type: git
@@ -1520,7 +1486,6 @@ parts:
       - zfs-0-6
       - zfs-0-7
       - zfs-0-8
-      - zfs-2-0
       - zfs-2-1
       - zfs-2-2
       - zstd

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -344,10 +344,6 @@ elif echo "${VERSION}" | grep -q ^2\.1; then
     echo "==> Setting up ZFS (2.1)"
     export LD_LIBRARY_PATH="${SNAP_CURRENT}/zfs-2.1/lib/:${LD_LIBRARY_PATH}"
     export PATH="${SNAP_CURRENT}/zfs-2.1/bin:${PATH}"
-elif echo "${VERSION}" | grep -q ^2\.0; then
-    echo "==> Setting up ZFS (2.0)"
-    export LD_LIBRARY_PATH="${SNAP_CURRENT}/zfs-2.0/lib/:${LD_LIBRARY_PATH}"
-    export PATH="${SNAP_CURRENT}/zfs-2.0/bin:${PATH}"
 elif echo "${VERSION}" | grep -q ^0\.8; then
     echo "==> Setting up ZFS (0.8)"
     export LD_LIBRARY_PATH="${SNAP_CURRENT}/zfs-0.8/lib/:${LD_LIBRARY_PATH}"

--- a/snapcraft/commands/lxd-migrate
+++ b/snapcraft/commands/lxd-migrate
@@ -24,9 +24,6 @@ if echo "${VERSION}" | grep -q ^2\.2; then
 elif echo "${VERSION}" | grep -q ^2\.1; then
     export LD_LIBRARY_PATH="${SNAP_CURRENT}/zfs-2.1/lib/:${LD_LIBRARY_PATH}"
     export PATH="${SNAP_CURRENT}/zfs-2.1/bin:${PATH}"
-elif echo "${VERSION}" | grep -q ^2\.0; then
-    export LD_LIBRARY_PATH="${SNAP_CURRENT}/zfs-2.0/lib/:${LD_LIBRARY_PATH}"
-    export PATH="${SNAP_CURRENT}/zfs-2.0/bin:${PATH}"
 elif echo "${VERSION}" | grep -q ^0\.8; then
     export LD_LIBRARY_PATH="${SNAP_CURRENT}/zfs-0.8/lib/:${LD_LIBRARY_PATH}"
     export PATH="${SNAP_CURRENT}/zfs-0.8/bin:${PATH}"


### PR DESCRIPTION
ZFS 2.0 was needed back when Ubuntu 20.04 HWE kernel was based on 5.11/5.13
kernels. Those kernels were from Ubuntu 21.04 and 21.10 which are long EOL now.
Ubuntu 20.04 now only has 2 supported kernels 5.4 (GA) and 5.15 (HWE from
22.04). As such, drop ZFS 2.0 which isn't used by officially supported Ubuntu
kernels.

This aligns the snap with versions shipped in Ubuntu:

```
$ rmadison zfsutils-linux
 zfsutils-linux | 0.6.5.6-0ubuntu8       | xenial/universe | amd64, arm64, armhf, i386, powerpc, ppc64el, s390x
 zfsutils-linux | 0.6.5.6-0ubuntu30      | xenial-updates  | amd64, arm64, armhf, i386, powerpc, ppc64el, s390x
 zfsutils-linux | 0.7.5-1ubuntu15        | bionic          | amd64, arm64, armhf, i386, ppc64el, s390x
 zfsutils-linux | 0.7.5-1ubuntu16.12     | bionic-security | amd64, arm64, armhf, i386, ppc64el, s390x
 zfsutils-linux | 0.7.5-1ubuntu16.12     | bionic-updates  | amd64, arm64, armhf, i386, ppc64el, s390x
 zfsutils-linux | 0.8.3-1ubuntu12        | focal           | amd64, arm64, armhf, ppc64el, s390x
 zfsutils-linux | 0.8.3-1ubuntu12.16     | focal-security  | amd64, arm64, armhf, ppc64el, s390x
 zfsutils-linux | 0.8.3-1ubuntu12.16     | focal-updates   | amd64, arm64, armhf, ppc64el, s390x
 zfsutils-linux | 0.8.3-1ubuntu12.17     | focal-proposed  | amd64, arm64, armhf, ppc64el, s390x
 zfsutils-linux | 2.1.2-1ubuntu3         | jammy           | amd64, arm64, armhf, ppc64el, riscv64, s390x
 zfsutils-linux | 2.1.5-1ubuntu6~22.04.2 | jammy-security  | amd64, arm64, armhf, ppc64el, riscv64, s390x
 zfsutils-linux | 2.1.5-1ubuntu6~22.04.2 | jammy-updates   | amd64, arm64, armhf, ppc64el, riscv64, s390x
 zfsutils-linux | 2.1.5-1ubuntu6~22.04.3 | jammy-proposed  | amd64, arm64, armhf, ppc64el, riscv64, s390x
 zfsutils-linux | 2.2.0~rc3-0ubuntu4     | mantic          | amd64, arm64, armhf, ppc64el, riscv64, s390x
 zfsutils-linux | 2.2.0-0ubuntu1~23.10.2 | mantic-updates  | amd64, arm64, armhf, ppc64el, riscv64, s390x
 zfsutils-linux | 2.2.2-0ubuntu4         | noble           | amd64, arm64, armhf, ppc64el, riscv64, s390x
```