### PR TITLE
snapcraft: enable support for gpu-2404 plug with nvidia-container-cli

### DIFF
--- a/snapcraft/wrappers/nvidia-container-cli
+++ b/snapcraft/wrappers/nvidia-container-cli
@@ -1,4 +1,18 @@
 #!/bin/sh
 
-# Set the root path
-exec nvidia-container-cli.real -r /var/lib/snapd/hostfs/ "$@"
+#
+# This is a bit hacky, as we rely on a library names but at the moment,
+# we don't have any way to distinguish generic mesa-2404 snap from
+# mesa-2404 snap with NVIDIA drivers connected to it. (At least, I don't know one.)
+# Let's do this like that for now at least for PoC purpose.
+#
+if snapctl is-connected gpu-2404 &&
+   [ -f "${SNAP}/gpu-2404-2/usr/lib/x86_64-linux-gnu/libnvidia-ml.so" ] &&
+   [ -f "${SNAP}/gpu-2404-2/usr/lib/x86_64-linux-gnu/libcuda.so" ];
+then
+    # We have NVIDIA drivers snap connected, let's use it
+    exec nvidia-container-cli.real "$@"
+else
+    # Set the root path to use NVIDIA libraries from the host
+    exec nvidia-container-cli.real -r /var/lib/snapd/hostfs/ "$@"
+fi


### PR DESCRIPTION
Completely reworked successor of https://github.com/canonical/lxd-pkg-snap/pull/485 (please read it too, as Gabriel posted many important technical details in there)