### PR TITLE
edk2: use patch to revert ARM EFI_LOADER_DATA no-exec

### DIFF
--- a/patches/edk2-0008-Revert-ArmVirtPkg-make-EFI_LOADER_DATA-non-execurable.patch
+++ b/patches/edk2-0008-Revert-ArmVirtPkg-make-EFI_LOADER_DATA-non-execurable.patch
@@ -1,0 +1,35 @@
+commit 9d5f77121a2f2469ba3a9f473ee2a00ecf97c059 (HEAD)
+Author: Simon Deziel <simon.deziel@canonical.com>
+Date:   2025-02-05 17:56:48 -0500
+
+    Revert "ArmVirtPkg: make EFI_LOADER_DATA non-executable"
+    
+    This reverts commit 2997ae38739756ecba9b0de19e86032ebc689ef9.
+
+diff --git a/ArmVirtPkg/ArmVirt.dsc.inc b/ArmVirtPkg/ArmVirt.dsc.inc
+index fe6488ee99..c0f69a26c2 100644
+--- a/ArmVirtPkg/ArmVirt.dsc.inc
++++ b/ArmVirtPkg/ArmVirt.dsc.inc
+@@ -368,21 +368,21 @@
+   # Enable strict image permissions for all images. (This applies
+   # only to images that were built with >= 4 KB section alignment.)
+   #
+   gEfiMdeModulePkgTokenSpaceGuid.PcdImageProtectionPolicy|0x3
+ 
+   #
+   # Enable NX memory protection for all non-code regions, including OEM and OS
+   # reserved ones, with the exception of LoaderData regions, of which OS loaders
+   # (i.e., GRUB) may assume that its contents are executable.
+   #
+-  gEfiMdeModulePkgTokenSpaceGuid.PcdDxeNxMemoryProtectionPolicy|0xC000000000007FD5
++  gEfiMdeModulePkgTokenSpaceGuid.PcdDxeNxMemoryProtectionPolicy|0xC000000000007FD1
+ 
+   gEfiMdeModulePkgTokenSpaceGuid.PcdCpuStackGuard|TRUE
+ 
+ [Components.common]
+   #
+   # Ramdisk support
+   #
+   MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskDxe.inf
+ 
+   ShellPkg/DynamicCommand/TftpDynamicCommand/TftpDynamicCommand.inf {

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -391,20 +391,16 @@ parts:
       [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
       set -ex
 
-      # Git cherry-picks
-      git config user.email "noreply@lists.canonical.com"
-      git config user.name "LXD snap builder"
-
       # Apply patches
       patch -p1 < "${CRAFT_PROJECT_DIR}/patches/edk2-0001-force-DUID-LLT.patch"
       cp "${CRAFT_PROJECT_DIR}/patches/edk2-0002-logo.bmp" MdeModulePkg/Logo/Logo.bmp
       patch -p1 < "${CRAFT_PROJECT_DIR}/patches/edk2-0003-boot-delay.patch"
       patch -p1 < "${CRAFT_PROJECT_DIR}/patches/edk2-0004-gcc-errors.patch"
       patch --binary -p1 < "${CRAFT_PROJECT_DIR}/patches/edk2-0005-disable-dynamic-mmio-winsize.patch"
-      # revert "ArmVirtPkg: make EFI_LOADER_DATA non-executable" as it breaks almost everything
-      git revert 2997ae38739756ecba9b0de19e86032ebc689ef9
       patch --binary -p1 < "${CRAFT_PROJECT_DIR}/patches/edk2-0006-disable-EFI-memory-attributes-protocol.patch"
       patch --binary -p1 < "${CRAFT_PROJECT_DIR}/patches/edk2-0007-Disable-the-Shell-when-SecureBoot-is-enabled.patch"
+      # revert "ArmVirtPkg: make EFI_LOADER_DATA non-executable" as it breaks almost everything
+      patch --binary -p1 < "${CRAFT_PROJECT_DIR}/patches/edk2-0008-Revert-ArmVirtPkg-make-EFI_LOADER_DATA-non-execurable.patch"
 
       # Arch-specific logic
       ARCH="X64"


### PR DESCRIPTION
A snapcraft build was stucked waiting on an interactive editor to provide the commit message associated with the `git revert`:

```
sdeziel  4179987  2.2  0.3 336828 119940 pts/1   Ssl+ 16:47   1:19          \_ /snap/snapcraft/13341/bin/python /snap/snapcraft/13341/bin/snapcraft
sdeziel     5590  0.0  0.0   4752  2304 pts/1    S+   16:57   0:00              \_ /bin/bash /tmp/tmp2a3pyjce/scriptlet.sh
sdeziel     5599  0.0  0.0 1557076 8512 pts/1    S+   16:57   0:02                  \_ git revert 2997ae38739756ecba9b0de19e86032ebc689ef9
sdeziel     5623  0.0  0.0 1141628 12336 pts/1   S+   16:57   0:00                      \_ /usr/lib/git-core/git commit -n --no-gpg-sign -e
sdeziel     5722  0.0  0.0   3148  1280 pts/1    S+   16:58   0:00                          \_ /usr/bin/editor /root/parts/edk2/build/.git/COMMIT_EDITMSG
```

Using a patch file should avoid that.