### PR TITLE
Snap tweaks

### DIFF
--- a/snapcraft/commands/daemon.reload
+++ b/snapcraft/commands/daemon.reload
@@ -11,4 +11,4 @@ fi
 
 echo reload > "${SNAP_COMMON}/state"
 read -r PID < "${SNAP_COMMON}/lxd.pid"
-kill "$PID"
+exec kill "$PID"

--- a/snapcraft/commands/lxc
+++ b/snapcraft/commands/lxc
@@ -11,13 +11,6 @@ if [ -z "${SNAP_REAL_HOME:-""}" ]; then
     fi
 fi
 
-# Migrate data if needed
-if [ ! -d "${SNAP_USER_COMMON}/config" ]; then
-    if [ -d "${SNAP_REAL_HOME}/.config/lxc" ]; then
-        cp -r "${SNAP_REAL_HOME}/.config/lxc" "${SNAP_USER_COMMON}/config" || true
-    fi
-fi
-
 # Set the environment
 if [ -z "${LXD_DIR:-""}" ]; then
     export LXD_DIR="${SNAP_COMMON}/lxd/"

--- a/snapcraft/commands/lxc
+++ b/snapcraft/commands/lxc
@@ -1,14 +1,6 @@
 #!/bin/sh
 set -eu
 
-# Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(while read -r l; do echo "$l"; done < /proc/self/attr/current)"
-  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
-    exec /usr/bin/aa-exec -p unconfined -- "$0" "$@"
-  fi
-fi
-
 # Fill SNAP_REAL_HOME if missing
 if [ -z "${SNAP_REAL_HOME:-""}" ]; then
     SNAP_REAL_HOME="${HOME}"
@@ -54,6 +46,14 @@ export PATH="/run/bin:${PATH}"
 LXC="${SNAP}/bin/lxc"
 if [ -x "${SNAP_COMMON}/lxc.debug" ]; then
     LXC="${SNAP_COMMON}/lxc.debug"
+fi
+
+# Run lxc itself outside of apparmor confinement
+if [ -d /sys/kernel/security/apparmor ]; then
+  label="$(while read -r l; do echo "$l"; done < /proc/self/attr/current)"
+  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+    exec /usr/bin/aa-exec -p unconfined -- "${LXC}" "$@"
+  fi
 fi
 
 # Run lxc itself

--- a/snapcraft/commands/lxc
+++ b/snapcraft/commands/lxc
@@ -16,8 +16,6 @@ if [ ! -d "${SNAP_USER_COMMON}/config" ]; then
     if [ -d "${SNAP_REAL_HOME}/.config/lxc" ]; then
         cp -r "${SNAP_REAL_HOME}/.config/lxc" "${SNAP_USER_COMMON}/config" || true
     fi
-
-    mkdir -p "${SNAP_USER_COMMON}/config"
 fi
 
 # Set the environment
@@ -30,6 +28,7 @@ if [ -z "${LXD_DIR:-""}" ]; then
 fi
 
 export LXD_CONF="${SNAP_USER_COMMON}/config"
+[ -d "${LXD_CONF}" ] || mkdir -p "${LXD_CONF}"
 export LXD_GLOBAL_CONF="${LXD_GLOBAL_CONF:-"${SNAP_COMMON}/global-conf/"}"
 
 # Use editor wrapper

--- a/snapcraft/commands/lxc
+++ b/snapcraft/commands/lxc
@@ -42,10 +42,7 @@ fi
 
 # Run lxc itself outside of apparmor confinement
 if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(while read -r l; do echo "$l"; done < /proc/self/attr/current)"
-  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
-    exec /usr/bin/aa-exec -p unconfined -- "${LXC}" "$@"
-  fi
+  exec /usr/bin/aa-exec -p unconfined -- "${LXC}" "$@"
 fi
 
 # Run lxc itself


### PR DESCRIPTION
This slightly reduces the overhead of the `lxc` command. In this rough benchmark, `lxc help >/dev/null` is used as it is self-contained (makes no API call).

Baseline:

```
$ timeout 30 bash -c 'i=0; trap "echo \$i" EXIT; while i=$((i+1)); do lxc help >/dev/null; done'
598
```

PR changes applied:

```
$ sudo mount -o bind,ro snapcraft/commands/lxc /snap/lxd/current/commands/lxc
$ timeout 30 bash -c 'i=0; trap "echo \$i" EXIT; while i=$((i+1)); do lxc help >/dev/null; done'
620
```

This is a meager improvement (~3.5%) but it moves the needle in the right direction. From ~19.93 execs/second to ~20.67 execs/second.

For comparison's sake, here's what I get from a simple **non-snap** binary (~1192 execs/second):

```
$ timeout 30 bash -c 'i=0; trap "echo \$i" EXIT; while i=$((i+1)); do /usr/bin/echo foo >/dev/null; done'
35767
```