### PR TITLE
LP `armhf` builds are done on `arm64` builders

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1228,8 +1228,6 @@ parts:
       rm "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/lib/libzpool.so"*
 
   zstd:
-    after:
-      - libatomic
     plugin: nil
     stage-packages:
       - zstd

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -878,7 +878,7 @@ parts:
       - --localstatedir=/var/
       - --disable-install-blobs # Ubuntu sources don't have the ROM blobs in them.
     build-packages:
-      - on armhf:
+      - to armhf:
         - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
       - on riscv64:
         - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1186,9 +1186,9 @@ parts:
       - --prefix=/
       - --with-config=user
     build-packages:
-      - on armhf:
+      - to armhf:
         - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
-      - on riscv64:
+      - to riscv64:
         - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
       - else:
         - libblkid-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1135,9 +1135,9 @@ parts:
       - --prefix=/
       - --with-config=user
     build-packages:
-      - on armhf:
+      - to armhf:
         - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
-      - on riscv64:
+      - to riscv64:
         - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
       - else:
         - libblkid-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -758,7 +758,7 @@ parts:
     build-packages:
       - to armhf:
         - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
-      - on riscv64:
+      - to riscv64:
         - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
       - else:
         - libspice-protocol-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -367,12 +367,12 @@ parts:
     source-type: git
     plugin: nil
     build-packages:
-      - on amd64:
+      - to amd64:
         - g++
         - acpica-tools
         - nasm
         - uuid-dev
-      - on arm64:
+      - to arm64:
         - g++
         - acpica-tools
         - nasm

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -292,7 +292,7 @@ parts:
     source-type: git
     plugin: nil
     build-packages:
-      - on riscv64:
+      - to riscv64:
         - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
       - else:
         - asciidoc

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -880,7 +880,7 @@ parts:
     build-packages:
       - to armhf:
         - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
-      - on riscv64:
+      - to riscv64:
         - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
       - else:
         - bison

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -992,12 +992,12 @@ parts:
     source: edk2-vars-generator
     plugin: nil
     build-packages:
-      - on amd64:
+      - to amd64:
         - dosfstools
         - mtools
         - python3-pexpect
         - xorriso
-      - on arm64:
+      - to arm64:
         - dosfstools
         - mtools
         - python3-pexpect

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -756,7 +756,7 @@ parts:
       - -Dsmartcard=disabled
       - -Dtests=false
     build-packages:
-      - on armhf:
+      - to armhf:
         - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
       - on riscv64:
         - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -589,14 +589,14 @@ parts:
     build-environment:
       - GIT_TAG: "1.17.4" # Enables source-depth: 1, should match git tag without "v" prefix.
     build-packages:
-      - on amd64:
+      - to amd64:
         - bmake
         - curl
         - libelf-dev
         - libseccomp-dev
         - lsb-release
         - libtirpc-dev
-      - on arm64:
+      - to arm64:
         - bmake
         - curl
         - libelf-dev


### PR DESCRIPTION
I couldn't explain why `armhf` still wanted to install `librbd-dev` despite having the arch exclusion, https://launchpadlibrarian.net/775800234/buildlog_snap_ubuntu_noble_armhf_lxd-latest-edge_BUILDING.txt.gz:
```
Running '['linux32', 'snap', 'install', '--channel=latest/edge', 'snapd']'. Attempt 1
error: cannot perform the following tasks:
- Setup snap "snapd" (23954) security profiles (cannot reload udev rules: exit status 1
udev output:
Failed to send reload request: No such file or directory
)
Running '['linux32', 'snap', 'install', '--channel=latest/edge', 'snapd']'. Attempt 2
2025-02-10T20:06:32Z INFO Waiting for automatic snapd restart...
snapd (edge) 2.67.1+g338.66866f3 from Canonical** installed
snap "snapd" has no updates available
Running '['linux32', 'snap', 'install', '--classic', '--channel=stable/launchpad-buildd', 'snapcraft']'. Attempt 1
snapcraft 8.6.1 from Canonical** installed
Running repo phase...
Cloning into 'lxd'...
[10/Feb/2025:20:06:59 +0000] "CONNECT git.launchpad.net:443 HTTP/1.1" 200 3154915 "-" "git/2.43.0"
Running pull phase...
Initialising lifecycle
Installing build-packages
Cannot find package listed in 'build-packages': librbd-dev
```

Then I noticed the build long have this line:

```
Kernel version: Linux bos03-arm64-104 6.8.0-51-generic #52-Ubuntu SMP PREEMPT_DYNAMIC Thu Dec  5 13:32:09 UTC 2024 aarch64
```

Which started to make sense with the `'['linux32', 'snap', 'install', '--channel=latest/edge', 'snapd']'`.

That's when I finally realized that `armhf` builds are done on `arm64` builders. OK, I should have picked this one up earlier ;)