### PR TITLE
lxd-ui: Bump to 0.12 (latest-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1463,7 +1463,7 @@ parts:
     source: https://github.com/canonical/lxd-ui
     source-depth: 1
     source-type: git
-    source-commit: 4fca29a49ad01af516f441d17c701305b40db1da # 0.11
+    source-commit: 4ab1839a557f8458a531c243ec14b245d64fe7c8 # 0.12
     plugin: nil
     override-prime: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
* include recent fixes, see https://github.com/canonical/lxd-ui/releases/tag/0.12 for changes