### PR TITLE
OVS/OVN: don't install stage packages

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -642,6 +642,10 @@ parts:
     stage-packages:
       - openvswitch-common
       - openvswitch-switch
+    override-stage: |-
+      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "$(uname -m)" = "riscv64" ] && exit 0
+      craftctl default
     override-prime: |-
       [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -674,6 +674,10 @@ parts:
     plugin: nil
     stage-packages:
       - ovn-common
+    override-stage: |-
+      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "$(uname -m)" = "riscv64" ] && exit 0
+      craftctl default
     override-prime: |-
       [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
The previous tentative of **not** pulling OVS/OVN on `armhf` didn't work as https://launchpadlibrarian.net/774846252/buildlog_snap_ubuntu_noble_armhf_lxd-latest-edge_BUILDING.txt.gz:

```
Pulling openvswitch
Fetching stage-packages
Stage package not found in part 'openvswitch': openvswitch-common.
```

Hopefully overriding the stage phase will avoid this tentative package installation.