### PR TITLE
snapcraft/hooks/remove: also unmount /var/snap/lxd/shmounts

### DIFF
--- a/snapcraft/hooks/remove
+++ b/snapcraft/hooks/remove
@@ -10,7 +10,7 @@ if [ -d /sys/kernel/security/apparmor ]; then
 fi
 
 # Unmount potential LXD paths.
-for path in "${SNAP_COMMON}/ns/shmounts" "${SNAP_COMMON}/ns/mntns" "${SNAP_COMMON}/ns" "${SNAP_COMMON}/var/lib/lxcfs/"; do
+for path in "${SNAP_COMMON}/ns/shmounts" "${SNAP_COMMON}/ns/mntns" "${SNAP_COMMON}/ns" "${SNAP_COMMON}/var/lib/lxcfs/" "${SNAP_COMMON}/shmounts"; do
     nsenter -t 1 -m umount -l "${path}" >/dev/null 2>&1 || true
 done
 


### PR DESCRIPTION
It may happen that the shmounts setup failed for whatever reason, in which case the fallback path mounts a tmpfs at /var/snap/lxd/shmounts (https://github.com/canonical/lxd-pkg-snap/blob/aa12cd4131eb38cb5d66fac891d0dcf2017af619/snapcraft/commands/daemon.start#L111-L114).

Make sure to clean it up during remove if needed.

Works around problem in https://github.com/canonical/lxd/issues/13158