### PR TITLE
ceph: add missing `libboots_url.so` for `denc-mod-cephfs`

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -256,6 +256,7 @@ parts:
       - lib/*/libboost_iostreams.so*
       - lib/*/libboost_program_options.so*
       - lib/*/libboost_thread.so*
+      - lib/*/libboost_url.so*
       - lib/*/libbrotlicommon.so*
       - lib/*/libbrotlidec.so*
       - lib/*/libcurl-gnutls.so*


### PR DESCRIPTION
https://launchpadlibrarian.net/772100182/buildlog_snap_ubuntu_noble_amd64_lxd-latest-edge_BUILDING.txt.gz:
```
:: + craftctl default
Packing...
Reading snap metadata...
Running linters...
Running linter: classic
Running linter: library
Lint warnings:
- library: lib/x86_64-linux-gnu/ceph/denc/denc-mod-cephfs.so: missing dependency 'libboost_url.so.1.83.0'. (https://snapcraft.io/docs/linters-library)
- library: libapparmor.so.1: unused library 'lib/libapparmor.so.1.19.0'. (https://snapcraft.io/docs/linters-library)
... many more "unused library" warnings we ignore
Creating snap package...
```

We ignore the "unused library" lint warnings but the "missing dependency" ones are indicative of real problems. In this case, `denc-mod-cephfs.so` was likely unusable. Since we haven't heard any complains it is probably only used in niche scenario (cephfs+encryption?).

The `libboost_url.so` file is rather small (323KiB) so it's best to ship it as we already ship the much bigger (~8MiB) `denc-mod-cephfs.so` file.