### PR TITLE
snapcraft: install edk2 build dependencies only when needed

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -303,9 +303,10 @@ parts:
     source-type: git
     plugin: nil
     build-packages:
-      - g++
-      - acpica-tools
-      - uuid-dev
+      - on amd64,arm64:
+        - g++
+        - acpica-tools
+        - uuid-dev
     override-prime: |-
       [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
       craftctl default


### PR DESCRIPTION
It's a fix for a build failure on s390:
Installing build-packages
Cannot find package listed in 'build-packages': acpica-tools Full execution log: '/root/.local/state/snapcraft/log/snapcraft-20240621-073250.087743.log' Build failed

Reason is that, in Ubuntu 24.04 acpica-tools package is not available for s390: https://packages.ubuntu.com/noble/acpica-tools
compare with:
https://packages.ubuntu.com/jammy/acpica-tools

Let's workaround this by preventing build packages installation for any architectures other than amd64/arm64. It's safe, because we only build edk2 for these two architectures.