### PR TITLE
snapcraft: hardcode support for compopt to fix bash completion

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1442,8 +1442,8 @@ parts:
       mkdir -p "${CRAFT_PART_INSTALL}/etc/bash_completion.d/"
       # Snapd requires the unaliased command `lxd.lxc` to be supplied as the first command for completion to be detected
       set_cmds='s/^\s*complete.*__start_lxc /&lxd.lxc /'
-      # When executed by Snapd, the COLUMNS shell value is unset, so use $(tput cols) instead
-      set_cols='s/COLUMNS/$(tput cols)/'
+      # When executed by snapd, the COLUMNS shell value is unset, so use $(tput cols) instead
+      set_cols='s/# $COLUMNS.*/COLUMN="$(tput cols)"  \# store the current shell width./'
       # When executed by snapd, the `compopt` support detection doesn't work so fake that it is always `builtin`
       set_compopt='s|$(type -t compopt)|"builtin"|'
       # Modify requestComp variable to use lxc based on context ($SNAP/bin/lxc in Snap environment)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1444,10 +1444,12 @@ parts:
       set_cmds='s/^\s*complete.*__start_lxc /&lxd.lxc /'
       # When executed by Snapd, the COLUMNS shell value is unset, so use $(tput cols) instead
       set_cols='s/COLUMNS/$(tput cols)/'
+      # When executed by snapd, the `compopt` support detection doesn't work so fake that it is always `builtin`
+      set_compopt='s|$(type -t compopt)|"builtin"|'
       # Modify requestComp variable to use lxc based on context ($SNAP/bin/lxc in Snap environment)
       set_request_comp='s|requestComp="${words\[0\]} __complete ${args\[\*\]}"|requestComp="/snap/lxd/current/bin/lxc __complete ${args[*]}"|'
       # Generate completions script
-      "${CRAFT_PART_INSTALL}/bin/lxc" completion bash | sed -e "${set_cmds}" -e "${set_cols}" -e "${set_request_comp}" > "${CRAFT_PART_INSTALL}/etc/bash_completion.d/snap.lxd.lxc"
+      "${CRAFT_PART_INSTALL}/bin/lxc" completion bash | sed -e "${set_cmds}" -e "${set_cols}" -e "${set_compopt}" -e "${set_request_comp}" > "${CRAFT_PART_INSTALL}/etc/bash_completion.d/snap.lxd.lxc"
     organize:
       usr/bin/: bin/
       usr/lib/: lib/


### PR DESCRIPTION
@kadinsayani found that when executed by snapd, the `compopt` support detection was broken.