### PR TITLE
snapcraft: Add `libsystemd-dev` dependency for LXD

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1348,6 +1348,7 @@ parts:
       - libblas-dev
       - libopenblas-dev
       - liblapack-dev
+      - libsystemd-dev
       - pkg-config
       - pypy3-dev
       - python3-dev
@@ -1362,6 +1363,7 @@ parts:
       - gdisk
       - iw
       - lshw
+      - libsystemd0
       - pci.ids
       - pigz
       - rsync


### PR DESCRIPTION
Required before https://github.com/canonical/lxd/pull/14327

* LXD requires `libsystemd-dev` at build time to allow `go-systemd` to be built.
* `libsystemd.so` is also needed at runtime hence why `libsystemd0` is added as a staged package (`-dev` package is intended for development purposes and includes files that are unnecessary (and potentially problematic) at runtime). The resulting `libsystemd.so` included in the snap communicates over D-Bus to interact with systemd. As long as the communication paths are accessible (via the `log-observe` interface), LXD can read the host's systemd.