### PR TITLE
snapcraft/commands/daemon.start: consistently use `mkdir -p /etc/ovn`

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -327,13 +327,13 @@ if [ "${ovn_builtin:-"false"}" = "true" ]; then
     ln -s "${SNAP_COMMON}/ovn" /etc/ovn
 elif [ -d "${SNAP_DATA}/microovn/certificates/pki" ]; then
     echo "=> Detected MicroOVN Content Interface"
-    mkdir /etc/ovn
+    mkdir -p /etc/ovn
     ln -s "${SNAP_DATA}/microovn/certificates/pki/client-cert.pem" /etc/ovn/cert_host
     ln -s "${SNAP_DATA}/microovn/certificates/pki/client-privkey.pem" /etc/ovn/key_host
     ln -s "${SNAP_DATA}/microovn/certificates/pki/cacert.pem" /etc/ovn/ovn-central.crt
 elif [ -d /var/snap/microovn/ ]; then
     echo "=> Detected MicroOVN"
-    mkdir /etc/ovn
+    mkdir -p /etc/ovn
     ln -s /var/snap/microovn/common/data/pki/client-cert.pem /etc/ovn/cert_host
     ln -s /var/snap/microovn/common/data/pki/client-privkey.pem /etc/ovn/key_host
     ln -s /var/snap/microovn/common/data/pki/cacert.pem /etc/ovn/ovn-central.crt


### PR DESCRIPTION
MicroCloud tests often fail with:

```
 + lxc exec micro02 -- snap install microceph microovn
2024-04-18T02:29:04Z INFO Waiting for conflicting change in progress: conflicting slot snap snapd, task "connect"
error: cannot perform the following tasks:
- Run hook connect-plug-ovn-certificates of snap "lxd" (run hook "connect-plug-ovn-certificates": mkdir: cannot create directory ‘/etc/ovn’: File exists)
```

While the error presumably comes from the hook "connect-plug-ovn-certificates", that hook uses `mkdir -p` since f650f1ce0bae590244. The only other place where that dir is created by LXD is in `daemon.start` where for some reason, `-p` was not used contrary to most other dir creations elsewhere in that script.