### PR TITLE
snapcraft: add `zfs.external` config key

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -51,6 +51,7 @@ description: |-
    - openvswitch.external: Use the system's OVS tools (ignores openvswitch.builtin) [default=false]
    - ovn.builtin: Use snap-specific OVN configuration [default=false]
    - ui.enable: Enable the web interface [default=true]
+   - zfs.external: Use the system's ZFS tools [default=false]
 
  For system-wide configuration of the CLI, place your configuration in
  /var/snap/lxd/common/global-conf/ (config.yml and servercerts)

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -204,6 +204,12 @@ if [ "${lvm_external:-"false"}" = "true" ]; then
     ln -s "${SNAP}/wrappers/run-host" "/run/bin/lvresize"
 fi
 
+if [ "${zfs_external:-"false"}" = "true" ]; then
+    ln -s "${SNAP}/wrappers/run-host" "/run/bin/zfs"
+    ln -s "${SNAP}/wrappers/run-host" "/run/bin/zpool"
+    ln -s "${SNAP}/wrappers/run-host" "/run/bin/zvol_id"
+fi
+
 # Detect presence of sideloaded lxd-agent executable.
 if [ -x "${SNAP_COMMON}/lxd-agent.debug" ]; then
     echo "==> WARNING: Using a custom debug lxd-agent binary!"
@@ -370,22 +376,28 @@ echo "==> Rotating logs"
 logrotate -f "${SNAP}/etc/logrotate.conf" -s "/etc/logrotate.status" || true
 
 # Setup for ZFS
-if [ -e /sys/module/zfs/version ]; then
-    read -r VERSION < /sys/module/zfs/version
-else
-    VERSION=$(nsenter -t 1 -m modinfo -F version zfs 2>/dev/null || true)
-fi
+if [ "${zfs_external:-"false"}" = "false" ]; then
+    if [ -e /sys/module/zfs/version ]; then
+        read -r VERSION < /sys/module/zfs/version
+    else
+        VERSION=$(nsenter -t 1 -m modinfo -F version zfs 2>/dev/null || true)
+    fi
 
-ZFS_VER="$(echo "${VERSION}" | cut -c 1-3)"
+    ZFS_VER="$(echo "${VERSION}" | cut -c 1-3)"
 
-if [ -d "${SNAP_CURRENT}/zfs-${ZFS_VER}/bin" ]; then
-    echo "==> Setting up ZFS (${ZFS_VER})"
-    export LD_LIBRARY_PATH="${SNAP_CURRENT}/zfs-${ZFS_VER}/lib/:${LD_LIBRARY_PATH}"
-    export PATH="${SNAP_CURRENT}/zfs-${ZFS_VER}/bin:${PATH}"
-elif [ -n "${ZFS_VER}" ]; then
-    echo "==> Unsupported ZFS version (${ZFS_VER})"
+    if [ -d "${SNAP_CURRENT}/zfs-${ZFS_VER}/bin" ]; then
+        echo "==> Setting up ZFS (${ZFS_VER})"
+        export LD_LIBRARY_PATH="${SNAP_CURRENT}/zfs-${ZFS_VER}/lib/:${LD_LIBRARY_PATH}"
+        export PATH="${SNAP_CURRENT}/zfs-${ZFS_VER}/bin:${PATH}"
+    elif [ -n "${ZFS_VER}" ]; then
+        echo "==> Unsupported ZFS version (${ZFS_VER})"
+        echo "Consider installing ZFS tools in the host and use zfs.external"
+    else
+        echo "==> No ZFS support"
+        echo "Consider installing ZFS tools in the host and use zfs.external"
+    fi
 else
-    echo "==> No ZFS support"
+    echo "==> Using ZFS tools from the host system"
 fi
 
 # Escape resource limits

--- a/snapcraft/hooks/configure
+++ b/snapcraft/hooks/configure
@@ -58,6 +58,7 @@ openvswitch_builtin=$(get_bool "$(snapctl get openvswitch.builtin)")
 openvswitch_external=$(get_bool "$(snapctl get openvswitch.external)")
 ovn_builtin=$(get_bool "$(snapctl get ovn.builtin)")
 ui_enable=$(get_bool "$(snapctl get ui.enable)")
+zfs_external=$(get_bool "$(snapctl get zfs.external)")
 
 # Special-handling of daemon.preseed
 daemon_preseed=$(snapctl get daemon.preseed)
@@ -89,6 +90,7 @@ openvswitch_builtin=${openvswitch_builtin:-"false"}
 openvswitch_external=${openvswitch_external:-"false"}
 ovn_builtin=${ovn_builtin:-"false"}
 ui_enable=${ui_enable:-"true"}
+zfs_external=${zfs_external:-"false"}
 EOC
 
 # Set socket ownership in case it changed


### PR DESCRIPTION
```
root@u1:~# modinfo zfs | grep ^version:
version:        0.8.3-1ubuntu12.14
root@u1:~# uname -a
Linux u1 5.4.0-150-generic #167~18.04.1-Ubuntu SMP Wed May 24 00:51:42 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
root@u1:~# modinfo zfs | grep ^version:
version:        0.8.3-1ubuntu12.14
root@u1:~# snap get lxd zfs.external
true
root@u1:~# lxc storage ls
+---------+--------+--------------------------------------------+-------------+---------+---------+
|  NAME   | DRIVER |                   SOURCE                   | DESCRIPTION | USED BY |  STATE  |
+---------+--------+--------------------------------------------+-------------+---------+---------+
| default | zfs    | /var/snap/lxd/common/lxd/disks/default.img |             | 3       | CREATED |
+---------+--------+--------------------------------------------+-------------+---------+---------+
root@u1:~# lxc storage info default
info:
  description: ""
  driver: zfs
  name: default
  space used: 6.46MiB
  total space: 831.93MiB
used by:
  images:
  - 6c8cffcd31b9f5cba79b59f19e485ffcd295e463db9207fdd8ea0a2866c5a6de
  instances:
  - a1
  profiles:
  - default
```