### PR TITLE
snapcraft: qemu: Don't download submodules (5.0-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -819,11 +819,6 @@ parts:
     override-pull: |-
       [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "ppc64le" ] && [ "$(uname -m)" != "s390x" ] && exit 0
       craftctl default
-
-      set -ex
-
-      # Pull submodules after switching to source-commit
-      git submodule update --init --recursive
     override-build: |-
       [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "ppc64le" ] && [ "$(uname -m)" != "s390x" ] && exit 0
       set -ex


### PR DESCRIPTION
As was observed in 5.0-candidate, we do not need to download submodules for qemu build due to the pre-built firmwares being available in the repo.

The difference between 5.0-candidate and 5.0-edge is that 5.0-edge is on core22 and uses source-commit, which then defaults to downloading the submodules (and henced failed when one of the submodules was broken).

Now we are using `source-submodules: []` to prevent snapcraft from download submodules we do not need to manually download them either.