### PR TITLE
snapcraft: fix acpica-tools dependency package name

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -310,7 +310,7 @@ parts:
         - uuid-dev
       - on arm64:
         - g++
-        - acpica-tools12
+        - acpica-tools
         - uuid-dev
     override-prime: |-
       [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0


### PR DESCRIPTION
Only for core24.