### PR TITLE
snapcraft: nvidia-container: Enable shallow clone and fix edk2 submodules (4.0-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -249,14 +249,13 @@ parts:
       set -ex
       git clone https://github.com/tianocore/edk2 . -b edk2-stable202208
 
+      # Pull submodules after switching to source-commit
+      git submodule update --init --recursive
+
       git config user.email "noreply@lists.canonical.com"
       git config user.name "LXD snap builder"
     override-build: |-
       [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
-
-      # Fix submodules
-      sed -i "s#https://git.cryptomilk.org/projects/cmocka#https://gitlab.com/cmocka/cmocka#g" .gitmodules
-      git submodule update --init --recursive
 
       # Apply patches
       patch -p1 < "${SNAPCRAFT_PROJECT_DIR}/patches/edk2-0001-force-DUID-LLT.patch"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -492,10 +492,12 @@ parts:
     after:
       - libseccomp
     source: https://github.com/NVIDIA/libnvidia-container
-    source-type: git
-    source-tag: v1.11.0
+    source-commit: c8f267be0bac1c654d59ad4ea5df907141149977 # v1.11.0
     source-depth: 1
+    source-type: git
     plugin: make
+    build-environment:
+      - GIT_TAG: "1.11.0" # Enables source-depth: 1, should match git tag without "v" prefix.
     build-packages:
       - bmake
       - curl


### PR DESCRIPTION
To reduce the size of the git repo clone (~2GB) which is causing failures on riscv64.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>
(cherry picked from commit 4503d12af52741f3bf73317314de4044925cf9a7)
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>
(cherry picked from commit a73fe9974c1230c34b053666452cd2486e20fba7)