### PR TITLE
snapcraft: explicitly add libtirpc-dev dev for zfs* parts

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1162,6 +1162,7 @@ parts:
         - libssl-dev
         - uuid-dev
         - zlib1g-dev
+        - libtirpc-dev
     override-stage: |-
       [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
@@ -1211,6 +1212,7 @@ parts:
         - libssl-dev
         - uuid-dev
         - zlib1g-dev
+        - libtirpc-dev
     override-stage: |-
       [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
We have libtirpc-dev declared as a dependency for nvidia-container, but it is also required for zfs* parts.

It should fix a random failures like this one:
https://launchpadlibrarian.net/780529969/buildlog_snap_ubuntu_noble_s390x_lxd-latest-edge_BUILDING.txt.gz