### PR TITLE
lxc: Bump to lxc 6.0.3 (latest-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1236,7 +1236,7 @@ parts:
     after:
       - apparmor
     source: https://github.com/lxc/lxc
-    source-commit: 2444f5841444a0a33705e2418727c23c1f167d1e # v6.0.2
+    source-commit: fe31d844e882d5cc176a7935a93b14b4b2823992 # v6.0.3
     source-depth: 1
     source-type: git
     build-packages:


### PR DESCRIPTION
To see if the lxc exec regression is present.