### PR TITLE
snapcraft/commands: Link the pro command to the run-host wrapper.

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -227,6 +227,9 @@ fi
 # Redirect getent to the host
 ln -s "${SNAP}/wrappers/run-host" "/run/bin/getent"
 
+# Redirect pro to the host
+ln -s "${SNAP}/wrappers/run-host" "/run/bin/pro"
+
 # Avoid xtables talking to nft
 ln -s "${SNAP}/bin/arptables-legacy" "/run/bin/arptables"
 ln -s "${SNAP}/bin/ebtables-legacy" "/run/bin/ebtables"


### PR DESCRIPTION
This command is used for retrieving tokens for guests. `pro` will never be packaged inside the snap, so always link it.