### PR TITLE
lxd: Cherry-pick upstream bugfixes (5.0-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1406,6 +1406,8 @@ parts:
       git cherry-pick -x fe71f2135bdc3aa6ea28de7ed1ac324f7d689ed6 # shared/simplestreams/products: Fix regression in parsing version files
       git cherry-pick -x d3253e4cbc85b97e3bc6dba9a27fd2ab0c4d8685 # shared/simplestreams/simplestreams: Improve error messages
       git cherry-pick -x 55bd4024dbfc315c0f57da57f2f9bd9c5c97dad1 # shared/simplestreams/products: Search only for lxd archives
+      git cherry-pick -x f1c377195a1febda39d6d99ecfbc647ffcd5d740 # lxd/rsync: Merge sendSetup and Send functions
+      git cherry-pick -x e1a37a5c240e068ffaff4fe20fa8af612e4143fe # lxd/rsync: Add description of cleanup function to RunWrappers
 
       # Setup build environment
       export GOPATH=$(realpath ./.go)


### PR DESCRIPTION
Fixes from https://github.com/canonical/lxd/pull/12949