### PR TITLE
make apparmor.unprivileged-restrictions-disable=false by default

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -31,7 +31,7 @@ description: |-
 
  Supported configuration options for the snap (snap set lxd [<key>=<value>...]):
 
-   - apparmor.unprivileged-restrictions-disable: Whether to disable restrictions on unprivileged user namespaces [default=true]
+   - apparmor.unprivileged-restrictions-disable: Whether to disable restrictions on unprivileged user namespaces [default=false]
    - ceph.builtin: Use snap-specific Ceph configuration [default=false]
    - ceph.external: Use the system's ceph tools (ignores ceph.builtin) [default=false]
    - criu.enable: Enable experimental live-migration support [default=false]

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -489,7 +489,7 @@ if [ "$(stat -c '%u' /proc)" = 0 ]; then
         fi
     fi
 
-    if [ "${apparmor_unprivileged_restrictions_disable:-"true"}" = "true" ]; then
+    if [ "${apparmor_unprivileged_restrictions_disable:-"false"}" = "true" ]; then
         if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
             if [ "$(cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" = "1" ]; then
                 echo "==> Disabling Apparmor unprivileged userns mediation"

--- a/snapcraft/hooks/configure
+++ b/snapcraft/hooks/configure
@@ -71,7 +71,7 @@ config="${SNAP_COMMON}/config"
 
 cat << EOC > "${config}"
 # This file is auto-generated, do NOT manually edit
-apparmor_unprivileged_restrictions_disable=${apparmor_unprivileged_restrictions_disable:-"true"}
+apparmor_unprivileged_restrictions_disable=${apparmor_unprivileged_restrictions_disable:-"false"}
 ceph_builtin=${ceph_builtin:-"false"}
 ceph_external=${ceph_external:-"false"}
 criu_enable=${criu_enable:-"false"}


### PR DESCRIPTION
Since we have prepared ourselves by enabling unconfined profile for LXD snap we can stop disabling unprivileged user namespace restrictions.

This depends on:
- snapcraft.yaml: enable unconfined mode in lxd-support interface
- snapcraft/{hooks,commands}: handle new AppArmor unconfined profile mode