### PR TITLE
Revert "lxd-ui: build with node snap from 22/stable channel (latest LTS)"

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1412,7 +1412,7 @@ parts:
     override-pull: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0
 
-      snap install node --channel=22/stable --classic
+      snap install node --channel=20/stable --classic
       craftctl default
     override-build: |
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
This reverts commit 65dda779a72dac2d35a171cd730c9e90c318ff15.

This is while waiting for https://github.com/nodejs/snap/issues/73