### PR TITLE
snapcraft/commands/daemon.start: bump fs.inotify.max_user_watches (5.0-edge)

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -406,6 +406,13 @@ if [ "$(stat -c '%u' /proc)" = 0 ]; then
         fi
     fi
 
+    if [ -e /proc/sys/fs/inotify/max_user_watches ]; then
+        if [ "$(cat /proc/sys/fs/inotify/max_user_watches)" -lt "1048576" ]; then
+            echo "==> Increasing the number of inotify user watches"
+            echo 1048576 > /proc/sys/fs/inotify/max_user_watches || true
+        fi
+    fi
+
     if [ -e /proc/sys/kernel/keys/maxkeys ]; then
         if [ "$(cat /proc/sys/kernel/keys/maxkeys)" -lt "2000" ]; then
             echo "==> Increasing the number of keys for a nonroot user"


### PR DESCRIPTION
https://documentation.ubuntu.com/lxd/en/latest/reference/server_settings/#etc-sysctl-conf recommends setting `fs.inotify.max_user_watches` to `10485761` for production setup. Since we already set `fs.inotify.max_user_instances` to `1024` it means we expect a given host to at least accomodate for that many containers. However, launching ~85 containers apparently pushed LXD into consuming all the user watches:

```
$ for i in $(seq 100); do lxc launch ... ; done
$ sudo systemctl reload snap.lxd.daemon
Failed to allocate directory watch: Too many open files
```

Signed-off-by: Simon Deziel <simon.deziel@canonical.com>
(cherry picked from commit 8db7324a9fbf2774f1b69469f206975e08eabfde)