### PR TITLE
snapcraft: bump to zfs 2.2.3 (compat with kernel 6.7 & 6.8)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1128,7 +1128,7 @@ parts:
   zfs-2-2:
     source: https://github.com/openzfs/zfs
     source-depth: 1
-    source-tag: zfs-2.2.2
+    source-tag: zfs-2.2.3
     source-type: git
     plugin: autotools
     autotools-configure-parameters:


### PR DESCRIPTION
I'm proposing this one out of cycle because Ubuntu 24.04 is now shipping kernel 6.8.