### PR TITLE
Misc backports (5.21-edge)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,13 @@ updates:
     labels: []
     schedule:
       interval: "weekly"
+    target-branch: "5.21-edge"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels: []
+    schedule:
+      interval: "weekly"
     target-branch: "5.0-edge"
 
   - package-ecosystem: "github-actions"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1287,6 +1287,7 @@ parts:
 
   lxcfs:
     source: https://github.com/lxc/lxcfs
+    source-branch: stable-6.0
     source-depth: 1
     source-type: git
     build-packages:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1041,6 +1041,7 @@ parts:
     source-tag: v1.10.1
     source-type: git
     plugin: rust
+    rust-channel: stable
     build-packages:
       - cargo
       - libseccomp-dev


### PR DESCRIPTION
Those were found to be missing (not yet backported) while working on the backports for `5.0-edge`.