### PR TITLE
snapcraft: make (dis)connect-plug-qemu-external privileged

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -179,6 +179,14 @@ hooks:
     plugs:
       - lxd-support
       - system-observe
+  connect-plug-qemu-external:
+    plugs:
+      - lxd-support
+      - system-observe
+  disconnect-plug-qemu-external:
+    plugs:
+      - lxd-support
+      - system-observe
   configure:
     plugs:
       - lxd-support


### PR DESCRIPTION
Everything was working locally, likely because I was using --devmode. But for LXD installed from store we need to explicitly give necessary privileged to these hooks.