### PR TITLE
QEMU: disable unneeded options

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -833,6 +833,7 @@ parts:
       - --disable-fuse
       - --disable-glusterfs
       - --disable-gnutls
+      - --disable-gtk
       - --disable-guest-agent
       - --disable-parallels
       - --disable-pvrdma

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -825,6 +825,7 @@ parts:
     autotools-configure-parameters:
       - --disable-auth-pam
       - --disable-bochs
+      - --disable-brlapi
       - --disable-cloop
       - --disable-dmg
       - --disable-docs

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -843,6 +843,7 @@ parts:
       - --disable-parallels
       - --disable-pvrdma
       - --disable-qed
+      - --disable-sdl
       - --disable-slirp
       - --disable-user
       - --disable-vdi

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -849,6 +849,7 @@ parts:
       - --disable-user
       - --disable-vde
       - --disable-vdi
+      - --disable-vmnet
       - --disable-vnc
       - --disable-xen
       - --disable-xkbcommon

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -839,6 +839,7 @@ parts:
       - --disable-libnfs
       - --disable-libpmem
       - --disable-libssh
+      - --disable-nettle
       - --disable-parallels
       - --disable-pvrdma
       - --disable-qed

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -840,6 +840,7 @@ parts:
       - --disable-libpmem
       - --disable-libssh
       - --disable-nettle
+      - --disable-oss
       - --disable-parallels
       - --disable-pvrdma
       - --disable-qed

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -830,6 +830,7 @@ parts:
       - --disable-curl
       - --disable-dmg
       - --disable-docs
+      - --disable-fuse
       - --disable-guest-agent
       - --disable-parallels
       - --disable-pvrdma

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -831,6 +831,7 @@ parts:
       - --disable-dmg
       - --disable-docs
       - --disable-fuse
+      - --disable-glusterfs
       - --disable-guest-agent
       - --disable-parallels
       - --disable-pvrdma

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -837,6 +837,7 @@ parts:
       - --disable-guest-agent
       - --disable-libiscsi
       - --disable-libnfs
+      - --disable-libpmem
       - --disable-parallels
       - --disable-pvrdma
       - --disable-qed

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -851,6 +851,7 @@ parts:
       - --disable-vdi
       - --disable-vmnet
       - --disable-vnc
+      - --disable-vvfat
       - --disable-xen
       - --disable-xkbcommon
       - --enable-attr

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -847,6 +847,7 @@ parts:
       - --disable-sdl
       - --disable-slirp
       - --disable-user
+      - --disable-vde
       - --disable-vdi
       - --disable-vnc
       - --disable-xen

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -823,6 +823,7 @@ parts:
     source-type: git
     plugin: autotools
     autotools-configure-parameters:
+      - --disable-auth-pam
       - --disable-bochs
       - --disable-cloop
       - --disable-dmg

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -832,6 +832,7 @@ parts:
       - --disable-docs
       - --disable-fuse
       - --disable-glusterfs
+      - --disable-gnutls
       - --disable-guest-agent
       - --disable-parallels
       - --disable-pvrdma

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -838,6 +838,7 @@ parts:
       - --disable-libiscsi
       - --disable-libnfs
       - --disable-libpmem
+      - --disable-libssh
       - --disable-parallels
       - --disable-pvrdma
       - --disable-qed

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -836,6 +836,7 @@ parts:
       - --disable-gtk
       - --disable-guest-agent
       - --disable-libiscsi
+      - --disable-libnfs
       - --disable-parallels
       - --disable-pvrdma
       - --disable-qed

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -835,6 +835,7 @@ parts:
       - --disable-gnutls
       - --disable-gtk
       - --disable-guest-agent
+      - --disable-libiscsi
       - --disable-parallels
       - --disable-pvrdma
       - --disable-qed

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -827,6 +827,7 @@ parts:
       - --disable-bochs
       - --disable-brlapi
       - --disable-cloop
+      - --disable-curl
       - --disable-dmg
       - --disable-docs
       - --disable-guest-agent


### PR DESCRIPTION
The list of options was obtained by running the following in a git clone of QEMU's source:

```
$ . scripts/meson-buildoptions.sh
$ meson_options_help
  --audio-drv-list=CHOICES Set audio driver list [default] (choices: alsa/co
                           reaudio/default/dsound/jack/oss/pa/pipewire/sdl/s
                           ndio)
  --bindir=VALUE           Executable directory [bin]
  --block-drv-ro-whitelist=VALUE
                           set block driver read-only whitelist (by default
                           affects only QEMU, not tools like qemu-img)
  --block-drv-rw-whitelist=VALUE
                           set block driver read-write whitelist (by default
                           affects only QEMU, not tools like qemu-img)
  --datadir=VALUE          Data file directory [share]
  --disable-coroutine-pool coroutine freelist (better performance)
  --disable-debug-info     Enable debug symbols and other information
  --disable-hexagon-idef-parser
                           use idef-parser to automatically generate TCG
                           code for the Hexagon frontend
  --disable-install-blobs  install provided firmware blobs
  --disable-qom-cast-debug cast debugging support
  --disable-relocatable    toggle relocatable install
  --docdir=VALUE           Base directory for documentation installation
                           (can be empty) [share/doc]
  --enable-block-drv-whitelist-in-tools
                           use block whitelist also in tools instead of only
                           QEMU
  --enable-cfi             Control-Flow Integrity (CFI)
  --enable-cfi-debug       Verbose errors in case of CFI violation
  --enable-debug-graph-lock
                           graph lock debugging support
  --enable-debug-mutex     mutex debugging support
  --enable-debug-stack-usage
                           measure coroutine stack usage
  --enable-debug-tcg       TCG debugging
  --enable-fdt[=CHOICE]    Whether and how to find the libfdt library
                           (choices: auto/disabled/enabled/internal/system)
  --enable-fuzzing         build fuzzing targets
  --enable-gcov            Enable coverage tracking.
  --enable-lto             Use link time optimization
  --enable-malloc=CHOICE   choose memory allocator to use [system] (choices:
                           jemalloc/system/tcmalloc)
  --enable-module-upgrades try to load modules from alternate paths for
                           upgrades
  --enable-rng-none        dummy RNG, avoid using /dev/(u)random and
                           getrandom()
  --enable-safe-stack      SafeStack Stack Smash Protection (requires
                           clang/llvm and coroutine backend ucontext)
  --enable-sanitizers      enable default sanitizers
  --enable-strip           Strip targets on install
  --enable-tcg-interpreter TCG with bytecode interpreter (slow)
  --enable-trace-backends=CHOICES
                           Set available tracing backends [log] (choices:
                           dtrace/ftrace/log/nop/simple/syslog/ust)
  --enable-tsan            enable thread sanitizer
  --firmwarepath=VALUES    search PATH for firmware files [share/qemu-
                           firmware]
  --iasl=VALUE             Path to ACPI disassembler
  --includedir=VALUE       Header file directory [include]
  --interp-prefix=VALUE    where to find shared libraries etc., use %M for
                           cpu name [/usr/gnemul/qemu-%M]
  --libdir=VALUE           Library directory [system default]
  --libexecdir=VALUE       Library executable directory [libexec]
  --localedir=VALUE        Locale data directory [share/locale]
  --localstatedir=VALUE    Localstate data directory [/var/local]
  --mandir=VALUE           Manual page directory [share/man]
  --prefix=VALUE           Installation prefix [/usr/local]
  --qemu-ga-distro=VALUE   second path element in qemu-ga registry entries
                           [Linux]
  --qemu-ga-manufacturer=VALUE
                           "manufacturer" name for qemu-ga registry entries
                           [QEMU]
  --qemu-ga-version=VALUE  version number for qemu-ga installer
  --smbd=VALUE             Path to smbd for slirp networking
  --sysconfdir=VALUE       Sysconf data directory [etc]
  --tls-priority=VALUE     Default TLS protocol/cipher priority string
                           [NORMAL]
  --with-coroutine=CHOICE  coroutine backend to use (choices:
                           auto/sigaltstack/ucontext/windows)
  --with-pkgversion=VALUE  use specified string as sub-version of the
                           package
  --with-suffix=VALUE      Suffix for QEMU data/modules/config directories
                           (can be empty) [qemu]
  --with-trace-file=VALUE  Trace file prefix for simple backend [trace]

Optional features, enabled with --enable-FEATURE and
disabled with --disable-FEATURE, default is enabled if available
(unless built with --without-default-features):

  af-xdp          AF_XDP network backend support
  alsa            ALSA sound support
  attr            attr/xattr support
  auth-pam        PAM access control
  avx2            AVX2 optimizations
  avx512bw        AVX512BW optimizations
  avx512f         AVX512F optimizations
  blkio           libblkio block device driver
  bochs           bochs image format support
  bpf             eBPF support
  brlapi          brlapi character device driver
  bzip2           bzip2 support for DMG images
  canokey         CanoKey support
  cap-ng          cap_ng support
  capstone        Whether and how to find the capstone library
  cloop           cloop image format support
  cocoa           Cocoa user interface (macOS only)
  colo-proxy      colo-proxy support
  coreaudio       CoreAudio sound support
  crypto-afalg    Linux AF_ALG crypto backend driver
  curl            CURL block device driver
  curses          curses UI
  dbus-display    -display dbus support
  dmg             dmg image format support
  docs            Documentations build support
  dsound          DirectSound sound support
  fuse            FUSE block device export
  fuse-lseek      SEEK_HOLE/SEEK_DATA support for FUSE exports
  gcrypt          libgcrypt cryptography support
  gettext         Localization of the GTK+ user interface
  gio             use libgio for D-Bus support
  glusterfs       Glusterfs block device driver
  gnutls          GNUTLS cryptography support
  gtk             GTK+ user interface
  gtk-clipboard   clipboard support for the gtk UI (EXPERIMENTAL, MAY HANG)
  guest-agent     Build QEMU Guest Agent
  guest-agent-msi Build MSI package for the QEMU Guest Agent
  hv-balloon      hv-balloon driver (requires Glib 2.68+ GTree API)
  hvf             HVF acceleration support
  iconv           Font glyph conversion support
  jack            JACK sound support
  keyring         Linux keyring support
  kvm             KVM acceleration support
  l2tpv3          l2tpv3 network backend support
  libdaxctl       libdaxctl support
  libdw           debuginfo support
  libiscsi        libiscsi userspace initiator
  libkeyutils     Linux keyutils support
  libnfs          libnfs block device driver
  libpmem         libpmem support
  libssh          ssh block device support
  libudev         Use libudev to enumerate host devices
  libusb          libusb support for USB passthrough
  libvduse        build VDUSE Library
  linux-aio       Linux AIO support
  linux-io-uring  Linux io_uring support
  live-block-migration
                  block migration in the main migration stream
  lzfse           lzfse support for DMG images
  lzo             lzo compression support
  malloc-trim     enable libc malloc_trim() for memory optimization
  membarrier      membarrier system call (for Linux 4.14+ or Windows
  modules         modules support (non Windows)
  mpath           Multipath persistent reservation passthrough
  multiprocess    Out of process device emulation support
  netmap          netmap network backend support
  nettle          nettle cryptography support
  numa            libnuma support
  nvmm            NVMM acceleration support
  opengl          OpenGL support
  oss             OSS sound support
  pa              PulseAudio sound support
  parallels       parallels image format support
  pipewire        PipeWire sound support
  pixman          pixman support
  plugins         TCG plugins via shared library loading
  png             PNG support with libpng
  pvrdma          Enable PVRDMA support
  qcow1           qcow1 image format support
  qed             qed image format support
  qga-vss         build QGA VSS support (broken with MinGW)
  rbd             Ceph block device driver
  rdma            Enable RDMA-based migration
  replication     replication support
  rutabaga-gfx    rutabaga_gfx support
  sdl             SDL user interface
  sdl-image       SDL Image support for icons
  seccomp         seccomp support
  selinux         SELinux support in qemu-nbd
  slirp           libslirp user mode network backend support
  slirp-smbd      use smbd (at path --smbd=*) in slirp networking
  smartcard       CA smartcard emulation support
  snappy          snappy compression support
  sndio           sndio sound support
  sparse          sparse checker
  spice           Spice server support
  spice-protocol  Spice protocol support
  stack-protector compiler-provided stack protection
  tcg             TCG support
  tools           build support utilities that come with QEMU
  tpm             TPM support
  u2f             U2F emulation support
  usb-redir       libusbredir support
  vde             vde network backend support
  vdi             vdi image format support
  vduse-blk-export
                  VDUSE block export support
  vfio-user-server
                  vfio-user server support
  vhdx            vhdx image format support
  vhost-crypto    vhost-user crypto backend support
  vhost-kernel    vhost kernel backend support
  vhost-net       vhost-net kernel acceleration support
  vhost-user      vhost-user backend support
  vhost-user-blk-server
                  build vhost-user-blk server
  vhost-vdpa      vhost-vdpa kernel backend support
  virglrenderer   virgl rendering support
  virtfs          virtio-9p support
  virtfs-proxy-helper
                  virtio-9p proxy helper support
  vmdk            vmdk image format support
  vmnet           vmnet.framework network backend support
  vnc             VNC server
  vnc-jpeg        JPEG lossy compression for VNC server
  vnc-sasl        SASL authentication for VNC server
  vpc             vpc image format support
  vte             vte support for the gtk UI
  vvfat           vvfat image format support
  werror          Treat warnings as errors
  whpx            WHPX acceleration support
  xen             Xen backend support
  xen-pci-passthrough
                  Xen PCI passthrough support
  xkbcommon       xkbcommon support
  zstd            zstd compression support
```

Note: `--disable-tcg` is still not possible as the `qemu-ovmf-secureboot` part still depends on it as before (https://github.com/canonical/lxd-pkg-snap/pull/454#discussion_r1591849373).