### PR TITLE
lxd-ui: bump to 0.8.5, include fix for cephfs backed storage pools (5.21-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1556,7 +1556,7 @@ parts:
     source: https://github.com/canonical/lxd-ui
     source-depth: 1
     source-type: git
-    source-commit: ae9d3e8236931bc73ed1a0f682518c7d841593e5 # 0.8.4
+    source-commit: 087e4e3d3c0a8b691e6d77c042672f171f7f8c29 # 0.8.5
     plugin: nil
     override-prime: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
# Done
- created new 0.8.5 tag and version for ui
- include fix for cephfs backed storage pools