### PR TITLE
snapcraft: lxcfs doesn't need PAM dev libs

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1295,7 +1295,6 @@ parts:
     source-type: git
     build-packages:
       - libfuse3-dev
-      - libpam0g-dev
       - pkg-config
       - python3-jinja2
       - meson


### PR DESCRIPTION
PAM dev libs are no longer needed to build lxcfs since around lxcfs 3.0.0 (https://github.com/lxc/lxcfs/pull/233/commits/398ad1b91dce2efc80b6aead57c350605e50c8b8)