### PR TITLE
Drop support for OVS/OVN on `armhf` and `riscv64`

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -648,12 +648,15 @@ parts:
       - openvswitch-switch
     override-prime: |-
       [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-pull: |-
       [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-build: |-
       [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     organize:
       sbin/: bin/

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -676,12 +676,15 @@ parts:
       - ovn-common
     override-prime: |-
       [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-pull: |-
       [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-build: |-
       [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     organize:
       usr/bin/: bin/

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -646,6 +646,15 @@ parts:
     stage-packages:
       - openvswitch-common
       - openvswitch-switch
+    override-prime: |-
+      [ "$(uname -m)" = "armv7l" ] && exit 0
+      craftctl default
+    override-pull: |-
+      [ "$(uname -m)" = "armv7l" ] && exit 0
+      craftctl default
+    override-build: |-
+      [ "$(uname -m)" = "armv7l" ] && exit 0
+      craftctl default
     organize:
       sbin/: bin/
       usr/bin/: bin/

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -671,6 +671,15 @@ parts:
     plugin: nil
     stage-packages:
       - ovn-common
+    override-prime: |-
+      [ "$(uname -m)" = "armv7l" ] && exit 0
+      craftctl default
+    override-pull: |-
+      [ "$(uname -m)" = "armv7l" ] && exit 0
+      craftctl default
+    override-build: |-
+      [ "$(uname -m)" = "armv7l" ] && exit 0
+      craftctl default
     organize:
       usr/bin/: bin/
       usr/lib/: lib/


### PR DESCRIPTION
For `armhf`, this was effectively not working as there are not packages for this arch.

For `riscv64`, while there are packages available, it makes little sense to support OVS/OVN while Ceph and QEMU are explicitly not supported for this arch.