### PR TITLE
snapcraft: prime only needed python bits for pyuefivars

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1318,6 +1318,12 @@ parts:
     source-tag: v1.0.0
     source-type: git
     plugin: python
+    organize:
+      lib/python3.10/site-packages/: lib/python3/dist-packages/
+    prime:
+      - bin/uefivars.py
+      - lib/python3/dist-packages/google_crc32c*
+      - lib/python3/dist-packages/pyuefivars*
 
   lxd:
     source: https://github.com/canonical/lxd

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1318,6 +1318,15 @@ parts:
     source-tag: v1.0.0
     source-type: git
     plugin: python
+    override-prime: |-
+      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
+      craftctl default
+    override-pull: |-
+      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
+      craftctl default
+    override-build: |-
+      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
+      craftctl default
     organize:
       lib/python3.10/site-packages/: lib/python3/dist-packages/
     prime:


### PR DESCRIPTION
It looks like the snapcraft python plugin does weird things as the uefivars part ended up bringing a lot of unneeded bits:

```
$ du -smc /snap/lxd/current/lib/python3.10/site-packages/*
1	/snap/lxd/current/lib/python3.10/site-packages/_distutils_hack
1	/snap/lxd/current/lib/python3.10/site-packages/distutils-precedence.pth
1	/snap/lxd/current/lib/python3.10/site-packages/google_crc32c
1	/snap/lxd/current/lib/python3.10/site-packages/google_crc32c-1.5.0.dist-info
1	/snap/lxd/current/lib/python3.10/site-packages/google_crc32c.libs
12	/snap/lxd/current/lib/python3.10/site-packages/pip
1	/snap/lxd/current/lib/python3.10/site-packages/pip-24.0.dist-info
2	/snap/lxd/current/lib/python3.10/site-packages/pkg_resources
1	/snap/lxd/current/lib/python3.10/site-packages/pyuefivars
1	/snap/lxd/current/lib/python3.10/site-packages/pyuefivars-0.1.dist-info
4	/snap/lxd/current/lib/python3.10/site-packages/setuptools
1	/snap/lxd/current/lib/python3.10/site-packages/setuptools-69.1.0.dist-info
1	/snap/lxd/current/lib/python3.10/site-packages/wheel
1	/snap/lxd/current/lib/python3.10/site-packages/wheel-0.42.0.dist-info
18	total
```

The other python bits we have are all under `lib/python3` so I did some mangling to put pyuefivars there as well. Since pip/setuptools and wheel packages are only needed to install/update packages, I dropped them as unneeded bits.

Lastly, this is amd64/arm64 specific so I added the usual set of `override-*`.

This was tested locally to not break `lxc config uefi`.