### PR TITLE
snapcraft: remove sqlite part, use pkg instead

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -335,8 +335,6 @@ parts:
       - lib/*/libproto*
 
   dqlite:
-    after:
-      - sqlite
     source: https://github.com/canonical/dqlite
     source-depth: 1
     source-type: git
@@ -347,13 +345,18 @@ parts:
     stage-packages:
       - liblz4-1
       - libuv1t64
+      - sqlite3
     build-packages:
       - liblz4-dev
+      - libsqlite3-dev
       - libuv1-dev
     organize:
+      usr/bin/: bin/
       usr/lib/: lib/
     prime:
+      - bin/sqlite3
       - lib/libdqlite*so*
+      - lib/*/libsqlite3*so*
       - lib/*/libuv*
       #- lib/*/liblz4.so*  # use liblz4.so from the base snap
 
@@ -983,20 +986,6 @@ parts:
     prime:
       - share/qemu/*
 
-  sqlite:
-    source: https://github.com/sqlite/sqlite
-    source-commit: f3d536d37825302e31ed0eddd811c689f38f85a3 # version-3.46.1
-    source-depth: 1
-    source-type: git
-    plugin: autotools
-    autotools-configure-parameters:
-      - --prefix=
-    build-packages:
-      - tcl
-    prime:
-      - bin/sqlite3
-      - lib/libsqlite3*so*
-
   squashfs-tools-ng:
     source: https://github.com/AgentD/squashfs-tools-ng
     source-commit: 8f9966c8ea3ea8a854941d041e7fcb9eb4f772fb # v1.3.1
@@ -1350,7 +1339,6 @@ parts:
     after:
       - lxc
       - dqlite
-      - sqlite
     build-packages:
       - cmake
       - libacl1-dev
@@ -1526,7 +1514,6 @@ parts:
       - ovn
       - qemu-ovmf-secureboot
       - spice-server
-      - sqlite
       - squashfs-tools-ng
       - swtpm
       - virtiofsd


### PR DESCRIPTION
The relevant sqlite3 bits are now primed in the dqlite part.