### PR TITLE
snapcraft: add apparmor part for core22 only (5.0-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1209,15 +1209,51 @@ parts:
       - bin/pzstd
       - bin/zstd
 
+  apparmor:
+    source: https://gitlab.com/apparmor/apparmor.git
+    source-depth: 1
+    source-tag: v4.0.1
+    source-type: git
+    plugin: autotools
+    build-packages:
+      - g++
+      - bison
+      - flex
+      - autoconf-archive
+      - gettext
+    override-build: |-
+      set -ex
+
+      cd ./libraries/libapparmor
+      sh ./autogen.sh
+      sh ./configure --prefix=/
+      make
+      make install
+
+      cd ../../parser
+      make
+      make install
+
+      mkdir "${CRAFT_PART_INSTALL}/bin"
+      cp /sbin/apparmor_parser "${CRAFT_PART_INSTALL}/bin/"
+      mkdir "${CRAFT_PART_INSTALL}/lib"
+      cp /lib/libapparmor.so* "${CRAFT_PART_INSTALL}/lib/"
+
+      set +ex
+    prime:
+      - bin/apparmor_parser
+      - lib/libapparmor.so.1
+      - lib/libapparmor.so.1.*
+
   # Core components
   lxc:
     after:
       - libseccomp
+      - apparmor
     source: https://github.com/lxc/lxc
     source-type: git
     source-branch: stable-5.0
     build-packages:
-      - libapparmor-dev
       - libcap-dev
       - libdbus-1-dev
       - libgnutls28-dev


### PR DESCRIPTION
Let's ship newer version of AppArmor with support of new features. Only needed for core22.