### PR TITLE
netfilter: Switch to upstream source tarballs for libmnl and libnftnl (5.21-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -445,11 +445,9 @@ parts:
       - lib/*/libatomic.so*
 
   libmnl:
-    source: https://git.netfilter.org/libmnl
-    # XXX: git.netfilter.org does not support depth/shallow clones
-    #source-depth: 1
-    source-tag: libmnl-1.0.5
-    source-type: git
+    # XXX: Netfilter's git repo is unreliable
+    source: https://www.netfilter.org/projects/libmnl/files/libmnl-1.0.5.tar.bz2
+    source-checksum: sha256/274b9b919ef3152bfb3da3a13c950dd60d6e2bcd54230ffeca298d03b40d0525
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=
@@ -461,11 +459,9 @@ parts:
   libnftnl:
     after:
       - libmnl
-    source: https://git.netfilter.org/libnftnl
-    # XXX: git.netfilter.org does not support depth/shallow clones
-    #source-depth: 1
-    source-tag: libnftnl-1.2.6
-    source-type: git
+    # XXX: Netfilter's git repo is unreliable
+    source: https://www.netfilter.org/projects/libnftnl/files/libnftnl-1.2.6.tar.xz
+    source-checksum: sha256/ceeaea2cd92147da19f13a35a7f1a4bc2767ff897e838e4b479cf54b59c777f4
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=


### PR DESCRIPTION
As netfilter's git repo service is unreliable.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>
(cherry picked from commit 03a4fcc2f768d832ef1493a183f6c04720dc9928) (cherry picked from commit 8f7062f79f2f66c53de37bc7f40679d812208409)