### PR TITLE
snapcraft: add support for `gpu-2404` snap interface

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -71,6 +71,10 @@ plugs:
  ovn-chassis:
    interface: content
    target: "$SNAP_DATA/microovn/chassis"
+ graphics-core22:
+   interface: content
+   target: "$SNAP/graphics"
+   default-provider: mesa-core22
 
 apps:
   # Main commands
@@ -82,6 +86,8 @@ apps:
       - system-observe
 
   daemon:
+    command-chain:
+      - bin/graphics-core22-wrapper
     command: commands/daemon.start
     reload-command: commands/daemon.reload
     stop-command: commands/daemon.stop
@@ -121,6 +127,8 @@ apps:
       - system-observe
 
   lxd:
+    command-chain:
+      - bin/graphics-core22-wrapper
     command: commands/lxd
     plugs:
       - lxd-support
@@ -1493,6 +1501,18 @@ parts:
     prime:
       - share/lxd-ui*
 
+  graphics-core22:
+    after:
+      - lxd
+    source: https://github.com/canonical/gpu-snap.git
+    plugin: dump
+    override-prime: |
+      craftctl default
+      ${CRAFT_PART_SRC}/bin/graphics-core22-cleanup mesa-core22 nvidia-core22
+    prime:
+      - bin/graphics-core22-wrapper
+      - bin/graphics-core22-cleanup
+
   shmounts:
     source: shmounts/
     plugin: make
@@ -1526,6 +1546,7 @@ parts:
       - lxcfs
       - criu
       - lxd
+      - graphics-core22
       - shmounts
     plugin: nil
     override-prime: |
@@ -1548,6 +1569,8 @@ parts:
         -not -path "${CRAFT_PRIME}/bin/sshfs" \
         -not -path "${CRAFT_PRIME}/bin/xfs_admin" \
         -not -path "${CRAFT_PRIME}/bin/uefivars.py" \
+        -not -path "${CRAFT_PRIME}/bin/graphics-core22-wrapper" \
+        -not -path "${CRAFT_PRIME}/bin/graphics-core22-cleanup" \
         -not -path "${CRAFT_PRIME}/bin/lxcfs" \
         -exec strip -s {} +
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -171,6 +171,14 @@ hooks:
     plugs:
       - lxd-support
       - system-observe
+  connect-plug-graphics-core22:
+    plugs:
+      - lxd-support
+      - system-observe
+  disconnect-plug-graphics-core22:
+    plugs:
+      - lxd-support
+      - system-observe
   configure:
     plugs:
       - lxd-support

--- a/snapcraft/hooks/connect-plug-graphics-core22
+++ b/snapcraft/hooks/connect-plug-graphics-core22
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -eu
+
+# Re-exec outside of apparmor confinement
+if [ -d /sys/kernel/security/apparmor ]; then
+  label="$(cat /proc/self/attr/current 2>/dev/null)"
+  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+    exec aa-exec -p unconfined -- "$0" "$@"
+  fi
+fi
+
+if [ -e "/etc/.lxd_generated" ]; then
+    nvidia_container_cli="${SNAP}/bin/nvidia-container-cli"
+
+    # Create a backup if it doesn't exist
+    if [ ! -f "${nvidia_container_cli}.bak" ]; then
+        cp "${nvidia_container_cli}" "${nvidia_container_cli}.bak"
+    fi
+
+    # Remove the root path frrm being `/var/lib/snapd/hostfs/` (host system)
+    # This will then allow `nvidia-container-cli` to discover userspace libs
+    # living within the snap mount namespace.
+    cat > "${nvidia_container_cli}" << EOF
+#!/bin/sh
+
+# Set the root path
+exec nvidia-container-cli.real "\$@"
+EOF
+
+    # Ensure the file is executable
+    chmod +x "$nvidia_container_cli"
+fi

--- a/snapcraft/hooks/disconnect-plug-graphics-core22
+++ b/snapcraft/hooks/disconnect-plug-graphics-core22
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eu
+
+# Re-exec outside of apparmor confinement
+if [ -d /sys/kernel/security/apparmor ]; then
+  label="$(cat /proc/self/attr/current 2>/dev/null)"
+  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+    exec aa-exec -p unconfined -- "$0" "$@"
+  fi
+fi
+
+if [ -e "/etc/.lxd_generated" ]; then
+    nvidia_container_cli="${SNAP}/bin/nvidia-container-cli"
+    backup_file_nvidia_container_cli="${nvidia_container_cli}.bak"
+
+    # Restore from backup if it exists
+    if [ -f "${backup_file_nvidia_container_cli}" ]; then
+        mv "${backup_file_nvidia_container_cli}" "${nvidia_container_cli}"
+        chmod +x "${nvidia_container_cli}"
+    else
+        # If no backup, recreate the original content
+        cat > "${nvidia_container_cli}" << EOF
+#!/bin/sh
+
+# Set the root path
+exec nvidia-container-cli.real -r /var/lib/snapd/hostfs/ "\$@"
+EOF
+        chmod +x "${nvidia_container_cli}"
+    fi
+fi


### PR DESCRIPTION
JIRA ticket: https://warthogs.atlassian.net/browse/LXD-1244

## Goal

Having a host system without NVIDIA userspace libraries, we want to be able to provide the LXD snap with NVIDIA userspace libraries in order to have containers enabled with `nvidia.runtime=true` so that if a GPU device has been passed through, the container contains CUDA related libs alongside with the drivers.

## Requirements

Before doing anything related to the LXD snap, ensure that you have the **right** NVIDIA drivers installed on your system. If you're using Ubuntu Core, you must have the right **kernel snap** providing the NVIDIA drivers. The rest of the requirements steps shown here are merely a PoC that proves that the GPU snap connection works on a classical system, not with Ubuntu Core.

* The userspace libs provided by `nvidia-core22`, and especially `libnvidia-ml.so.1` that allows a program like `nvidia-container-cli`  to configure a GPU passthrough within a LXD container, requires the triplet version `535.161.08` for the NVIDIA drivers.
* You can download [this driver](https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/nvidia-graphics-drivers-535-server/535.161.08-0ubuntu2/nvidia-graphics-drivers-535-server_535.161.08.orig-amd64.tar.gz) that, when unpacked and installed, will give you the right drivers.
* You can check it with ` lsmod | grep nvidia` that should show:
```bash
nvidia_drm             90112  0
nvidia_uvm           1789952  0
nvidia_modeset       1314816  1 nvidia_drm
nvidia              56827904  2 nvidia_uvm,nvidia_modeset
video                  73728  2 nouveau,nvidia_modeset
```
* ..and most importantly `modinfo nvidia | grep "^version:"` that should output:
```bash
version:        535.161.08
```
* The drawback of installing the drivers through this installer is that it also installs the userspace libs on your host. They will be provided by the `nvidia-core22` snap so let's remove them to show that the GPU snap interface with LXD works as expected:
```bash
cd /usr/lib/x86_64-linux-gnu
sudo rm libnvidia* && rm libcuda* && rm -r nvidia
```
* Now, you should be good with the requirements

## How-to's

Ultimately, a user having setup LXD (and ensured that the previous requirements were fulfilled) could do the following:

* Install the `nvidia-core22` snap containing the userspace libraries: `sudo snap install nvidia-core22`
* Connect the `lxd` and `nvidia-core22` snaps through the `graphics-core22` interface: `sudo snap connect lxd:graphics-core22 nvidia-core22:graphics-core22`
* Restart LXD: `sudo snap restart lxd`
* Initiate a container instance with an NVIDIA runtime: `lxc init ubuntu:<jammy | noble> c1 -c nvidia.runtime=true`
* Add a GPU device to the container instance: `lxc config device add c1 gpu0 gpu id=0`
* Start the container: `lxc start c1`

You should now have `c1` running with a GPU passthrough and the NVIDIA userspace libs provided by `nvidia-core22` mounted inside the container. You can now run compute workload inside `c1` leveeraging the NVIDIA runtime. 

## `nvidia-core22` explanations

Although the LXD snap uses the `core24` base snap, we can't rely (as of now) on the `gpu-2404` content snap. This is because what we're really interested in, are the nvidia userspace libraries. These come from the `nvidia-core22` producer snap that can only be plugged to the `graphics-core22` content snap. Plus, `nvidia-core24` does not exist yet. Once it will exist and that it will be able to be consumed by the `gpu-2404` wrapper, then we will switch to using `gpu-2404`. 

We'd then use `mesa-core22` as a default-provider for LXD's `graphics-core22` plug so that `nvidia-core22` is not auto installed. The only drawback of this approach is that we can not connect the `mesa-2404` producer to LXD but it does not seems to be the primary purpose behind this feature.

## What is doing the `graphics-core22-wrapper` ?

This script will call the underlying provider wrapper and update the LD_LIBRARY_PATH env variable to append the userspace lib paths loaded inside LXD snap at `${SNAP}/graphics`. This provider wrapper is executed  as a `command chain` with LXD's `daemon` app, which means that the LXD daemon is executed with an updated LD_LIBRARY_PATH environment. We'd then need to restart the daemon app after the plug connection for the change to be effective.

Then, the `hooks/nvida` script inside liblxc is executed with an updated version of `LD_LIBRARY_PATH` which contains a path to the `$SNAP/graphics/lib/<arch-triplet>` , allowing the `nvidia-container-cli` program to dynamiclly fetch the shared libs it needs to configure the passthrough, to complete successfully. Indeed, this program relies on `LD_LIBRARY_PATH` for its discover / configure logic which requires NVIDIA management libs like `libnvidia-ml.so` 

## `<connect|disconnect>-plug-graphics-core22` snap hooks

In order for the `nvidia-container-cli` **binary** program (internally named `nvidia-container-cli.real`) to work in case of working with `nvidia-core22`, we need to modify the `nvidia-container-cli` **script** from:

```bash
#!/bin/sh

# Set the root path
exec nvidia-container-cli.real -r /var/lib/snapd/hostfs/ "$@"
```

to

```bash
#!/bin/sh

# Set the root path
exec nvidia-container-cli.real "$@"
```

Indeed, when connected to the `graphics-core22` plug, the nvidia userspace libs are in the snap mount namespace and not in the host filesystem that we can search after `/var/lib/snapd/hostfs/`. We simply tell the `nvidia-container-cli` binary to change its root path for libs discovery. The disconnect operation simply revert this change to come back to normal. 