### PR TITLE
lxc: Switch edge to lxc 6.0.2 (latest-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1236,6 +1236,7 @@ parts:
     after:
       - apparmor
     source: https://github.com/lxc/lxc
+    source-commit: 2444f5841444a0a33705e2418727c23c1f167d1e # v6.0.2
     source-depth: 1
     source-type: git
     build-packages:


### PR DESCRIPTION
To confirm if there has been a regression in LXC 6.0.3

Related to https://github.com/canonical/lxd-ci/actions/runs/12762449280/job/35571011234#step:12:851

```
 + lxc exec c1 -- mkdir -p /root/dd
Error: Failed to retrieve PID of executing child process
```