### PR TITLE
Vendor apparmor (5.0-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1227,8 +1227,8 @@ parts:
 
   apparmor:
     source: https://gitlab.com/apparmor/apparmor.git
+    source-commit: 84a6bc1b6dcdfeabb1ed3597f01e314f3bcee5c1 # v4.0.2
     source-depth: 1
-    source-tag: v4.0.1
     source-type: git
     plugin: autotools
     build-packages:
@@ -1265,8 +1265,8 @@ parts:
   lxc:
     build-attributes: [core22-step-dependencies]
     after:
-      - libseccomp
       - apparmor
+      - libseccomp
     source: https://github.com/lxc/lxc
     source-type: git
     source-commit: cb8e38aca27a23964941f0f011a8919aab8bebab # lxc-5.0.3

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1225,16 +1225,52 @@ parts:
       - bin/pzstd
       - bin/zstd
 
+  apparmor:
+    source: https://gitlab.com/apparmor/apparmor.git
+    source-depth: 1
+    source-tag: v4.0.1
+    source-type: git
+    plugin: autotools
+    build-packages:
+      - g++
+      - bison
+      - flex
+      - autoconf-archive
+      - gettext
+    override-build: |-
+      set -ex
+
+      cd ./libraries/libapparmor
+      sh ./autogen.sh
+      sh ./configure --prefix=/
+      make
+      make install
+
+      cd ../../parser
+      make
+      make install
+
+      mkdir "${CRAFT_PART_INSTALL}/bin"
+      cp /sbin/apparmor_parser "${CRAFT_PART_INSTALL}/bin/"
+      mkdir "${CRAFT_PART_INSTALL}/lib"
+      cp /lib/libapparmor.so* "${CRAFT_PART_INSTALL}/lib/"
+
+      set +ex
+    prime:
+      - bin/apparmor_parser
+      - lib/libapparmor.so.1
+      - lib/libapparmor.so.1.*
+
   # Core components
   lxc:
     build-attributes: [core22-step-dependencies]
     after:
       - libseccomp
+      - apparmor
     source: https://github.com/lxc/lxc
     source-type: git
     source-commit: cb8e38aca27a23964941f0f011a8919aab8bebab # lxc-5.0.3
     build-packages:
-      - libapparmor-dev
       - libcap-dev
       - libdbus-1-dev
       - libgnutls28-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1226,6 +1226,7 @@ parts:
       - bin/zstd
 
   apparmor:
+    build-attributes: [core22-step-dependencies]
     source: https://gitlab.com/apparmor/apparmor.git
     source-commit: 84a6bc1b6dcdfeabb1ed3597f01e314f3bcee5c1 # v4.0.2
     source-depth: 1
@@ -1250,10 +1251,10 @@ parts:
       make
       make install
 
-      mkdir "${CRAFT_PART_INSTALL}/bin"
-      cp /sbin/apparmor_parser "${CRAFT_PART_INSTALL}/bin/"
-      mkdir "${CRAFT_PART_INSTALL}/lib"
-      cp /lib/libapparmor.so* "${CRAFT_PART_INSTALL}/lib/"
+      mkdir "${SNAPCRAFT_PART_INSTALL}/bin"
+      cp /sbin/apparmor_parser "${SNAPCRAFT_PART_INSTALL}/bin/"
+      mkdir "${SNAPCRAFT_PART_INSTALL}/lib"
+      cp /lib/libapparmor.so* "${SNAPCRAFT_PART_INSTALL}/lib/"
 
       set +ex
     prime:


### PR DESCRIPTION
This is required to take advantage of the improved apparmor rules in LXD that enables running Oracular containers.