### PR TITLE
Invoke virt-v2v-in-place on host

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1547,6 +1547,7 @@ parts:
         -not -path "${CRAFT_PRIME}/bin/remote-viewer" \
         -not -path "${CRAFT_PRIME}/bin/snap-query" \
         -not -path "${CRAFT_PRIME}/bin/sshfs" \
+        -not -path "${CRAFT_PRIME}/bin/virt-v2v-in-place" \
         -not -path "${CRAFT_PRIME}/bin/xfs_admin" \
         -not -path "${CRAFT_PRIME}/bin/uefivars.py" \
         -not -path "${CRAFT_PRIME}/bin/lxcfs" \
@@ -1603,3 +1604,4 @@ parts:
       wrappers/editor: bin/
       wrappers/remote-viewer: bin/
       wrappers/sshfs: bin/
+      wrappers/virt-v2v-in-place: bin/

--- a/snapcraft/wrappers/virt-v2v-in-place
+++ b/snapcraft/wrappers/virt-v2v-in-place
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+CMD="virt-v2v-in-place"
+
+unset XDG_RUNTIME_DIR
+unset LD_LIBRARY_PATH
+
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+if [ "$(id -u)" = "0" ]; then
+    exec nsenter -t 1 -m "${CMD}" "$@"
+fi
+
+exec unshare -U -r --root="/var/lib/snapd/hostfs/" "${CMD}" "$@"


### PR DESCRIPTION
This is required for virt-v2v-in-place to be invoked on the host.

Requires: https://github.com/canonical/lxd/pull/13748