### PR TITLE
Use variable substitution to replace `basename` that is an external binary

### DIFF
--- a/snapcraft/commands/daemon.activate
+++ b/snapcraft/commands/daemon.activate
@@ -18,8 +18,10 @@ fi
 # shellcheck disable=SC2155
 export SNAP_CURRENT="$(realpath "${SNAP}/..")/current"
 
-# shellcheck disable=SC2155
-export ARCH="$(basename "$(readlink -f "${SNAP_CURRENT}"/lib/*-linux-gnu*/)")"
+# Turn `/snap/lxd/28637/lib/x86_64-linux-gnu` into `x86_64-linux-gnu`
+# Similar to `basename` but using variable substitution instead of external executable
+LIB_ARCH="$(readlink -f "${SNAP_CURRENT}"/lib/*-linux-gnu*/)"
+export ARCH="${LIB_ARCH##*/}"
 
 export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:${SNAP_CURRENT}/lib:${SNAP_CURRENT}/lib/${ARCH}:${SNAP_CURRENT}/lib/${ARCH}/ceph"
 export PATH="${PATH}:${SNAP_CURRENT}/bin"

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -14,8 +14,10 @@ echo "=> Preparing the system (${SNAP_REVISION})"
 # shellcheck disable=SC2155
 export SNAP_CURRENT="$(realpath "${SNAP}/..")/current"
 
-# shellcheck disable=SC2155
-export ARCH="$(basename "$(readlink -f "${SNAP_CURRENT}"/lib/*-linux-gnu*/)")"
+# Turn `/snap/lxd/28637/lib/x86_64-linux-gnu` into `x86_64-linux-gnu`
+# Similar to `basename` but using variable substitution instead of external executable
+LIB_ARCH="$(readlink -f "${SNAP_CURRENT}"/lib/*-linux-gnu*/)"
+export ARCH="${LIB_ARCH##*/}"
 
 export HOME="/tmp/"
 export LXD_DIR="${SNAP_COMMON}/lxd/"

--- a/snapcraft/commands/lxd
+++ b/snapcraft/commands/lxd
@@ -12,8 +12,10 @@ fi
 # shellcheck disable=SC2155
 export SNAP_CURRENT="$(realpath "${SNAP}/..")/current"
 
-# shellcheck disable=SC2155
-export ARCH="$(basename "$(readlink -f "${SNAP_CURRENT}"/lib/*-linux-gnu*/)")"
+# Turn `/snap/lxd/28637/lib/x86_64-linux-gnu` into `x86_64-linux-gnu`
+# Similar to `basename` but using variable substitution instead of external executable
+LIB_ARCH="$(readlink -f "${SNAP_CURRENT}"/lib/*-linux-gnu*/)"
+export ARCH="${LIB_ARCH##*/}"
 
 export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:${SNAP_CURRENT}/lib:${SNAP_CURRENT}/lib/${ARCH}:${SNAP_CURRENT}/lib/${ARCH}/ceph"
 export PATH="${PATH}:${SNAP_CURRENT}/bin"

--- a/snapcraft/wrappers/editor
+++ b/snapcraft/wrappers/editor
@@ -52,7 +52,7 @@ fi
 if [ -n "${EDIT_CMD}" ] && [ "${USERNS}" = 1 ]; then
     exec 9< /tmp/
     # Replace "/tmp/" prefix by exec'ed FD 9.
-    EDIT_PATH_HOST="/proc/self/fd/9/$(echo "${EDIT_PATH}" | cut -d/ -f3)"
+    EDIT_PATH_HOST="/proc/self/fd/9/${EDIT_PATH##*/}"
     find_and_spawn "${EDIT_CMD}" "${EDIT_PATH_HOST}"
 fi
 

--- a/snapcraft/wrappers/kmod
+++ b/snapcraft/wrappers/kmod
@@ -1,5 +1,7 @@
 #!/bin/sh
-NAME="$(basename "${0}")"
+# Turn `/usr/sbin/foo` into `foo`
+# Similar to `basename` but using variable substitution instead of external executable
+NAME="${0##/*}"
 
 # Detect base name
 SNAP_BASE="$(sed -n '/^name:/ s/^name:\s*\(core[0-9]\{2\}\)/\1/p' /meta/snap.yaml)"

--- a/snapcraft/wrappers/run-host
+++ b/snapcraft/wrappers/run-host
@@ -1,5 +1,7 @@
 #!/bin/sh
-CMD="$(basename "${0}")"
+# Turn `/usr/sbin/foo` into `foo`
+# Similar to `basename` but using variable substitution instead of external executable
+CMD="${0##*/}"
 
 unset LD_LIBRARY_PATH
 unset PYTHONPATH

--- a/snapcraft/wrappers/sshfs
+++ b/snapcraft/wrappers/sshfs
@@ -7,7 +7,10 @@ if [ "$(id -u)" != "0" ]; then
     exit 1
 fi
 
-CMD="$(basename "${0}")"
+# Turn `/usr/sbin/foo` into `foo`
+# Similar to `basename` but using variable substitution instead of external executable
+CMD="${0##*/}"
+
 unset LD_LIBRARY_PATH
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 


### PR DESCRIPTION
`basename` is not a builtin command so replacing it with variable substitution is a bit less readable but avoids forking.