### PR TITLE
lxd-ui: Bump to 0.8 (5.21-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1425,7 +1425,7 @@ parts:
     source: https://github.com/canonical/lxd-ui
     source-depth: 1
     source-type: git
-    source-tag: 0.7
+    source-tag: 0.8
     plugin: nil
     override-prime: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>
(cherry picked from commit 47567e15cc76bced0d0de3298646856b55bb5a4e)