### PR TITLE
snapcraft: use non-shallow clone for nvidia-container (5.0-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -582,9 +582,10 @@ parts:
     after:
       - libseccomp
     source: https://github.com/NVIDIA/libnvidia-container
-    source-type: git
     source-commit: 4c2494f16573b585788a42e9c7bee76ecd48c73d # v1.16.1
-    source-depth: 1
+    # XXX: fails to build if using source-commit and source-depth
+    #source-depth: 1
+    source-type: git
     plugin: make
     build-packages:
       - bmake


### PR DESCRIPTION
Signed-off-by: Simon Deziel <simon.deziel@canonical.com>
(cherry picked from commit 3780d4b155d1481c2545f890c42e82b54d074beb) (cherry picked from commit a2321a4bca15f6d24c4bbc8f763abb4c435c499b)