### PR TITLE
snapcraft: edk2: fix subhook submodule url

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -394,7 +394,8 @@ parts:
       git config user.name "LXD snap builder"
 
       # Fix submodules
-      sed -i "s#https://git.cryptomilk.org/projects/cmocka#https://gitlab.com/cmocka/cmocka#g" .gitmodules
+      # see https://github.com/tianocore/edk2/commit/95d8a1c255cfb8e063d679930d08ca6426eb5701
+      sed -i "s#https://github.com/Zeex/subhook.git#https://github.com/tianocore/edk2-subhook.git#g" .gitmodules
       git submodule update --init --recursive
 
       # Apply patches


### PR DESCRIPTION
Also, we don't need cmocka submodule url fixup anymore as: https://github.com/tianocore/edk2/commit/2ad22420a710dc07e3b644f91a5b55c09c39ecf3

Suggested-by: Thomas Parrott <thomas.parrott@canonical.com>