### PR TITLE
snapcraft: use stable-6.0 branch of `lxc` part (5.21-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1231,6 +1231,7 @@ parts:
   # Core components
   lxc:
     source: https://github.com/lxc/lxc
+    source-branch: stable-6.0
     source-depth: 1
     source-type: git
     build-packages:


### PR DESCRIPTION
I quickly glanced at [the changes](https://github.com/lxc/lxc/compare/stable-6.0...main) and `LXC_DEVEL=0` caught my attention. There are quite a few commits from @mihalicyn we'd lose though, so maybe we should wait for 6.0.2?
