### PR TITLE
lxd-ui: update source-commit hash (5.21-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1502,7 +1502,7 @@ parts:
     source: https://github.com/canonical/lxd-ui
     source-depth: 1
     source-type: git
-    source-commit: 9e7d0b0964f1b1f4b8cfe3410272696111a8bdc4 # 0.8.3
+    source-commit: 0662dae0750c5e23fe560a3e0fe39db039ea237e # 0.8.3
     plugin: nil
     override-prime: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
include migration.stateful and security.nesting configuration options for containers and VMs (tag 0.8.3 was updated for this)