### PR TITLE
snapcraft: add apparmor part (latest-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1187,14 +1187,51 @@ parts:
       - bin/pzstd
       - bin/zstd
 
+  apparmor:
+    source: https://gitlab.com/apparmor/apparmor.git
+    source-commit: 84a6bc1b6dcdfeabb1ed3597f01e314f3bcee5c1 # v4.0.2
+    source-depth: 1
+    source-type: git
+    plugin: autotools
+    build-packages:
+      - g++
+      - bison
+      - flex
+      - autoconf-archive
+      - gettext
+    override-build: |-
+      set -ex
+
+      cd ./libraries/libapparmor
+      sh ./autogen.sh
+      sh ./configure --prefix=/
+      make
+      make install
+
+      cd ../../parser
+      make
+      make install
+
+      mkdir "${CRAFT_PART_INSTALL}/bin"
+      cp /sbin/apparmor_parser "${CRAFT_PART_INSTALL}/bin/"
+      mkdir "${CRAFT_PART_INSTALL}/lib"
+      cp /lib/libapparmor.so* "${CRAFT_PART_INSTALL}/lib/"
+
+      set +ex
+    prime:
+      - bin/apparmor_parser
+      - lib/libapparmor.so.1
+      - lib/libapparmor.so.1.*
+
   # Core components
   lxc:
+    after:
+      - apparmor
     source: https://github.com/lxc/lxc
     source-depth: 1
     source-type: git
     build-packages:
       - dpkg-dev
-      - libapparmor-dev
       - libcap-dev
       - libdbus-1-dev
       - libgnutls28-dev


### PR DESCRIPTION
Let's ship newer version of AppArmor with support of new features. Only needed for core22. But we will use with core24 based series for consistency.

Also bumped apparmor to v4.0.2.


(cherry picked from commit 8591ed414b4dab7d045ccb344eb914d07f67b93f)

Related to https://github.com/canonical/lxd/issues/13810