### PR TITLE
commands/daemon: Redirect iscsiadm to the host

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -236,6 +236,9 @@ ln -s "${SNAP}/wrappers/run-host" "/run/bin/getent"
 # Redirect pro to the host
 ln -s "${SNAP}/wrappers/run-host" "/run/bin/pro"
 
+# Redirect iscsiadm to the host.
+ln -s "${SNAP}/wrappers/run-host" "/run/bin/iscsiadm"
+
 # Avoid xtables talking to nft
 ln -s "${SNAP}/bin/arptables-legacy" "/run/bin/arptables"
 ln -s "${SNAP}/bin/ebtables-legacy" "/run/bin/ebtables"


### PR DESCRIPTION
Redirects `iscsiadm` command to the host. Required for the upcoming PureStorage integration with iSCSI.