### PR TITLE
snapcraft: nvidia-container: Enable shallow clone (5.0-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -570,10 +570,11 @@ parts:
       - libseccomp
     source: https://github.com/NVIDIA/libnvidia-container
     source-commit: 4c2494f16573b585788a42e9c7bee76ecd48c73d # v1.16.1
-    # XXX: fails to build if using source-commit and source-depth
-    #source-depth: 1
+    source-depth: 1
     source-type: git
     plugin: make
+    build-environment:
+      - GIT_TAG: "1.16.1" # Enables source-depth: 1, should match git tag without "v" prefix.
     build-packages:
       - bmake
       - curl


### PR DESCRIPTION
To reduce the size of the git repo clone (~2GB) which is causing failures on riscv64.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>
(cherry picked from commit 4503d12af52741f3bf73317314de4044925cf9a7)