### PR TITLE
snapcraft/wrappers/gpu-2404-custom-wrapper: adjust XDG_DATA_DIRS env variable

### DIFF
--- a/snapcraft/wrappers/gpu-2404-custom-wrapper
+++ b/snapcraft/wrappers/gpu-2404-custom-wrapper
@@ -5,6 +5,12 @@
 if snapctl is-connected gpu-2404
 then
     echo "INFO: the gpu-2404 interface is connected. Running with gpu-2404 wrapper."
+    #
+    # We need this to help nvidia-container-toolkit with finding of
+    # some configuration files so they can be bindmounted in the container
+    # if needed.
+    #
+    export XDG_DATA_DIRS=${XDG_DATA_DIRS:+$XDG_DATA_DIRS:}/usr/share
     exec "${SNAP}/gpu-2404/bin/gpu-2404-provider-wrapper" "$@"
 else
     echo "INFO: the gpu-2404 interface isn't connected. Skipping gpu-2404 wrapper."


### PR DESCRIPTION
We have to adjust XDG_DATA_DIRS variable to make nvidia-container-toolkit happy and find necessary configuration files. Actually, XDG_DATA_DIRS environment variable value we provided with is already correct (it's getting prepared for us in https://github.com/canonical/mesa-2404/blob/main/scripts/bin/gpu-2404-provider-wrapper.in and
https://git.launchpad.net/~canonical-kernel-snaps/canonical-kernel-snaps/+git/kernel-snaps-u24.04/tree/hooks/kernel-gpu-2404-provider-mangler?h=pc-components) but for some reason nvidia-container-toolkit library expects these path to be relative to driver root, which leads to a situation when driver root is getting appended twice to a path and files can not be found. One possible (and clean) solution would be to explicitly specify config files search path with nvcdi.WithConfigSearchPaths() but it doesn't work because of a bug https://github.com/NVIDIA/nvidia-container-toolkit/pull/847.

So the easiest way I found is to adjust XDG_DATA_DIRS variable in that weird way so when nvidia-container-toolkit prepend driverRoot to it a final path became valid and everything works.

This is to fix an issue with delivering some of the nvidia files that CDI does by default, which are the config files for things like Vulkan and EGL  The files are included in the kernels user components, so it just seems like LXD is excluding passing them through via CDI.

Please don't consider this an exhaustive list of files, necessarily, but examples are:

```
/usr/share/glvnd/egl_vendor.d/10_nvidia.json
/usr/share/glvnd/egl_vendor.d/50_mesa.json
/usr/share/vulkan/icd.d/nvidia_icd.json
/usr/share/vulkan/implicit_layer.d/nvidia_layers.json
/usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json
/usr/share/egl/egl_external_platform.d/10_nvidia_wayland.json
```