### PR TITLE
Rework how lvm.conf is patched

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -563,6 +563,7 @@ parts:
       - -bin/lvmetad
       - -bin/lvmpolld
       - etc/lvm/lvm.conf
+      - etc/lvm/profile/*
       - lib/*/device-mapper/*
       - lib/*/libaio.so*
       - lib/*/libdevmapper*

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -550,9 +550,14 @@ parts:
       usr/sbin/: bin/
     override-build: |-
       # Patch lvm.conf
+      # lvm.conf changes for lvm2 from 22.04/core22
       sed -i \
         -e "s%\(# \)\?obtain_device_list_from_udev = 1%obtain_device_list_from_udev = 0%" \
         -e "s%\(# \)\?cache_file_prefix = \"\"%cache_file_prefix = \"lxd\"%" \
+        "${CRAFT_PART_INSTALL}/etc/lvm/lvm.conf"
+
+      # Generic lvm.conf changes
+      sed -i \
         -e "s%\(# \)\?udev_sync = 1%udev_sync = 0%" \
         -e "s%\(# \)\?udev_rules = 1%udev_rules = 0%" \
         -e "s%\(# \)\?use_lvmetad = 1%use_lvmetad = 0%" \

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -550,13 +550,6 @@ parts:
       usr/sbin/: bin/
     override-build: |-
       # Patch lvm.conf
-      # lvm.conf changes for lvm2 from 22.04/core22
-      sed -i \
-        -e "s%\(# \)\?obtain_device_list_from_udev = 1%obtain_device_list_from_udev = 0%" \
-        -e "s%\(# \)\?cache_file_prefix = \"\"%cache_file_prefix = \"lxd\"%" \
-        "${CRAFT_PART_INSTALL}/etc/lvm/lvm.conf"
-
-      # Generic lvm.conf changes
       sed -i \
         -e "s%\(# \)\?udev_sync = 1%udev_sync = 0%" \
         -e "s%\(# \)\?udev_rules = 1%udev_rules = 0%" \

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -548,6 +548,20 @@ parts:
       sbin/: bin/
       usr/lib/: lib/
       usr/sbin/: bin/
+    override-build: |-
+      # Patch lvm.conf
+      sed -i \
+        -e "s%\(# \)\?obtain_device_list_from_udev = 1%obtain_device_list_from_udev = 0%" \
+        -e "s%\(# \)\?cache_file_prefix = \"\"%cache_file_prefix = \"lxd\"%" \
+        -e "s%\(# \)\?udev_sync = 1%udev_sync = 0%" \
+        -e "s%\(# \)\?udev_rules = 1%udev_rules = 0%" \
+        -e "s%\(# \)\?use_lvmetad = 1%use_lvmetad = 0%" \
+        -e "s%\(# \)\?monitoring = 1%monitoring = 0%" \
+        -e "/# .*_\?executable =/s/# //" \
+        -e "s%\(/usr\)\?/s\?bin/%/snap/lxd/current/bin/%" \
+        "${CRAFT_PART_INSTALL}/etc/lvm/lvm.conf"
+
+      craftctl default
     prime:
       - bin/cache_*
       - bin/dmeventd

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -343,9 +343,8 @@ sed \
     -e "s%\(# \)\?udev_rules = 1%udev_rules = 0%" \
     -e "s%\(# \)\?use_lvmetad = 1%use_lvmetad = 0%" \
     -e "s%\(# \)\?monitoring = 1%monitoring = 0%" \
-    -e "s%# executable = \"/s\?bin/dmeventd\"%executable = \"${SNAP}/bin/dmeventd\"%" \
-    -e "/# .*_executable =/s/# //" \
-    -e "s%/usr/s\?bin/%${SNAP}/bin/%" \
+    -e "/# .*_\?executable =/s/# //" \
+    -e "s%\(/usr\)\?/s\?bin/%${SNAP}/bin/%" \
     "${SNAP}/etc/lvm/lvm.conf" > /etc/lvm/lvm.conf
 
 # Setup for OVN

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -334,18 +334,16 @@ else
 fi
 
 # Setup for LVM
-echo "==> Setting up LVM configuration"
-mkdir -p /etc/lvm/
-sed \
-    -e "s%\(# \)\?obtain_device_list_from_udev = 1%obtain_device_list_from_udev = 0%" \
-    -e "s%\(# \)\?cache_file_prefix = \"\"%cache_file_prefix = \"lxd\"%" \
-    -e "s%\(# \)\?udev_sync = 1%udev_sync = 0%" \
-    -e "s%\(# \)\?udev_rules = 1%udev_rules = 0%" \
-    -e "s%\(# \)\?use_lvmetad = 1%use_lvmetad = 0%" \
-    -e "s%\(# \)\?monitoring = 1%monitoring = 0%" \
-    -e "/# .*_\?executable =/s/# //" \
-    -e "s%\(/usr\)\?/s\?bin/%${SNAP}/bin/%" \
-    "${SNAP}/etc/lvm/lvm.conf" > /etc/lvm/lvm.conf
+if [ "${lvm_external:-"false"}" = "false" ]; then
+    echo "==> Setting up LVM configuration"
+    # XXX: the directory ${SNAP}/etc/lvm cannot be symlink'ed as LVM tools try
+    # to create /etc/lvm/{archive,backup} dirs which is not possible as ${SNAP}
+    # is read-only.
+    mkdir -p /etc/lvm
+    ln -sf "${SNAP}/etc/lvm/lvm.conf" /etc/lvm/
+    # the /etc/lvm/profile dir is however only read from so a symlink is OK
+    ln -sf "${SNAP}/etc/lvm/profile" /etc/lvm/
+fi
 
 # Setup for OVN
 echo "==> Setting up OVN configuration"


### PR DESCRIPTION
Another attempt at fixing https://github.com/canonical/lxd/issues/14341

This changes how `lvm.conf` is patched to be done at build time rather than at `daemon.start` time. This implies that now, executables are using `/snap/lxd/current` instead of `/snap/lxd/${rev}`. `/etc/lvm/profile` files are now included in the snap. It's unclear if they are used or not but they are so small (11KiB) that it doesn't hurt to ship them.

Lastly, the daemon visible `/etc/lvm` dir now contains 2 symlinks pointing to the read-only snap mount while still allowing the creation of the `/etc/lvm/archive` and `/etc/lvm/backup` directories backed by the `tmpfs` `/etc`:

```
# LD_LIBRARY_PATH=/snap/lxd/current/lib/:/snap/lxd/current/lib/x86_64-linux-gnu/:/snap/lxd/current/zfs-2.2/lib PATH=/snap/lxd/current/zfs-2.2/bin:/snap/lxd/current/bin:$PATH nsenter --mount=/run/snapd/ns/lxd.mnt -- ls -l /etc/lvm
total 0
drwx------ 2 root root 1860 Nov 14 19:54 archive
drwx------ 2 root root   40 Nov 14 19:54 backup
lrwxrwxrwx 1 root root   29 Nov 14 19:43 lvm.conf -> /snap/lxd/x1/etc/lvm/lvm.conf
lrwxrwxrwx 1 root root   28 Nov 14 19:43 profile -> /snap/lxd/x1/etc/lvm/profile
```
