### PR TITLE
lxd-qemu-snap: use GitHub mirror for qemu repository

### DIFF
--- a/lxd-qemu-snap/snapcraft.yaml
+++ b/lxd-qemu-snap/snapcraft.yaml
@@ -69,8 +69,8 @@ parts:
   qemu:
     after:
       - virgl
-    source: https://gitlab.com/qemu-project/qemu.git
-    source-tag: v9.0.1
+    source: https://github.com/qemu/qemu.git
+    source-tag: v9.0.3
     source-depth: 1
     plugin: autotools
     autotools-configure-parameters:


### PR DESCRIPTION
And also bump version from v9.0.1 to v9.0.3