### PR TITLE
lxd: Bump to 5.21.1 (5.21-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,7 +2,7 @@ name: lxd
 base: core22
 assumes:
   - snapd2.39
-version: "5.21.0"
+version: "5.21.1"
 grade: stable
 summary: LXD - container and VM manager
 license: AGPL-3.0


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>
(cherry picked from commit a37083b04422311c1db71747b18181965a667dde)