### PR TITLE
qemu: Bump to import/1%8.2.2+ds-0ubuntu2

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -803,7 +803,7 @@ parts:
       - spice-server
     source: https://git.launchpad.net/ubuntu/+source/qemu
     source-depth: 1
-    source-tag: import/1%8.2.1+ds-1ubuntu5
+    source-tag: import/1%8.2.2+ds-0ubuntu2
     source-type: git
     plugin: autotools
     autotools-configure-parameters:


### PR DESCRIPTION
To match what is in Noble (well almost, this one is slightly newer than what is showing in packages.ubuntu.com right now for Noble's QEMU) but it is a no-change rebuild commit:

https://git.launchpad.net/ubuntu/+source/qemu/commit/?h=import/1%258.2.2%2bds-0ubuntu2&id=3469cbaaead0ee6d1d9e28e3dbee7a9b555631ec

And the commit before that is what is in Noble:

https://git.launchpad.net/ubuntu/+source/qemu/commit/?h=import/1%258.2.2%2bds-0ubuntu1&id=4769f7051b0753455b775ab10c9226e149ed6237