### PR TITLE
Rework how existing LXD PIDs are validated/discovered

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -628,9 +628,8 @@ for pid in $(pgrep -f "lxd(\.debug)? --logfile"); do
     # to a file using the `/proc` path and comparing the content seen from
     # the `/var` path, we can conclude if the LXD daemon is executing
     # in the same mount namespace as ours (safe to kill) or not (ignore).
-    rm -f "/var/snap/lxd/common/lxd/.validate"
-    touch "/proc/${pid}/root/var/snap/lxd/common/lxd/.validate" 2>/dev/null || true
-    if [ -e "/var/snap/lxd/common/lxd/.validate" ]; then
+    echo "$$" > "/proc/${pid}/root/var/snap/lxd/common/lxd/.validate" 2>/dev/null || true
+    if [ "$(cat /var/snap/lxd/common/lxd/.validate 2>/dev/null)" = "$$" ]; then
         echo "=> Killing conflicting LXD (pid=${pid})"
         kill -9 "${pid}" || true
         rm -f "/var/snap/lxd/common/lxd/.validate"

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -619,7 +619,7 @@ fi
 
 # LXD
 ## Check for existing LXDs
-for pid in $(pgrep -f "lxd --logfile" ; pgrep -f "lxd.debug --logfile"); do
+for pid in $(pgrep -f "lxd(\.debug)? --logfile"); do
     # Cheap confirmation that we likely have a LXD PID
     grep -q --line-regexp --fixed-strings --max-count=1 "SNAP_NAME=lxd" "/proc/${pid}/environ" || continue
 

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -619,7 +619,7 @@ fi
 
 # LXD
 ## Check for existing LXDs
-for pid in $(pgrep -f "lxd(\.debug)? --logfile"); do
+for pid in $(pgrep --euid 0 --full "lxd(\.debug)? --logfile"); do
     # Cheap confirmation that we likely have a LXD PID
     grep -q --line-regexp --fixed-strings --max-count=1 "SNAP_NAME=lxd" "/proc/${pid}/environ" || continue
 
@@ -628,6 +628,8 @@ for pid in $(pgrep -f "lxd(\.debug)? --logfile"); do
     # to a file using the `/proc` path and comparing the content seen from
     # the `/var` path, we can conclude if the LXD daemon is executing
     # in the same mount namespace as ours (safe to kill) or not (ignore).
+    # A priv nested LXD would pass the EUID=0 and SNAP_NAME=lxd tests but would
+    # fail the `.validate` test as it wouldn't be in the same mount namespace.
     echo "$$" > "/proc/${pid}/root/var/snap/lxd/common/lxd/.validate" 2>/dev/null || true
     if [ "$(cat /var/snap/lxd/common/lxd/.validate 2>/dev/null)" = "$$" ]; then
         echo "=> Killing conflicting LXD (pid=${pid})"

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -620,7 +620,8 @@ fi
 # LXD
 ## Check for existing LXDs
 for pid in $(pgrep -f "lxd --logfile" ; pgrep -f "lxd.debug --logfile"); do
-    grep -qF "SNAP_NAME=lxd" "/proc/${pid}/environ" || continue
+    # Cheap confirmation that we likely have a LXD PID
+    grep -q --line-regexp --fixed-strings --max-count=1 "SNAP_NAME=lxd" "/proc/${pid}/environ" || continue
 
     rm -f "/var/snap/lxd/common/lxd/.validate"
     touch "/proc/${pid}/root/var/snap/lxd/common/lxd/.validate" 2>/dev/null || true

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -634,8 +634,8 @@ for pid in $(pgrep --euid 0 --full "lxd(\.debug)? --logfile"); do
     if [ "$(cat /var/snap/lxd/common/lxd/.validate 2>/dev/null)" = "$$" ]; then
         echo "=> Killing conflicting LXD (pid=${pid})"
         kill -9 "${pid}" || true
-        rm -f "/var/snap/lxd/common/lxd/.validate"
     fi
+    rm -f "/proc/${pid}/root/var/snap/lxd/common/lxd/.validate"
 done
 
 ## Move the database out of the versioned path if present

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -623,6 +623,11 @@ for pid in $(pgrep -f "lxd(\.debug)? --logfile"); do
     # Cheap confirmation that we likely have a LXD PID
     grep -q --line-regexp --fixed-strings --max-count=1 "SNAP_NAME=lxd" "/proc/${pid}/environ" || continue
 
+    # Confirm the PID found by pgrep is indeed ours and not one from
+    # a nested instance also running LXD or a recycled PID. By writing
+    # to a file using the `/proc` path and comparing the content seen from
+    # the `/var` path, we can conclude if the LXD daemon is executing
+    # in the same mount namespace as ours (safe to kill) or not (ignore).
     rm -f "/var/snap/lxd/common/lxd/.validate"
     touch "/proc/${pid}/root/var/snap/lxd/common/lxd/.validate" 2>/dev/null || true
     if [ -e "/var/snap/lxd/common/lxd/.validate" ]; then


### PR DESCRIPTION
Change how LXD's `daemon.start` detects existing LXD processes left behind.

1. Optimize how `pgrep` is used to avoid needing to invoke it twice, once for regular daemons and another for debug ones.
2. Tweak `pgrep` invocation to only report PIDs that have an EUID of `0`. This ensures we don't accidentally get nested LXD PIDs because those should be in a different userns (for `unpriv`)
3. Once we have a candidate PID, make sure it's from a snap (`SNAP_NAME=lxd` line in `/proc/$pid/environ`)
4. Now that we have a probable LXD PID, make sure it is really a leftover process and not a nested LXD from a `privileged` container.

This last step involves writing short random data through the PID's mount namespace (`/proc/${pid}/root/var/snap/lxd/common/lxd/.validate`) and comparing it with our own view of the mount namespace by accessing the same file but directly (`/var/snap/lxd/common/lxd/.validate`).