### PR TITLE
Remove dependency on `uuidgen`

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -686,8 +686,6 @@ parts:
     autotools-configure-parameters:
       - --enable-ssl
       - --prefix=
-    stage-packages:
-      - uuid-runtime
     organize:
       sbin/: bin/
       usr/bin/: bin/
@@ -696,7 +694,6 @@ parts:
       - bin/ovs-vsctl
       - bin/ovs-vswitchd
       - bin/ovsdb-*
-      - bin/uuidgen
       - share/openvswitch/
 
   ovn:

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -544,6 +544,11 @@ if [ "${openvswitch_builtin:-"false"}" = "true" ]; then
         export OVS_SBINDIR="${SNAP}/bin/"
 
         mkdir -p "${OVS_SYSCONFDIR}/openvswitch"
+        OVS_SYSTEM_ID_FILE="${OVS_SYSCONFDIR}/openvswitch/system-id.conf"
+        if ! [ -s "${OVS_SYSTEM_ID_FILE}" ]; then
+            systemd-id128 new --uuid > "${OVS_SYSTEM_ID_FILE}"
+        fi
+
         (
             # Close socket activation fd
             exec 3<&- || true


### PR DESCRIPTION
`ovs-ctl` uses `uuidgen` only on the first startup when there is no `system-id.conf` file. After the first startup, the freshly created UUID is saved into that file for later use.

By generating the exact same kind and format of UUID ahead of time using `systemd-id128` (readily available from core base), we can remove that dependency on `uuidgen`.