### PR TITLE
lxd: Change to previous tag format lxd-5.21.0 (5.21-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1304,7 +1304,7 @@ parts:
     source: https://github.com/canonical/lxd
     # XXX: We often cherry-pick for candidate builds so don't do shallow clone
     #source-depth: 1
-    source-tag: v5.21.0
+    source-tag: lxd-5.21.0
     source-type: git
     after:
       - lxc


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>
(cherry picked from commit 92c31e4f2ac50461c95bf9046b4af44e6f8d829d)