### PR TITLE
github: Use stable go version for triggering snap build

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed  # v5.1.0
         with:
-          go-version-file: go.mod
+          go-version: 'stable'
 
       - name: Setup Launchpad SSH access
         env:


### PR DESCRIPTION
Reverts breakage introduced by 136d7fe8472b0b96a080260a59a2758018c6cd12