### PR TITLE
snapcraft: update QEMU to 1:8.2.2+ds-0ubuntu1.2

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -818,7 +818,7 @@ parts:
       - spice-server
     source: https://git.launchpad.net/ubuntu/+source/qemu
     source-depth: 1
-    source-tag: import/1%8.2.2+ds-0ubuntu1
+    source-tag: import/1%8.2.2+ds-0ubuntu1.2
     source-type: git
     plugin: autotools
     autotools-configure-parameters:


### PR DESCRIPTION
https://launchpad.net/ubuntu/+source/qemu/1:8.2.2+ds-0ubuntu1.2:

```
qemu (1:8.2.2+ds-0ubuntu1.2) noble-security; urgency=medium

  * SECURITY UPDATE: buffer overflow
    - debian/patches/CVE-2024-26327.patch: Check num_vfs size
    - CVE-2024-26327
  * SECURITY UPDATE: out of bounds memory access
    - debian/patches/CVE-2024-26328.patch: Use pcie_sriov_num_vfs to
      get number of enabled vfs before and after config writes
    - CVE-2024-26328

 -- Bruce Cable <bruce.cable@canonical.com>  Wed, 21 Aug 2024 11:53:08 +1000
```