### PR TITLE
snapcraft: don't strip LXCFS-related binaries (5.0-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1549,7 +1549,7 @@ parts:
       strip -s ${SNAPCRAFT_PRIME}/lib/libdqlite*
       strip -s ${SNAPCRAFT_PRIME}/lib/libsqlite*
 
-      # Strip binaries (excluding shell scripts)
+      # Strip binaries (excluding shell scripts and LXCFS)
       find "${SNAPCRAFT_PRIME}"/bin -type f \
         -not -path "${SNAPCRAFT_PRIME}/bin/ceph" \
         -not -path "${SNAPCRAFT_PRIME}/bin/editor" \
@@ -1559,6 +1559,7 @@ parts:
         -not -path "${SNAPCRAFT_PRIME}/bin/sshfs" \
         -not -path "${SNAPCRAFT_PRIME}/bin/upgrade-bridge" \
         -not -path "${SNAPCRAFT_PRIME}/bin/xfs_admin" \
+        -not -path "${CRAFT_PRIME}/bin/lxcfs" \
         -exec strip -s {} +
 
       # Strip binaries not under bin/ due to being dynamically
@@ -1574,9 +1575,10 @@ parts:
         find "${v}/" -type f -exec strip -s {} +
       done
 
-      # Strip libraries (excluding python3 scripts)
+      # Strip libraries (excluding python3 scripts and liblxcfs)
       find "${SNAPCRAFT_PRIME}"/lib -type f \
         -not -path "${SNAPCRAFT_PRIME}/lib/python3/*" \
+        -not -path "${CRAFT_PRIME}/lib/liblxcfs.so" \
         -exec strip -s {} +
 
       # XXX: look for broken symlinks indicating missing/invalid prime


### PR DESCRIPTION
We really need these for debugging crashes sometimes.