### PR TITLE
snapcraft: Add support for cobra bash completions

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1448,7 +1448,7 @@ parts:
 
       # Setup bash completion
       mkdir -p "${CRAFT_PART_INSTALL}/etc/bash_completion.d/"
-      cp scripts/bash/lxd-client "${CRAFT_PART_INSTALL}/etc/bash_completion.d/snap.lxd.lxc"
+      "${CRAFT_PART_INSTALL}/bin/lxc" completion bash > "${CRAFT_PART_INSTALL}/etc/bash_completion.d/snap.lxd.lxc"
     organize:
       usr/bin/: bin/
       usr/lib/: lib/


### PR DESCRIPTION
Cobra completions introduced in https://github.com/canonical/lxd/pull/13959, making bash completions obsolete.