### PR TITLE
ui: use node 18, as node 20 snap is incompatible with core20 (5.0-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1512,7 +1512,7 @@ parts:
       snapcraftctl pull
       set -ex
 
-      snap install node --channel=20/stable --classic || true
+      snap install node --channel=18/stable --classic || true
     override-build: |
       [ "$(uname -m)" = "riscv64" ] && exit 0
       set -ex


### PR DESCRIPTION
# Done

- ui: downgrade back to node 18, as node 20 snap is incompatible with core20 build environment
- see https://github.com/nodejs/snap/issues/54