### PR TITLE
Revert to requiring old `snapd` and reintroduce workaround for `core24`

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: lxd
 base: core24
 assumes:
-  - snapd2.64
+  - snapd2.39
 version: git
 grade: devel
 summary: LXD - container and VM manager

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -39,6 +39,13 @@ fi
 # Detect base name
 SNAP_BASE="$(sed -n '/^name:/ s/^name:\s*\(core[0-9]\{2\}\)/\1/p' /meta/snap.yaml)"
 
+# Temporary hack to workaround systemctl reload snap.lxd.daemon
+# problem with core24-based LXD snap
+if [ "${SNAP_BASE}" = "core24" ]; then
+    _LXD_SNAP_DEVCGROUP_CONFIG="/var/lib/snapd/hostfs/var/lib/snapd/cgroup/snap.lxd.device"
+    grep -qxF 'self-managed=true' "${_LXD_SNAP_DEVCGROUP_CONFIG}" || echo 'self-managed=true' >> "${_LXD_SNAP_DEVCGROUP_CONFIG}"
+fi
+
 # Wait for appliance configuration
 if [ "${LXD_APPLIANCE}" = "true" ]; then
     while :; do


### PR DESCRIPTION
ATM, the minimum `snapd` version we can reliably require is 2.63 which is the version in the `-security` pocket of all the supported releases.

As such, we need to keep the workaround for `core24` a bit longer and wait for `-security` to get a newer `snapd` version.