### PR TITLE
Revert "snapcraft: bump snapd requirement to 2.67"

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: lxd
 base: core24
 assumes:
-  - snapd2.67
+  - snapd2.39
 version: git
 grade: devel
 summary: LXD - container and VM manager


### PR DESCRIPTION
This reverts commit 98ab6204f970dba9aa7cd55384bba2c44adf0ff2.

... because of test failures
https://github.com/canonical/lxd-ci/actions/runs/13758467965

It turns out, that even on Ubuntu Noble LXD fails to install from latest/edge channel because snapd does not trigger autorefresh and just bail out LXD installation.