### PR TITLE
snapcraft/hooks: Use mkdir -p for ovn interface (5.21-candidate)

### DIFF
--- a/snapcraft/hooks/connect-plug-ovn-certificates
+++ b/snapcraft/hooks/connect-plug-ovn-certificates
@@ -42,7 +42,7 @@ if [ -e "/etc/.lxd_generated" ]; then
   fi
 
   if ! [ "${ovn_builtin:-"false"}" = "true" ]; then
-    mkdir /etc/ovn
+    mkdir -p /etc/ovn
     ln -snf "${SNAP_DATA}/microovn/certificates/pki/client-cert.pem" /etc/ovn/cert_host
     ln -snf "${SNAP_DATA}/microovn/certificates/pki/client-privkey.pem" /etc/ovn/key_host
     ln -snf "${SNAP_DATA}/microovn/certificates/pki/cacert.pem" /etc/ovn/ovn-central.crt


### PR DESCRIPTION
The same hooks can run concurrently many times, so use `mkdir -p` to succeed if the path exists

Signed-off-by: Max Asnaashari <max.asnaashari@canonical.com>
(cherry picked from commit f650f1ce0bae5902441d94d76bfb6638677eab4a)