### PR TITLE
nvidia-container-toolkit: fix override-build arch exclusion

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -638,6 +638,8 @@ parts:
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-build: |-
+      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "$(uname -m)" = "riscv64" ] && exit 0
       set -ex
 
       make binaries


### PR DESCRIPTION
Fixes f57e344d843c5d427623dfc6bb23eb1e224936a6 in which I forgot to skip the build on unsupported arches.