### PR TITLE
lxd-ui: update 0.16 tag (latest-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1584,7 +1584,7 @@ parts:
     source: https://github.com/canonical/lxd-ui
     source-depth: 1
     source-type: git
-    source-commit: 9275167fe13162233bb9d7d1353d298539305b9d # 0.15
+    source-commit: e1943398482f19dfd029bce42daa8281b1edaa7e # 0.16
     plugin: nil
     override-prime: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
Update latest candidate to the [0.16 ui tag](https://github.com/canonical/lxd-ui/releases/tag/0.16)