### PR TITLE
nftables: Switch to source tarball (5.21-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -643,11 +643,9 @@ parts:
     after:
       - libmnl
       - libnftnl
-    source: https://git.netfilter.org/nftables
-    source-commit: 49151cd0709acbfb7c6c7f35c44fc12060b695d1 # v1.0.9
-    # XXX: git.netfilter.org does not support depth/shallow clones
-    #source-depth: 1
-    source-type: git
+    # XXX: Netfilter's git repo is unreliable
+    source: https://www.netfilter.org/projects/nftables/files/nftables-1.0.9.tar.xz
+    source-checksum: sha256/a3c304cd9ba061239ee0474f9afb938a9bb99d89b960246f66f0c3a0a85e14cd
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=
@@ -659,15 +657,6 @@ parts:
       - libreadline-dev
     stage-packages:
       - libjansson4
-    override-build: |
-      set -ex
-
-      # Git cherry-picks
-      git config user.email "noreply@lists.canonical.com"
-      git config user.name "LXD snap builder"
-
-      set +ex
-      craftctl default
     organize:
       sbin/: bin/
       usr/lib/: lib/


### PR DESCRIPTION
As git repo is unreliable.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>
(cherry picked from commit 7eb76aaf8514089c7f3831daf70dfc496e987a2f)