### PR TITLE
snapcraft: ceph from `core24` depends on lua5.4

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -233,7 +233,7 @@ parts:
       - lib/*/libicuuc.so*
       - lib/*/liblber-2.5.so*
       - lib/*/libldap-2.5.so*
-      - lib/*/liblua5.3.so*
+      - lib/*/liblua5.4.so*
       - lib/*/libndctl.so*
       - lib/*/libnghttp2.so*
       - lib/*/liboath.so*


### PR DESCRIPTION
https://packages.ubuntu.com/noble/ceph-common

This is just a drive-by fix, I still need to review all the `prime`'ed files from every parts.