### PR TITLE
Rename microovn content interface

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -65,7 +65,7 @@ plugs:
  ceph-conf:
    interface: content
    target: "$SNAP_DATA/microceph"
- ovn-api:
+ ovn-certificates:
    interface: content
    target: "$SNAP_DATA/microovn/certificates"
  ovn-chassis:


### PR DESCRIPTION
The microovn content interface for certificates is called `ovn-certificates` now, instead of the initially proposed `ovn-api`, which was chosen when it contained more than just certificates.