### PR TITLE
snapcraft: lxd docs are now under doc/_build/

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1375,14 +1375,14 @@ parts:
         make doc
 
         # Remove unneeded bits
-        rm doc/html/objects.inv    # only objects.inv.txt is used
+        rm doc/_build/objects.inv    # only objects.inv.txt is used
         # not needed once built
-        rm doc/html/.buildinfo
-        rm -rf doc/html/_sphinx_design_static/
+        rm doc/_build/.buildinfo
+        rm -rf doc/_build/_sphinx_design_static/
 
         # Stage the static website
         mkdir -p "${CRAFT_STAGE}/share/lxd-documentation"
-        cp -a doc/html/. "${CRAFT_STAGE}/share/lxd-documentation/"
+        cp -a doc/_build/. "${CRAFT_STAGE}/share/lxd-documentation/"
       fi
 
       # Setup bash completion


### PR DESCRIPTION
Since https://github.com/canonical/lxd/pull/13537