### PR TITLE
lxd-ui: bump to 0.8.4 (5.21-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1502,7 +1502,7 @@ parts:
     source: https://github.com/canonical/lxd-ui
     source-depth: 1
     source-type: git
-    source-commit: 0662dae0750c5e23fe560a3e0fe39db039ea237e # 0.8.3
+    source-commit: 7583096c386421a135b730a7ddfa74c3bd7859db # 0.8.4
     plugin: nil
     override-prime: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
* include any recent fixes in preparation of 5.21.3, see https://github.com/canonical/lxd-ui/releases/tag/0.8.4 for changes