### PR TITLE
snapcraft: drop nasm part and use the package from core24

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -357,8 +357,6 @@ parts:
       #- lib/*/liblz4.so*  # use liblz4.so from the base snap
 
   edk2:
-    after:
-      - nasm
     source: https://github.com/tianocore/edk2
     source-depth: 1
     source-tag: IRRELEVANT
@@ -368,10 +366,12 @@ parts:
       - on amd64:
         - g++
         - acpica-tools
+        - nasm
         - uuid-dev
       - on arm64:
         - g++
         - acpica-tools
+        - nasm
         - uuid-dev
     override-prime: |-
       [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
@@ -612,28 +612,6 @@ parts:
       - lib/*/libdevmapper*
       - lib/*/liblvm*
       - lib/*/libreadline.so*
-
-  nasm:
-    source: https://github.com/netwide-assembler/nasm
-    source-depth: 1
-    source-tag: nasm-2.16.03
-    source-type: git
-    plugin: autotools
-    autotools-configure-parameters:
-      - --prefix=
-    organize:
-      usr/bin/: bin/
-    override-prime:
-      # no need to prime anything as the nasm binary is only used by edk2
-      # and is not needed in the final snap artifact
-      exit 0
-    override-pull: |-
-      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
-      craftctl default
-    override-build: |
-      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
-      patch -p1 < "${CRAFT_PROJECT_DIR}/patches/nasm-0000-disable-manpages.patch"
-      craftctl default
 
   nftables:
     after:


### PR DESCRIPTION
core24 ships with nasm 2.16.01 which should be recent enough to build edk2.