### PR TITLE
lxd: Build lxd-user as static binary

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1399,8 +1399,10 @@ parts:
       # Build the binaries
       go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/lxc" github.com/canonical/lxd/lxc
       go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/lxd" -tags=libsqlite3 github.com/canonical/lxd/lxd
+
+      # Build static binaries
       CGO_ENABLED=0 go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/lxd-agent" -tags=agent,netgo github.com/canonical/lxd/lxd-agent
-      go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/lxd-user" github.com/canonical/lxd/lxd-user
+      CGO_ENABLED=0 go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/lxd-user" -tags netgo github.com/canonical/lxd/lxd-user
 
       # Some python dependencies are not available for riscv64 or just require a build from source.
       # Not worth the effort for now.


### PR DESCRIPTION
This is in preparation for it being used as a container stop hook helper to allow it to be called across snap base changes without depending in libs from the core snaps.