### PR TITLE
Use latest ZFS tooling if no exact match is found

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -351,7 +351,10 @@ if [ -d "${SNAP_CURRENT}/zfs-${ZFS_VER}/bin" ]; then
     export LD_LIBRARY_PATH="${SNAP_CURRENT}/zfs-${ZFS_VER}/lib/:${LD_LIBRARY_PATH}"
     export PATH="${SNAP_CURRENT}/zfs-${ZFS_VER}/bin:${PATH}"
 elif [ -n "${ZFS_VER}" ]; then
-    echo "==> Unsupported ZFS version (${ZFS_VER})"
+    NEWEST_ZFS_VER="$(cd "${SNAP_CURRENT}" && find -maxdepth 1 -type d -name 'zfs-*' | sort | tail -n1 | cut -d- -f2-)"
+    echo "==> Unsupported ZFS version (${ZFS_VER}), falling back to ${NEWEST_ZFS_VER}"
+    export LD_LIBRARY_PATH="${SNAP_CURRENT}/zfs-${NEWEST_ZFS_VER}/lib/:${LD_LIBRARY_PATH}"
+    export PATH="${SNAP_CURRENT}/zfs-${NEWEST_ZFS_VER}/bin:${PATH}"
 else
     echo "==> No ZFS support"
 fi

--- a/snapcraft/commands/daemon.stop
+++ b/snapcraft/commands/daemon.stop
@@ -74,7 +74,7 @@ fi
 
 # Shutdown the daemons
 ## LXD
-echo "=> Stopping LXD (with container shutdown)"
+echo "=> Stopping LXD (with instance shutdown)"
 
 echo host-shutdown > "${SNAP_COMMON}/state"
 if [ -n "${PID}" ] && kill -0 "${PID}" 2>/dev/null; then


### PR DESCRIPTION
This kind of logic would have avoided the rushed 5.0.2 respin to cope with Ubuntu 22.04 HWE kernel moving from 6.2.0 (ZFS 2.1) to 6.5.0 (ZFS 2.2).