### PR TITLE
lxd-ui: Use source-depth 1 to avoid checking out full history (5.0-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1464,6 +1464,7 @@ parts:
 
   lxd-ui:
     source: https://github.com/canonical/lxd-ui
+    source-depth: 1
     source-type: git
     source-tag: "0.5"
     plugin: nil


### PR DESCRIPTION
There's something large in the lxd-ui history that is filling up the LP builder's 100GB quota.