### PR TITLE
Invoke virt-v2v-in-place on host (5.21-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1496,6 +1496,7 @@ parts:
         -not -path "${CRAFT_PRIME}/bin/remote-viewer" \
         -not -path "${CRAFT_PRIME}/bin/snap-query" \
         -not -path "${CRAFT_PRIME}/bin/sshfs" \
+        -not -path "${CRAFT_PRIME}/bin/virt-v2v-in-place" \
         -not -path "${CRAFT_PRIME}/bin/xfs_admin" \
         -not -path "${CRAFT_PRIME}/bin/uefivars.py" \
         -exec strip -s {} +
@@ -1550,3 +1551,4 @@ parts:
       wrappers/editor: bin/
       wrappers/remote-viewer: bin/
       wrappers/sshfs: bin/
+      wrappers/virt-v2v-in-place: bin/

--- a/snapcraft/wrappers/virt-v2v-in-place
+++ b/snapcraft/wrappers/virt-v2v-in-place
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+CMD="virt-v2v-in-place"
+
+unset XDG_RUNTIME_DIR
+unset LD_LIBRARY_PATH
+
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+if [ "$(id -u)" = "0" ]; then
+    exec nsenter -t 1 -m "${CMD}" "$@"
+fi
+
+exec unshare -U -r --root="/var/lib/snapd/hostfs/" "${CMD}" "$@"


### PR DESCRIPTION
From https://github.com/canonical/lxd-pkg-snap/pull/510

This is required for conversion option `virtio` which failed the tests for 5.21-edge in https://github.com/canonical/lxd-ci/pull/274.