### PR TITLE
Stop bundling `nano` in the snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -550,16 +550,6 @@ parts:
       - lib/*/liblvm*
       - lib/*/libreadline.so*
 
-  nano:
-    plugin: nil
-    stage-packages:
-      - nano
-    organize:
-      usr/bin/: bin/
-    prime:
-      - bin/nano
-      - etc/nanorc
-
   nasm:
     source: https://github.com/netwide-assembler/nasm
     source-depth: 1
@@ -1465,7 +1455,6 @@ parts:
       - dqlite
       - logrotate
       - lvm
-      - nano
       - nvidia-container
       - openvswitch
       - ovn

--- a/snapcraft/wrappers/editor
+++ b/snapcraft/wrappers/editor
@@ -38,6 +38,11 @@ if [ -z "${EDIT_PATH}" ] || [ "$#" -ge "3" ]; then
     done
 fi
 
+# Default to trying nano if no editor is provided
+if [ -z "${EDIT_CMD}" ]; then
+    EDIT_CMD="nano"
+fi
+
 # Try running the editor through the host.
 if [ -n "${EDIT_CMD}" ] && [ "${USERNS}" = 1 ]; then
     exec 9< /tmp/
@@ -46,32 +51,19 @@ if [ -n "${EDIT_CMD}" ] && [ "${USERNS}" = 1 ]; then
     find_and_spawn "${EDIT_CMD}" "${EDIT_PATH_HOST}"
 fi
 
-# If the editor's rcfile is not readable, ignore it.
+# Fallback to using vim.tiny from base snap
+
+# Search for a vimrc
+for vimrc in "${SNAP_USER_COMMON}/.vimrc" "/snap/${SNAP_BASE}/current/etc/vim/vimrc"; do
+    [ -r "${vimrc}" ] || continue
+    export VIMINIT="source ${vimrc}"
+done
+
+# Ignore vimrc if none was found to be readable.
 EDIT_IGNORE_RC=""
-EDIT_RESTRICT=""
-# Default to built-in nano.
-if [ -z "${EDIT_CMD}" ] || [ "$EDIT_CMD" = "nano" ]; then
-    EDIT_CMD="nano"
-    EDIT_RESTRICT="--restricted"
-    [ -r "${SNAP}/etc/nanorc" ] || EDIT_IGNORE_RC="--ignorercfiles"
-fi
-
-# Setup for VIM.
-if [ "$EDIT_CMD" != "nano" ]; then
-    # Find the base use by the LXD snap.
-    for vimrc in "${SNAP_USER_COMMON}/.vimrc" "/snap/${SNAP_BASE}/current/etc/vim/vimrc"; do
-        [ -r "${vimrc}" ] || continue
-        export VIMINIT="source ${vimrc}"
-    done
-
-    # Ignore vimrc if none was found to be readable.
-    if [ -z "${VIMINIT:-""}" ]; then
-        EDIT_IGNORE_RC="--clean"
-    fi
-
-    EDIT_CMD="vim.tiny"
-    EDIT_RESTRICT="-Z"
+if [ -z "${VIMINIT:-""}" ]; then
+    EDIT_IGNORE_RC="--clean"
 fi
 
 # Run the editor.
-exec "${EDIT_CMD}" ${EDIT_RESTRICT} ${EDIT_IGNORE_RC} "${EDIT_PATH}"
+exec vim.tiny -Z ${EDIT_IGNORE_RC} "${EDIT_PATH}"


### PR DESCRIPTION
`nano` is described as a user friendly editor and has historically been the default config editor for LXD, with `vim.tiny` being the fallback if the user provided `EDITOR` variable didn't point to a working editor.

This PR proposes to stop bundling `nano` in the snap and instead try to use `nano` from the host's system, unless the user provided a different `EDITOR` already. Like before, `vim.tiny` from the base/core snap is kept as the fallback editor.

Since `nano` is installed by default on Ubuntu Server and Desktop (22.04 and 24.04 were checked), there should be no behaviour change on a default install. The only cases I could think that would be seeing a change from `nano` to `vim.tiny`:

1. On Ubuntu, if a user decided to remove `nano` from the default install
1. On a Ubuntu **minimal** variant where no editor whatsoever is provided (not even `ed`)
1. On a non-Ubuntu system where `nano` is not installed