### PR TITLE
nvidia-container updates (5.21-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -640,10 +640,12 @@ parts:
 
   nvidia-container:
     source: https://github.com/NVIDIA/libnvidia-container
+    source-commit: 4c2494f16573b585788a42e9c7bee76ecd48c73d # v1.16.1
     source-depth: 1
-    source-tag: v1.14.6
     source-type: git
     plugin: make
+    build-environment:
+      - GIT_TAG: "1.16.1" # Enables source-depth: 1, should match git tag without "v" prefix.
     build-packages:
       - bmake
       - curl


### PR DESCRIPTION
To reduce the size of the git repo clone (~2GB) which is causing failures on riscv64.

And bump to 1.16.1.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>
(cherry picked from commit 4503d12af52741f3bf73317314de4044925cf9a7) (cherry picked from commit 5c9aee86cb162393daa8a382d8f3ec2826c38425) (cherry picked from commit 83b567db8648b0a27b08ec503917aee0c96f3a9e)