### PR TITLE
lxd-ui: update 0.14 tag to include latest changes (latest-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1570,7 +1570,7 @@ parts:
     source: https://github.com/canonical/lxd-ui
     source-depth: 1
     source-type: git
-    source-commit: c23928a3b757fa7de855bc732073fdb1d59390eb # 0.14
+    source-commit: 4f5b822cddae3a31b1cee9307543e34ab9ec76c0 # 0.14
     plugin: nil
     override-prime: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
# Done
* update ui 0.14 tag to include latest changes
* including a fix for cephfs
* see https://github.com/canonical/lxd-ui/releases/tag/0.14