### PR TITLE
qemu: restore vendored copies of Python wheels used for building (latest-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -984,6 +984,9 @@ parts:
       sed -i "s/^unset target_list$/target_list=\"${QEMUARCH}-softmmu\"/" configure
       sed -i 's#libseccomp_minver=".*#libseccomp_minver="0.0"#g' configure
 
+      # Restore vendored copies of meson and tomli Python wheels
+      git restore --source=4769f7051b0753455b775ab10c9226e149ed6237~ -- python/wheels/
+
       # Extract efi-virtio.rom from ipxe-qemu.
       # This doesn't work in the organize section below.
       mkdir -p "${CRAFT_PART_INSTALL}"/share/qemu


### PR DESCRIPTION
To get latest qemu building on latest-candidate whilst its on core22.

Signed-off-by: Simon Deziel <simon.deziel@canonical.com>
(cherry picked from commit 50cb24043e634aca8833ca7d52559a20aa9dc31d) (cherry picked from commit 7da5d20e6b20f9238de935085614e097f273a567)