### PR TITLE
snapcraft: bump snapd requirement to 2.67

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: lxd
 base: core24
 assumes:
-  - snapd2.39
+  - snapd2.67
 version: git
 grade: devel
 summary: LXD - container and VM manager


### PR DESCRIPTION
snapd 2.67 was released on Jan 16 (https://github.com/canonical/snapd/releases/tag/2.67) and contains many fixes, including those we need to eventually start using unconfined AppArmor profile.

See also
https://github.com/canonical/lxd-pkg-snap/pull/490