### PR TITLE
snapcraft: nvidia-container: Enable shallow clone (5.0-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -582,10 +582,11 @@ parts:
       - libseccomp
     source: https://github.com/NVIDIA/libnvidia-container
     source-commit: 4c2494f16573b585788a42e9c7bee76ecd48c73d # v1.16.1
-    # XXX: fails to build if using source-commit and source-depth
-    #source-depth: 1
+    source-depth: 1
     source-type: git
     plugin: make
+    build-environment:
+      - GIT_TAG: "1.16.1" # Enables source-depth: 1, should match git tag without "v" prefix.
     build-packages:
       - bmake
       - curl


### PR DESCRIPTION
To reduce the size of the git repo clone (~2GB) which is causing failures on riscv64.