### PR TITLE
snapcraft/wrappers/kmod: fix typo in `basename` emulation

### DIFF
--- a/snapcraft/wrappers/kmod
+++ b/snapcraft/wrappers/kmod
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Turn `/usr/sbin/foo` into `foo`
 # Similar to `basename` but using variable substitution instead of external executable
-NAME="${0##/*}"
+NAME="${0##*/}"
 
 # Detect base name
 SNAP_BASE="$(sed -n '/^name:/ s/^name:\s*\(core[0-9]\{2\}\)/\1/p' /meta/snap.yaml)"


### PR DESCRIPTION
Fixes 3a7d072cb52fdc2d1faa061a776532bd5896dabd