### PR TITLE
snapcraft: add `rust-channel` to virtiofsd rust part

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1062,6 +1062,7 @@ parts:
     source-tag: v1.10.1
     source-type: git
     plugin: rust
+    rust-channel: stable
     build-packages:
       - cargo
       - libseccomp-dev


### PR DESCRIPTION
While the upstream [doc doesn't mention it](https://snapcraft.io/docs/rust-plugin#heading--core22), rust parts need to define the expected channel to avoid this error (non-fatal) that we had previously:

```
$  snapcraft
...
error: rustup could not choose a version of rustc to run, because one wasn't specified explicitly, and no default is configured.
help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.
```

Since this `rust-channel` option is said to be valid for `core18` so maybe it's just a doc bug. Either way, adding this option makes the error go away.