### PR TITLE
lxd-ui: Bump to 0.8.2 (5.21-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1489,7 +1489,7 @@ parts:
     source: https://github.com/canonical/lxd-ui
     source-depth: 1
     source-type: git
-    source-tag: 0.8.1
+    source-tag: 0.8.2
     plugin: nil
     override-prime: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
This includes a fix for https://github.com/canonical/lxd-ui/issues/810 preventing an error in network configuration from the ui.