### PR TITLE
Revert "Revert "lxd-ui: build with node snap from 22/stable channel (…

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1412,7 +1412,7 @@ parts:
     override-pull: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0
 
-      snap install node --channel=20/stable --classic
+      snap install node --channel=22/stable --classic
       craftctl default
     override-build: |
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
…latest LTS)""

This reverts commit 928a0909cc80df8bb9995304fcd7b10f4d1d13b6.

https://launchpad.net/~openjs/+snap/node22 shows that a `ppc64el` build was made available so let's go back to using that new LTS.