### PR TITLE
editor: better handle nano rc files (5.21-edge)

### DIFF
--- a/snapcraft/wrappers/editor
+++ b/snapcraft/wrappers/editor
@@ -7,9 +7,17 @@ run_cmd() {
     export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
     export HOME="${SNAP_REAL_HOME}"
     export USER="${USERNAME}"
+    IGNORERCFILES=""
+    if [ "${HOME}" != "/root" ] && [ "${CMD}" = "nano" ]; then
+        export XDG_DATA_HOME="${HOME}/.local/share"
+        if [ ! -d "/var/lib/snapd/hostfs/${XDG_DATA_HOME}" ]; then
+            echo "Instructing nano to ignore RC files due to missing directory: \"${XDG_DATA_HOME}\""
+           IGNORERCFILES="--ignorercfiles"
+        fi
+    fi
 
     # shellcheck disable=SC2145
-    exec unshare --kill-child -U -m -p -r -f --root="/var/lib/snapd/hostfs/" "/bin/sh" -c "mount -t proc proc /proc 2>/dev/null || true; exec \"${CMD}\" \"$@\""
+    exec unshare --kill-child -U -m -p -r -f --root="/var/lib/snapd/hostfs/" "/bin/sh" -c "mount -t proc proc /proc 2>/dev/null || true; exec \"${CMD}\" ${IGNORERCFILES} \"$@\""
 }
 
 # Detect base name


### PR DESCRIPTION
When indirectly invoking `nano` as a non-root user this error is displayed:

```
ubuntu@nv1:~$ lxc profile edit default
Unable to create directory /root/.local/share/nano/: Permission denied
It is required for saving/loading search history or cursor positions.

```

While applications should use a default value for `XDG_DATA_HOME` of `$HOME/.local/share` it seems that `nano` does not. Exporting `XDG_DATA_HOME` helps but `nano` will fail if the directory does not exist:

```
$ ll .local/
ls: cannot access '.local/': No such file or directory
$ lxc profile edit default
Unable to create directory /home/ubuntu/.local/share/nano/: No such file or directory
It is required for saving/loading search history or cursor positions.

```

As such, if the directory `$HOME/.local/share` does not exist, tell `nano` to not attempt reading any rc files. This provides a nicer experience:

```
ubuntu@nv1:~$ ll .local/
ls: cannot access '.local/': No such file or directory
ubuntu@nv1:~$ lxc profile edit default
Instructing nano to ignore RC files due to missing directory: "/home/ubuntu/.local/share"
ubuntu@nv1:~$ ll .local/
ls: cannot access '.local/': No such file or directory
ubuntu@nv1:~$ mkdir -p .local/share
ubuntu@nv1:~$ lxc profile edit default
ubuntu@nv1:~$
```

When invoked by root, `nano` has no problem creating `/root/.local/share`.

Signed-off-by: Simon Deziel <simon.deziel@canonical.com>
(cherry picked from commit b32b62631fb2f7acde385efe5471788c81859250)