### PR TITLE
Rework user/group creation to ensure `lxd`'s primary group is `lxd`

### DIFF
--- a/snapcraft/commands/daemon.activate
+++ b/snapcraft/commands/daemon.activate
@@ -59,16 +59,6 @@ if echo "${SNAP_MODEL}" | grep -q "^lxd-core"; then
     exit 0
 fi
 
-# Setup the "lxd" user
-if ! getent passwd lxd >/dev/null 2>&1; then
-    echo "==> Creating \"lxd\" user"
-    if grep -q "^passwd.*extrausers" /var/lib/snapd/hostfs/etc/nsswitch.conf; then
-        nsenter -t 1 -m useradd --system -M -N --home "${SNAP_COMMON}/lxd" --shell /bin/false --extrausers lxd || true
-    else
-        nsenter -t 1 -m useradd --system -M -N --home "${SNAP_COMMON}/lxd" --shell /bin/false lxd || true
-    fi
-fi
-
 # Setup the "lxd" group
 if [ "${daemon_group}" = "lxd" ] && ! getent group lxd >/dev/null 2>&1; then
     echo "==> Creating \"lxd\" group"
@@ -76,6 +66,16 @@ if [ "${daemon_group}" = "lxd" ] && ! getent group lxd >/dev/null 2>&1; then
         nsenter -t 1 -m groupadd --system --extrausers lxd || true
     else
         nsenter -t 1 -m groupadd --system lxd || true
+    fi
+fi
+
+# Setup the "lxd" user
+if ! getent passwd lxd >/dev/null 2>&1; then
+    echo "==> Creating \"lxd\" user"
+    if grep -q "^passwd.*extrausers" /var/lib/snapd/hostfs/etc/nsswitch.conf; then
+        nsenter -t 1 -m useradd --system -M -N --home "${SNAP_COMMON}/lxd" --shell /bin/false --gid lxd --extrausers lxd || true
+    else
+        nsenter -t 1 -m useradd --system -M -N --home "${SNAP_COMMON}/lxd" --shell /bin/false --gid lxd lxd || true
     fi
 fi
 

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -274,16 +274,6 @@ for entry in dev proc sys; do
     mount -o bind "/${entry}" "/var/lib/snapd/hostfs/${entry}"
 done
 
-# Setup the "lxd" user
-if ! getent passwd lxd >/dev/null 2>&1; then
-    echo "==> Creating \"lxd\" user"
-    if grep -q "^passwd.*extrausers" /var/lib/snapd/hostfs/etc/nsswitch.conf; then
-        nsenter -t 1 -m useradd --system -M -N --home "${SNAP_COMMON}/lxd" --shell /bin/false --extrausers lxd || true
-    else
-        nsenter -t 1 -m useradd --system -M -N --home "${SNAP_COMMON}/lxd" --shell /bin/false lxd || true
-    fi
-fi
-
 # Setup the "lxd" group
 if [ "${daemon_group}" = "lxd" ] && ! getent group lxd >/dev/null 2>&1; then
     echo "==> Creating \"lxd\" group"
@@ -291,6 +281,16 @@ if [ "${daemon_group}" = "lxd" ] && ! getent group lxd >/dev/null 2>&1; then
         nsenter -t 1 -m groupadd --system --extrausers lxd || true
     else
         nsenter -t 1 -m groupadd --system lxd || true
+    fi
+fi
+
+# Setup the "lxd" user
+if ! getent passwd lxd >/dev/null 2>&1; then
+    echo "==> Creating \"lxd\" user"
+    if grep -q "^passwd.*extrausers" /var/lib/snapd/hostfs/etc/nsswitch.conf; then
+        nsenter -t 1 -m useradd --system -M -N --home "${SNAP_COMMON}/lxd" --shell /bin/false --gid lxd --extrausers lxd || true
+    else
+        nsenter -t 1 -m useradd --system -M -N --home "${SNAP_COMMON}/lxd" --shell /bin/false --gid lxd lxd || true
     fi
 fi
 


### PR DESCRIPTION
By first creating the group, we can create the user and assign it the right primary group from the start. This is mostly a cosmetic issue being addressed because otherwise the lxd daemon was anyway always started with the right group.

Before that fix, the `lxd` user's primary group defaulted to `users` which is a group meant for human beings.