### PR TITLE
Commit pinning and version bump

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -702,7 +702,7 @@ parts:
     after:
       - openvswitch
     source: https://github.com/ovn-org/ovn
-    source-commit: 41836afafd99d579bb277f638a31bffd5cf3efa3 # v24.03.2
+    source-commit: 459a3bab4c4a11b904aa3c37015372d34e1e1209 # v24.03.3
     source-depth: 1
     source-type: git
     plugin: autotools

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -678,7 +678,7 @@ parts:
 
   openvswitch:
     source: https://github.com/openvswitch/ovs
-    source-commit: 2b87b844dbedeb2582920634205b52f1eea7c0b7 # v3.3.1
+    source-commit: dfe601bbc154c836e6ec3526a1eb331c1c09a06e # v3.3.2
     source-depth: 1
     source-type: git
     plugin: autotools

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -598,8 +598,9 @@ parts:
 
   nvidia-container:
     source: https://github.com/NVIDIA/libnvidia-container
-    source-commit: d2eb0afe86f0b643e33624ee64f065dd60e952d4 # v1.14.6
+    # XXX: fails to build if using source-commit
     source-depth: 1
+    source-tag: v1.16.1
     source-type: git
     plugin: make
     build-packages:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1411,7 +1411,7 @@ parts:
       ln -s "$(pwd)" "${GOPATH}/src/github.com/canonical/lxd"
 
       # Download the dependencies
-      go get -d -v ./...
+      go get -v ./...
     override-build: |
       set -ex
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -783,7 +783,7 @@ parts:
     after:
       - libtpms
     source: https://github.com/stefanberger/swtpm
-    source-commit: 507d14219dde88eb3eb2d10d15872d4044aa9d3e # v0.8.2
+    source-commit: f756ee8a281ddff7e09b49e1ef00d5cbb42abb63 # v0.9.0
     source-depth: 1
     source-type: git
     plugin: autotools

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1145,7 +1145,7 @@ parts:
 
   zfs-2-2:
     source: https://github.com/openzfs/zfs
-    source-commit: 2566592045780e7be7afc899c2496b1ae3af4f4d # zfs-2.2.4
+    source-commit: baa50314567afd986a00838f0fa65fdacbd12daf # zfs-2.2.6
     source-depth: 1
     source-type: git
     plugin: autotools

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1034,7 +1034,7 @@ parts:
 
   virtiofsd:
     source: https://gitlab.com/virtio-fs/virtiofsd
-    source-commit: 3988b7304ceb2fdb4eed2c8bf8682e6ea19c4ecc # v1.10.1
+    source-commit: d20f4d698c14ada07ea9ff5cb7050c2c4703ff66 # v1.11.1
     source-depth: 1
     source-type: git
     plugin: rust

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -287,8 +287,8 @@ parts:
 
   criu:
     source: https://github.com/checkpoint-restore/criu
+    source-commit: f8b14286b092853a4485813e1efd564109df9123 # v3.19
     #source-depth: 1
-    source-tag: v3.19
     source-type: git
     plugin: nil
     build-packages:
@@ -492,8 +492,8 @@ parts:
 
   libtpms:
     source: https://github.com/stefanberger/libtpms
+    source-commit: f8c2dc7e12a730dcca4220d7ac5ad86d13dfd630 # v0.9.6
     source-depth: 1
-    source-tag: v0.9.6
     source-type: git
     plugin: autotools
     autotools-configure-parameters:
@@ -507,8 +507,8 @@ parts:
 
   liburing:
     source: https://github.com/axboe/liburing
+    source-commit: f4e42a515cd78c8c9cac2be14222834be5f8df2b # liburing-2.5
     source-depth: 1
-    source-tag: liburing-2.5
     source-type: git
     plugin: autotools
     autotools-configure-parameters:
@@ -529,8 +529,8 @@ parts:
 
   libusb:
     source: https://github.com/libusb/libusb
+    source-commit: d52e355daa09f17ce64819122cb067b8a2ee0d4b # v1.0.27
     source-depth: 1
-    source-tag: v1.0.27
     source-type: git
     plugin: autotools
     autotools-configure-parameters:
@@ -598,8 +598,8 @@ parts:
 
   nvidia-container:
     source: https://github.com/NVIDIA/libnvidia-container
+    source-commit: d2eb0afe86f0b643e33624ee64f065dd60e952d4 # v1.14.6
     source-depth: 1
-    source-tag: v1.14.6
     source-type: git
     plugin: make
     build-packages:
@@ -677,8 +677,8 @@ parts:
 
   openvswitch:
     source: https://github.com/openvswitch/ovs
+    source-commit: 2b87b844dbedeb2582920634205b52f1eea7c0b7 # v3.3.1
     source-depth: 1
-    source-tag: v3.3.1
     source-type: git
     plugin: autotools
     autotools-configure-parameters:
@@ -701,8 +701,8 @@ parts:
     after:
       - openvswitch
     source: https://github.com/ovn-org/ovn
+    source-commit: 41836afafd99d579bb277f638a31bffd5cf3efa3 # v24.03.2
     source-depth: 1
-    source-tag: v24.03.2
     source-type: git
     plugin: autotools
     autotools-configure-parameters:
@@ -715,8 +715,8 @@ parts:
 
   spice-protocol:
     source: https://gitlab.freedesktop.org/spice/spice-protocol
+    source-commit: 6f453a775d87087c6ba59fc180c1a1e466631a47 # v0.14.4
     source-depth: 1
-    source-tag: v0.14.4
     source-type: git
     plugin: meson
     prime: []
@@ -737,8 +737,8 @@ parts:
     after:
       - spice-protocol
     source: https://gitlab.freedesktop.org/spice/spice
+    source-commit: 0c2c1413a8b387ea597a95b6c867470a7c56c8ab # v0.15.2
     source-depth: 1
-    source-tag: v0.15.2
     source-type: git
     plugin: meson
     meson-parameters:
@@ -781,8 +781,8 @@ parts:
     after:
       - libtpms
     source: https://github.com/stefanberger/swtpm
+    source-commit: 507d14219dde88eb3eb2d10d15872d4044aa9d3e # v0.8.2
     source-depth: 1
-    source-tag: v0.8.2
     source-type: git
     plugin: autotools
     autotools-configure-parameters:
@@ -818,8 +818,8 @@ parts:
       - spice-protocol
       - spice-server
     source: https://git.launchpad.net/ubuntu/+source/qemu
+    source-commit: 7689f1b03bf4b055ef0c96cbece55e0a0c20c725 # import/1%8.2.2+ds-0ubuntu1.2
     source-depth: 1
-    source-tag: import/1%8.2.2+ds-0ubuntu1.2
     source-type: git
     plugin: autotools
     autotools-configure-parameters:
@@ -1003,8 +1003,8 @@ parts:
 
   sqlite:
     source: https://github.com/sqlite/sqlite
+    source-commit: 189e44dfecdc7868bb860dfb5d98eab371318c37 # version-3.45.1
     source-depth: 1
-    source-tag: version-3.45.1
     source-type: git
     plugin: autotools
     autotools-configure-parameters:
@@ -1017,8 +1017,8 @@ parts:
 
   squashfs-tools-ng:
     source: https://github.com/AgentD/squashfs-tools-ng
+    source-commit: 8f9966c8ea3ea8a854941d041e7fcb9eb4f772fb # v1.3.1
     source-depth: 1
-    source-tag: v1.3.1
     source-type: git
     plugin: autotools
     autotools-configure-parameters:
@@ -1032,8 +1032,8 @@ parts:
 
   virtiofsd:
     source: https://gitlab.com/virtio-fs/virtiofsd
+    source-commit: 3988b7304ceb2fdb4eed2c8bf8682e6ea19c4ecc # v1.10.1
     source-depth: 1
-    source-tag: v1.10.1
     source-type: git
     plugin: rust
     rust-channel: stable
@@ -1108,8 +1108,8 @@ parts:
 
   zfs-2-1:
     source: https://github.com/openzfs/zfs
+    source-commit: fb6d532066f23458f768a97ae94b158c42cbe484 # zfs-2.1.15
     source-depth: 1
-    source-tag: zfs-2.1.15
     source-type: git
     plugin: autotools
     autotools-configure-parameters:
@@ -1143,8 +1143,8 @@ parts:
 
   zfs-2-2:
     source: https://github.com/openzfs/zfs
+    source-commit: 2566592045780e7be7afc899c2496b1ae3af4f4d # zfs-2.2.4
     source-depth: 1
-    source-tag: zfs-2.2.4
     source-type: git
     plugin: autotools
     autotools-configure-parameters:
@@ -1340,8 +1340,8 @@ parts:
       - qemu-ovmf-secureboot
       - nftables
     source: https://github.com/awslabs/python-uefivars
+    source-commit: 9679002a4392d8e7831d2dbda3fab41ccc5c6b8c # v1.0.0
     source-depth: 1
-    source-tag: v1.0.0
     source-type: git
     plugin: python
     override-prime: |-

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1192,7 +1192,7 @@ parts:
 
   apparmor:
     source: https://gitlab.com/apparmor/apparmor.git
-    source-commit: 84a6bc1b6dcdfeabb1ed3597f01e314f3bcee5c1 # v4.0.2
+    source-commit: b4dfdf50f50ed1d64161424d036a2453645f0cfe # v4.0.3
     source-depth: 1
     source-type: git
     plugin: autotools

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1342,7 +1342,7 @@ parts:
       - qemu-ovmf-secureboot
       - nftables
     source: https://github.com/awslabs/python-uefivars
-    source-commit: 9679002a4392d8e7831d2dbda3fab41ccc5c6b8c # v1.0.0
+    source-commit: ec1eab1717c65ea36ca7160c96fe0e10e071fb66 # v1.2
     source-depth: 1
     source-type: git
     plugin: python

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1358,7 +1358,7 @@ parts:
     organize:
       lib/python3.12/site-packages/: lib/python3/dist-packages/
     prime:
-      - bin/uefivars.py
+      - bin/uefivars
       - lib/python3/dist-packages/google_crc32c*
       - lib/python3/dist-packages/pyuefivars*
 
@@ -1583,7 +1583,7 @@ parts:
         -not -path "${CRAFT_PRIME}/bin/sshfs" \
         -not -path "${CRAFT_PRIME}/bin/virt-v2v-in-place" \
         -not -path "${CRAFT_PRIME}/bin/xfs_admin" \
-        -not -path "${CRAFT_PRIME}/bin/uefivars.py" \
+        -not -path "${CRAFT_PRIME}/bin/uefivars" \
         -not -path "${CRAFT_PRIME}/bin/lxcfs" \
         -not -path "${CRAFT_PRIME}/bin/gpu-2404-custom-wrapper" \
         -exec strip -s {} +

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1005,7 +1005,7 @@ parts:
 
   sqlite:
     source: https://github.com/sqlite/sqlite
-    source-commit: 189e44dfecdc7868bb860dfb5d98eab371318c37 # version-3.45.1
+    source-commit: f3d536d37825302e31ed0eddd811c689f38f85a3 # version-3.46.1
     source-depth: 1
     source-type: git
     plugin: autotools

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -738,7 +738,8 @@ parts:
       - spice-protocol
     source: https://gitlab.freedesktop.org/spice/spice
     source-commit: 0c2c1413a8b387ea597a95b6c867470a7c56c8ab # v0.15.2
-    source-depth: 1
+    # XXX: source-depth does not work with submodules
+    #source-depth: 1
     source-type: git
     plugin: meson
     meson-parameters:


### PR DESCRIPTION
`source-commit` is used wherever possible. The one exception is for the `nvidia-container` part that otherwise fails for a mysterious reason (see commit message for what was tried).