### PR TITLE
bump snapd version requirement to 2.65 and remove hacky workaround

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -80,6 +80,9 @@ plugs:
    interface: content
    content: qemu-external-binaries
    target: $SNAP/external/qemu
+ lxd-support-with-unconfined-mode:
+   interface: lxd-support
+   enable-unconfined-mode: true
 
 layout:
   /usr/share/libdrm:
@@ -93,7 +96,7 @@ apps:
     command: commands/daemon.activate
     daemon: oneshot
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
 
   daemon:
@@ -108,7 +111,7 @@ apps:
     slots:
       - lxd
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - network-bind
       - system-observe
     sockets:
@@ -122,7 +125,7 @@ apps:
     restart-condition: on-failure
     daemon: simple
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - network-bind
       - system-observe
     sockets:
@@ -134,68 +137,68 @@ apps:
     command: commands/lxc
     completer: etc/bash_completion.d/snap.lxd.lxc
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
 
   lxd:
     command: commands/lxd
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
 
   # Sub-commands
   buginfo:
     command: commands/buginfo
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
   check-kernel:
     command: commands/lxd-check-kernel
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
 
 hooks:
   connect-plug-ceph-conf:
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
   disconnect-plug-ceph-conf:
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
   connect-plug-ovn-certificates:
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
   disconnect-plug-ovn-certificates:
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
   connect-plug-ovn-chassis:
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
   disconnect-plug-ovn-chassis:
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
   connect-plug-qemu-external:
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
   disconnect-plug-qemu-external:
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
   configure:
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - network
       - system-observe
   remove:
     plugs:
-      - lxd-support
+      - lxd-support-with-unconfined-mode
       - system-observe
 
 parts:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: lxd
 base: core24
 assumes:
-  - snapd2.39
+  - snapd2.65
 version: git
 grade: devel
 summary: LXD - container and VM manager

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -39,13 +39,6 @@ fi
 # Detect base name
 SNAP_BASE="$(sed -n '/^name:/ s/^name:\s*\(core[0-9]\{2\}\)/\1/p' /meta/snap.yaml)"
 
-# Temporary hack to workaround systemctl reload snap.lxd.daemon
-# problem with core24-based LXD snap
-if [ "${SNAP_BASE}" = "core24" ]; then
-    _LXD_SNAP_DEVCGROUP_CONFIG="/var/lib/snapd/hostfs/var/lib/snapd/cgroup/snap.lxd.device"
-    grep -qxF 'self-managed=true' "${_LXD_SNAP_DEVCGROUP_CONFIG}" || echo 'self-managed=true' >> "${_LXD_SNAP_DEVCGROUP_CONFIG}"
-fi
-
 # Wait for appliance configuration
 if [ "${LXD_APPLIANCE}" = "true" ]; then
     while :; do


### PR DESCRIPTION
snapd 2.65 is not released yet. We are waiting for it and:
https://github.com/snapcore/snapd/pull/14118
to be included