### PR TITLE
Drop support for the old LXD appliance

### DIFF
--- a/snapcraft/commands/daemon.activate
+++ b/snapcraft/commands/daemon.activate
@@ -51,13 +51,6 @@ if ! nsenter -t 1 -m systemctl is-active -q snap."${SNAP_INSTANCE_NAME}".daemon.
     fi
 fi
 
-# Start LXD if running as an appliance
-if nsenter -t 1 -m snap model --assertion | grep -q "^model: lxd-core"; then
-    echo "==> LXD appliance detected, starting LXD"
-    nsenter -t 1 -m systemctl start snap."${SNAP_INSTANCE_NAME}".daemon --no-block
-    exit 0
-fi
-
 # Setup the "lxd" group
 if [ "${daemon_group}" = "lxd" ] && ! getent group lxd >/dev/null 2>&1; then
     echo "==> Creating \"lxd\" group"

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -726,16 +726,14 @@ fi
 
 ## Check if this is the first time LXD is started
 if [ ! -d "${SNAP_COMMON}/lxd/database" ]; then
-    set -e
     echo "=> First LXD execution on this system"
 
-    ## Process preseed if present
+    ## Process preseed if present and ignore any errors
     if [ -e "${SNAP_COMMON}/init.yaml" ]; then
         echo "==> Running LXD preseed file"
-        ${LXD} init --preseed < "${SNAP_COMMON}/init.yaml"
+        ${LXD} init --preseed < "${SNAP_COMMON}/init.yaml" || true
         mv "${SNAP_COMMON}/init.yaml" "${SNAP_COMMON}/init.yaml.applied"
     fi
-    set +e
 fi
 
 ## Wait for the daemon to die

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -28,22 +28,8 @@ export LXD_CLUSTER_UPDATE="${SNAP_CURRENT}/commands/refresh"
 export LXD_QEMU_FW_PATH="${SNAP_CURRENT}/share/qemu"
 export PYTHONPATH=/snap/lxd/current/lib/python3/dist-packages/
 
-# Detect LXD appliance
-LXD_APPLIANCE="false"
-if nsenter -t 1 -m snap model --assertion | grep -q "^model: lxd-core"; then
-    LXD_APPLIANCE="true"
-fi
-
 # Detect base name
 SNAP_BASE="$(sed -n '/^name:/ s/^name:\s*\(core[0-9]\{2\}\)/\1/p' /meta/snap.yaml)"
-
-# Wait for appliance configuration
-if [ "${LXD_APPLIANCE}" = "true" ]; then
-    while :; do
-        [ "$(nsenter -t 1 -m snap managed)" = "true" ] && break
-        sleep 5
-    done
-fi
 
 # Workaround for systemd nuking our cgroups on refreshes
 nsenter -t 1 -m systemd-run -u snap."${SNAP_INSTANCE_NAME}".workaround -p Delegate=yes -r /bin/true >/dev/null 2>&1 || true
@@ -748,22 +734,6 @@ if [ ! -d "${SNAP_COMMON}/lxd/database" ]; then
         echo "==> Running LXD preseed file"
         ${LXD} init --preseed < "${SNAP_COMMON}/init.yaml"
         mv "${SNAP_COMMON}/init.yaml" "${SNAP_COMMON}/init.yaml.applied"
-    elif [ "${LXD_APPLIANCE}" = "true" ]; then
-        echo "==> Initializing LXD appliance"
-
-        # Network (NIC with the default gateway)
-        NIC="$(ip -4 -o route get 0.0.0.1 | cut -d' ' -f5)"
-        lxc --force-local --quiet profile device add default eth0 nic nictype=macvlan parent="${NIC}" name=eth0
-
-        # Storage (80% of free space)
-        AVAIL="$(($(df --output=avail "${SNAP_COMMON}" | tail -1)*1024*80/100))"
-        for fs in zfs btrfs; do
-            lxc --force-local --quiet storage create local "${fs}" size="${AVAIL}" && break
-        done
-        lxc --force-local --quiet profile device add default root disk pool=local path=/
-
-        # Network access
-        lxc --force-local --quiet config set core.https_address :8443
     fi
     set +e
 fi


### PR DESCRIPTION
https://cdimage.ubuntu.com/ubuntu-core/appliances/ shows that both `lxd-core18-amd64.img.xz` and `lxd-core18-pi.img.xz` were last updated on 2020-08-20.