### PR TITLE
snapcraft/commands: Fix check for first execution during daemon start

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -709,6 +709,12 @@ if [ "${daemon_verbose:-"false"}" = "true" ]; then
     CMD="${CMD} --verbose"
 fi
 
+# Check if this is the first time LXD is started.
+FIRSTRUN="false"
+if [ ! -d "${SNAP_COMMON}/lxd/database" ]; then
+    FIRSTRUN="true"
+fi
+
 # We deal with errors ourselves from this point on
 set +e
 
@@ -754,12 +760,11 @@ if [ "${RET}" -gt "0" ]; then
     exit 1
 fi
 
-## Check if this is the first time LXD is started
-if [ ! -d "${SNAP_COMMON}/lxd/database" ]; then
+## Process preseed if present
+if [ "${FIRSTRUN}" = "true" ]; then
     set -e
     echo "=> First LXD execution on this system"
 
-    ## Process preseed if present
     if [ -e "${SNAP_COMMON}/init.yaml" ]; then
         echo "==> Running LXD preseed file"
         ${LXD} init --preseed < "${SNAP_COMMON}/init.yaml"


### PR DESCRIPTION
This PR adjusts the point at which we check if it is the first lxd start in `daemon.start`. We are currently making this check after we begin the process of starting lxd, which means the check will always fail. This PR ensures we make the check before we start lxd.

Fixes  https://github.com/canonical/lxd/issues/13818.

