### PR TITLE
Build fixes

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -488,11 +488,18 @@ parts:
 
   libatomic:
     plugin: nil
+    override-stage: |-
+      [ "$(uname -m)" != "s390x" ] && exit 0
+      craftctl default
+    override-prime: |-
+      [ "$(uname -m)" != "s390x" ] && exit 0
+      craftctl default
     stage-packages:
       - libatomic1
     organize:
       usr/lib/: lib/
     prime:
+      # XXX: libatomic.so is only needed by Ceph/QEMU on s390x and no other arch.
       - lib/*/libatomic.so*
 
   logrotate:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1116,9 +1116,9 @@ parts:
       - --with-config=user
     build-packages:
       - on armhf:
-        - "" # do not pull pkg on unsupported arches
+        - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
       - on riscv64:
-        - "" # do not pull pkg on unsupported arches
+        - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
       - else:
         - libblkid-dev
         - libssl-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1167,9 +1167,9 @@ parts:
       - --with-config=user
     build-packages:
       - on armhf:
-        - "" # do not pull pkg on unsupported arches
+        - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
       - on riscv64:
-        - "" # do not pull pkg on unsupported arches
+        - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
       - else:
         - libblkid-dev
         - libssl-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -739,9 +739,9 @@ parts:
       - -Dtests=false
     build-packages:
       - on armhf:
-        - "" # do not pull pkg on unsupported arches
+        - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
       - on riscv64:
-        - "" # do not pull pkg on unsupported arches
+        - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
       - else:
         - libspice-protocol-dev
         - libjpeg-turbo8-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -860,9 +860,9 @@ parts:
       - --disable-install-blobs # Ubuntu sources don't have the ROM blobs in them.
     build-packages:
       - on armhf:
-        - "" # do not pull pkg on unsupported arches
+        - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
       - on riscv64:
-        - "" # do not pull pkg on unsupported arches
+        - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
       - else:
         - bison
         - bzip2

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -291,7 +291,7 @@ parts:
     plugin: nil
     build-packages:
       - on riscv64:
-        - "" # do not pull pkg on unsupported arches
+        - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
       - else:
         - asciidoc
         - libcap-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -214,6 +214,8 @@ parts:
       - bin/mkfs.btrfs
 
   ceph:
+    after:
+      - libatomic
     plugin: nil
     stage-packages:
       # XXX: explicitly depend on libsnappy1v5 due to https://bugs.launchpad.net/ubuntu/+source/ceph/+bug/2072656
@@ -483,6 +485,15 @@ parts:
       rm "${CRAFT_PART_INSTALL}/share/qemu/OVMF_VARS.4MB.debug.fd"
     prime:
       - share/qemu/*
+
+  libatomic:
+    plugin: nil
+    stage-packages:
+      - libatomic1
+    organize:
+      usr/lib/: lib/
+    prime:
+      - lib/*/libatomic.so*
 
   logrotate:
     plugin: nil
@@ -797,6 +808,7 @@ parts:
 
   qemu:
     after:
+      - libatomic
       - spice-server
     source: https://git.launchpad.net/ubuntu/+source/qemu
     source-commit: 50a4fe555e21d4b633580d63ae45e807de9e2f91 # import/1%8.2.2+ds-0ubuntu1.5
@@ -945,6 +957,7 @@ parts:
       - bin/qemu-system-*
       - bin/qemu-img*
       - bin/virtfs-proxy-helper*
+      - lib/*/libatomic.so*
       - lib/*/libmagic*so*
       - lib/*/libnuma*so*
       - lib/*/libpixman*so*
@@ -1208,6 +1221,8 @@ parts:
       rm "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/lib/libzpool.so"*
 
   zstd:
+    after:
+      - libatomic
     plugin: nil
     stage-packages:
       - zstd


### PR DESCRIPTION
This PR changes how `build-packages` are "skipped" for parts not built for a given arch. Since `build-packages` requires a list of packages to install, we provide a placeholder package that we need anyway to build the `lxd` part.

It also addresses the `snapcraft lint` issues showing on `s390x` only:

```
- library: bin/qemu-img: missing dependency 'libatomic.so.1'. (provided by 'libatomic1') (https://snapcraft.io/docs/linters-library)
- library: bin/qemu-system-s390x: missing dependency 'libatomic.so.1'. (provided by 'libatomic1') (https://snapcraft.io/docs/linters-library)
- library: bin/rbd: missing dependency 'libatomic.so.1'. (provided by 'libatomic1') (https://snapcraft.io/docs/linters-library)
- library: lib/python3/dist-packages/rbd.cpython-312-s390x-linux-gnu.so: missing dependency 'libatomic.so.1'. (provided by 'libatomic1') (https://snapcraft.io/docs/linters-library)
- library: lib/s390x-linux-gnu/librbd.so.1.19.0: missing dependency 'libatomic.so.1'. (provided by 'libatomic1') (https://snapcraft.io/docs/linters-library)
```