### PR TITLE
lxd-ui: bump to 0.13 (latest-candidate) 

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1463,7 +1463,7 @@ parts:
     source: https://github.com/canonical/lxd-ui
     source-depth: 1
     source-type: git
-    source-commit: 4ab1839a557f8458a531c243ec14b245d64fe7c8 # 0.12
+    source-commit: 14d17a0941ec10c862e8a64bcdfc05e06268d3a6 # 0.13
     plugin: nil
     override-prime: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
* include recent changes in preparation of 6.2, see https://github.com/canonical/lxd-ui/releases/tag/0.13 for changes