### PR TITLE
Revert "configure: no need to escape Apparmor for that hook"

### DIFF
--- a/snapcraft/hooks/configure
+++ b/snapcraft/hooks/configure
@@ -1,6 +1,14 @@
 #!/bin/sh
 set -eu
 
+# Re-exec outside of apparmor confinement
+if [ -d /sys/kernel/security/apparmor ]; then
+  label="$(cat /proc/self/attr/current 2>/dev/null)"
+  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+    exec aa-exec -p unconfined -- "$0" "$@"
+  fi
+fi
+
 # Utility functions
 get_bool() {
     value=$(echo "${1:-}" | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
This reverts commit 04bacb90848246baf567ce5f3fea59e15f1948d2.

As found by Din, changing the group fails if configure is still confined:

```
$ sudo snap install lxd --channel=latest/edge
$ sudo snap set lxd daemon.group=adm
error: cannot perform the following tasks:
- Run configure hook of "lxd" snap (run hook "configure": chgrp: changing group of '/var/snap/lxd/common/lxd/unix.socket': Operation not permitted)
```

Reported-by: Din Music <din.music@canonical.com>