### PR TITLE
Revert "snapcraft.yaml: enable unconfined mode in lxd-support interface"

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: lxd
 base: core24
 assumes:
-  - snapd2.62
+  - snapd2.39
 version: git
 grade: devel
 summary: LXD - container and VM manager
@@ -71,9 +71,6 @@ plugs:
  ovn-chassis:
    interface: content
    target: "$SNAP_DATA/microovn/chassis"
- lxd-support-with-unconfined-mode:
-   interface: lxd-support
-   enable-unconfined-mode: true
 
 apps:
   # Main commands
@@ -81,7 +78,7 @@ apps:
     command: commands/daemon.activate
     daemon: oneshot
     plugs:
-      - lxd-support-with-unconfined-mode
+      - lxd-support
       - system-observe
 
   daemon:
@@ -94,7 +91,7 @@ apps:
     slots:
       - lxd
     plugs:
-      - lxd-support-with-unconfined-mode
+      - lxd-support
       - network-bind
       - system-observe
     sockets:
@@ -108,7 +105,7 @@ apps:
     restart-condition: on-failure
     daemon: simple
     plugs:
-      - lxd-support-with-unconfined-mode
+      - lxd-support
       - network-bind
       - system-observe
     sockets:
@@ -120,60 +117,60 @@ apps:
     command: commands/lxc
     completer: etc/bash_completion.d/snap.lxd.lxc
     plugs:
-      - lxd-support-with-unconfined-mode
+      - lxd-support
       - system-observe
 
   lxd:
     command: commands/lxd
     plugs:
-      - lxd-support-with-unconfined-mode
+      - lxd-support
       - system-observe
 
   # Sub-commands
   buginfo:
     command: commands/buginfo
     plugs:
-      - lxd-support-with-unconfined-mode
+      - lxd-support
       - system-observe
   check-kernel:
     command: commands/lxd-check-kernel
     plugs:
-      - lxd-support-with-unconfined-mode
+      - lxd-support
       - system-observe
 
 hooks:
   connect-plug-ceph-conf:
     plugs:
-      - lxd-support-with-unconfined-mode
+      - lxd-support
       - system-observe
   disconnect-plug-ceph-conf:
     plugs:
-      - lxd-support-with-unconfined-mode
+      - lxd-support
       - system-observe
   connect-plug-ovn-certificates:
     plugs:
-      - lxd-support-with-unconfined-mode
+      - lxd-support
       - system-observe
   disconnect-plug-ovn-certificates:
     plugs:
-      - lxd-support-with-unconfined-mode
+      - lxd-support
       - system-observe
   connect-plug-ovn-chassis:
     plugs:
-      - lxd-support-with-unconfined-mode
+      - lxd-support
       - system-observe
   disconnect-plug-ovn-chassis:
     plugs:
-      - lxd-support-with-unconfined-mode
+      - lxd-support
       - system-observe
   configure:
     plugs:
-      - lxd-support-with-unconfined-mode
+      - lxd-support
       - network
       - system-observe
   remove:
     plugs:
-      - lxd-support-with-unconfined-mode
+      - lxd-support
       - system-observe
 
 parts:


### PR DESCRIPTION
This reverts commit 2f0fcab2cb520c8f9ef8af1f6150f7651348d558 from PR https://github.com/canonical/lxd-pkg-snap/pull/277

There are currently multiple issues with landing this change:

 * The snap store is not allowing uploads of snaps using this plug. See https://git.launchpad.net/review-tools/commit/reviewtools/sr_common.py?id=08e83bf8d0b36eb8ff82ae74e774f00d56493d5f
 * The Ubuntu kernel and/or the apparmor parser in Noble has a bug that is incorrectly confining LXD rather than providing unconfinement. See https://bugs.launchpad.net/apparmor/+bug/2067900

There are currently various proposals on the table on how to resolve this, but with no clear timeline.

Once it is resolved we can try and land this again.