### PR TITLE
snapcraft/qemu: Add QEMU patches for better error handling

### DIFF
--- a/patches/qemu-0001-kvm-Allow-kvm_arch_get-put_registers-to-accept-Error.patch
+++ b/patches/qemu-0001-kvm-Allow-kvm_arch_get-put_registers-to-accept-Error.patch
@@ -1,0 +1,234 @@
+From fc5c0b38724b2d4435696c6e4f254c4392311f42 Mon Sep 17 00:00:00 2001
+From: Julia Suvorova <jusual@redhat.com>
+Date: Fri, 27 Sep 2024 12:47:40 +0200
+Subject: [PATCH 1/2] kvm: Allow kvm_arch_get/put_registers to accept Error**
+
+This is necessary to provide discernible error messages to the caller.
+
+Signed-off-by: Julia Suvorova <jusual@redhat.com>
+Reviewed-by: Peter Xu <peterx@redhat.com>
+Link: https://lore.kernel.org/r/20240927104743.218468-2-jusual@redhat.com
+Signed-off-by: Paolo Bonzini <pbonzini@redhat.com>
+(cherry picked from commit a1676bb3047f28b292ecbce3a378ccc0b4721d47)
+---
+ accel/kvm/kvm-all.c        | 41 +++++++++++++++++++++++++++++---------
+ include/sysemu/kvm.h       |  4 ++--
+ target/i386/kvm/kvm.c      |  4 ++--
+ target/mips/kvm.c          |  4 ++--
+ target/ppc/kvm.c           |  4 ++--
+ target/riscv/kvm/kvm-cpu.c |  4 ++--
+ target/s390x/kvm/kvm.c     |  4 ++--
+ 7 files changed, 44 insertions(+), 21 deletions(-)
+
+diff --git a/accel/kvm/kvm-all.c b/accel/kvm/kvm-all.c
+index e39a810a4e..e6a3bb67f7 100644
+--- a/accel/kvm/kvm-all.c
++++ b/accel/kvm/kvm-all.c
+@@ -2700,9 +2700,15 @@ bool kvm_cpu_check_are_resettable(void)
+ static void do_kvm_cpu_synchronize_state(CPUState *cpu, run_on_cpu_data arg)
+ {
+     if (!cpu->vcpu_dirty) {
+-        int ret = kvm_arch_get_registers(cpu);
++        Error *err = NULL;
++        int ret = kvm_arch_get_registers(cpu, &err);
+         if (ret) {
+-            error_report("Failed to get registers: %s", strerror(-ret));
++            if (err) {
++                error_reportf_err(err, "Failed to synchronize CPU state: ");
++            } else {
++                error_report("Failed to get registers: %s", strerror(-ret));
++            }
++
+             cpu_dump_state(cpu, stderr, CPU_DUMP_CODE);
+             vm_stop(RUN_STATE_INTERNAL_ERROR);
+         }
+@@ -2720,9 +2726,15 @@ void kvm_cpu_synchronize_state(CPUState *cpu)
+ 
+ static void do_kvm_cpu_synchronize_post_reset(CPUState *cpu, run_on_cpu_data arg)
+ {
+-    int ret = kvm_arch_put_registers(cpu, KVM_PUT_RESET_STATE);
++    Error *err = NULL;
++    int ret = kvm_arch_put_registers(cpu, KVM_PUT_RESET_STATE, &err);
+     if (ret) {
+-        error_report("Failed to put registers after reset: %s", strerror(-ret));
++        if (err) {
++            error_reportf_err(err, "Restoring resisters after reset: ");
++        } else {
++            error_report("Failed to put registers after reset: %s",
++                         strerror(-ret));
++        }
+         cpu_dump_state(cpu, stderr, CPU_DUMP_CODE);
+         vm_stop(RUN_STATE_INTERNAL_ERROR);
+     }
+@@ -2737,9 +2749,15 @@ void kvm_cpu_synchronize_post_reset(CPUState *cpu)
+ 
+ static void do_kvm_cpu_synchronize_post_init(CPUState *cpu, run_on_cpu_data arg)
+ {
+-    int ret = kvm_arch_put_registers(cpu, KVM_PUT_FULL_STATE);
++    Error *err = NULL;
++    int ret = kvm_arch_put_registers(cpu, KVM_PUT_FULL_STATE, &err);
+     if (ret) {
+-        error_report("Failed to put registers after init: %s", strerror(-ret));
++        if (err) {
++            error_reportf_err(err, "Putting registers after init: ");
++        } else {
++            error_report("Failed to put registers after init: %s",
++                         strerror(-ret));
++        }
+         exit(1);
+     }
+ 
+@@ -2835,10 +2853,15 @@ int kvm_cpu_exec(CPUState *cpu)
+         MemTxAttrs attrs;
+ 
+         if (cpu->vcpu_dirty) {
+-            ret = kvm_arch_put_registers(cpu, KVM_PUT_RUNTIME_STATE);
++            Error *err = NULL;
++            ret = kvm_arch_put_registers(cpu, KVM_PUT_RUNTIME_STATE, &err);
+             if (ret) {
+-                error_report("Failed to put registers after init: %s",
+-                             strerror(-ret));
++                if (err) {
++                    error_reportf_err(err, "Putting registers after init: ");
++                } else {
++                    error_report("Failed to put registers after init: %s",
++                                 strerror(-ret));
++                }
+                 ret = -1;
+                 break;
+             }
+diff --git a/include/sysemu/kvm.h b/include/sysemu/kvm.h
+index d614878164..eaba7fc319 100644
+--- a/include/sysemu/kvm.h
++++ b/include/sysemu/kvm.h
+@@ -326,7 +326,7 @@ int kvm_arch_handle_exit(CPUState *cpu, struct kvm_run *run);
+ 
+ int kvm_arch_process_async_events(CPUState *cpu);
+ 
+-int kvm_arch_get_registers(CPUState *cpu);
++int kvm_arch_get_registers(CPUState *cpu, Error **errp);
+ 
+ /* state subset only touched by the VCPU itself during runtime */
+ #define KVM_PUT_RUNTIME_STATE   1
+@@ -335,7 +335,7 @@ int kvm_arch_get_registers(CPUState *cpu);
+ /* full state set, modified during initialization or on vmload */
+ #define KVM_PUT_FULL_STATE      3
+ 
+-int kvm_arch_put_registers(CPUState *cpu, int level);
++int kvm_arch_put_registers(CPUState *cpu, int level, Error **errp);
+ 
+ int kvm_arch_get_default_type(MachineState *ms);
+ 
+diff --git a/target/i386/kvm/kvm.c b/target/i386/kvm/kvm.c
+index a0bc9ea7b1..ab0c6499f5 100644
+--- a/target/i386/kvm/kvm.c
++++ b/target/i386/kvm/kvm.c
+@@ -4552,7 +4552,7 @@ static int kvm_get_nested_state(X86CPU *cpu)
+     return ret;
+ }
+ 
+-int kvm_arch_put_registers(CPUState *cpu, int level)
++int kvm_arch_put_registers(CPUState *cpu, int level, Error **errp)
+ {
+     X86CPU *x86_cpu = X86_CPU(cpu);
+     int ret;
+@@ -4640,7 +4640,7 @@ int kvm_arch_put_registers(CPUState *cpu, int level)
+     return 0;
+ }
+ 
+-int kvm_arch_get_registers(CPUState *cs)
++int kvm_arch_get_registers(CPUState *cs, Error **errp)
+ {
+     X86CPU *cpu = X86_CPU(cs);
+     int ret;
+diff --git a/target/mips/kvm.c b/target/mips/kvm.c
+index e22e24ed97..6bf2a9b76e 100644
+--- a/target/mips/kvm.c
++++ b/target/mips/kvm.c
+@@ -1179,7 +1179,7 @@ static int kvm_mips_get_cp0_registers(CPUState *cs)
+     return ret;
+ }
+ 
+-int kvm_arch_put_registers(CPUState *cs, int level)
++int kvm_arch_put_registers(CPUState *cs, int level, Error **errp)
+ {
+     MIPSCPU *cpu = MIPS_CPU(cs);
+     CPUMIPSState *env = &cpu->env;
+@@ -1215,7 +1215,7 @@ int kvm_arch_put_registers(CPUState *cs, int level)
+     return ret;
+ }
+ 
+-int kvm_arch_get_registers(CPUState *cs)
++int kvm_arch_get_registers(CPUState *cs, Error **errp)
+ {
+     MIPSCPU *cpu = MIPS_CPU(cs);
+     CPUMIPSState *env = &cpu->env;
+diff --git a/target/ppc/kvm.c b/target/ppc/kvm.c
+index 9b1abe2fc4..c84a252f0a 100644
+--- a/target/ppc/kvm.c
++++ b/target/ppc/kvm.c
+@@ -897,7 +897,7 @@ int kvmppc_put_books_sregs(PowerPCCPU *cpu)
+     return kvm_vcpu_ioctl(CPU(cpu), KVM_SET_SREGS, &sregs);
+ }
+ 
+-int kvm_arch_put_registers(CPUState *cs, int level)
++int kvm_arch_put_registers(CPUState *cs, int level, Error **errp)
+ {
+     PowerPCCPU *cpu = POWERPC_CPU(cs);
+     CPUPPCState *env = &cpu->env;
+@@ -1202,7 +1202,7 @@ static int kvmppc_get_books_sregs(PowerPCCPU *cpu)
+     return 0;
+ }
+ 
+-int kvm_arch_get_registers(CPUState *cs)
++int kvm_arch_get_registers(CPUState *cs, Error **errp)
+ {
+     PowerPCCPU *cpu = POWERPC_CPU(cs);
+     CPUPPCState *env = &cpu->env;
+diff --git a/target/riscv/kvm/kvm-cpu.c b/target/riscv/kvm/kvm-cpu.c
+index 117e33cf90..529381dd5f 100644
+--- a/target/riscv/kvm/kvm-cpu.c
++++ b/target/riscv/kvm/kvm-cpu.c
+@@ -964,7 +964,7 @@ const KVMCapabilityInfo kvm_arch_required_capabilities[] = {
+     KVM_CAP_LAST_INFO
+ };
+ 
+-int kvm_arch_get_registers(CPUState *cs)
++int kvm_arch_get_registers(CPUState *cs, Error **errp)
+ {
+     int ret = 0;
+ 
+@@ -1004,7 +1004,7 @@ int kvm_riscv_sync_mpstate_to_kvm(RISCVCPU *cpu, int state)
+     return 0;
+ }
+ 
+-int kvm_arch_put_registers(CPUState *cs, int level)
++int kvm_arch_put_registers(CPUState *cs, int level, Error **errp)
+ {
+     int ret = 0;
+ 
+diff --git a/target/s390x/kvm/kvm.c b/target/s390x/kvm/kvm.c
+index 33ab3551f4..26a5b4e804 100644
+--- a/target/s390x/kvm/kvm.c
++++ b/target/s390x/kvm/kvm.c
+@@ -472,7 +472,7 @@ static int can_sync_regs(CPUState *cs, int regs)
+ #define KVM_SYNC_REQUIRED_REGS (KVM_SYNC_GPRS | KVM_SYNC_ACRS | \
+                                 KVM_SYNC_CRS | KVM_SYNC_PREFIX)
+ 
+-int kvm_arch_put_registers(CPUState *cs, int level)
++int kvm_arch_put_registers(CPUState *cs, int level, Error **errp)
+ {
+     S390CPU *cpu = S390_CPU(cs);
+     CPUS390XState *env = &cpu->env;
+@@ -599,7 +599,7 @@ int kvm_arch_put_registers(CPUState *cs, int level)
+     return 0;
+ }
+ 
+-int kvm_arch_get_registers(CPUState *cs)
++int kvm_arch_get_registers(CPUState *cs, Error **errp)
+ {
+     S390CPU *cpu = S390_CPU(cs);
+     CPUS390XState *env = &cpu->env;
+-- 
+2.43.0
+

--- a/patches/qemu-0002-target-i386-kvm-Report-which-action-failed-in-kvm_ar.patch
+++ b/patches/qemu-0002-target-i386-kvm-Report-which-action-failed-in-kvm_ar.patch
@@ -1,0 +1,169 @@
+From f680584567227c2af540cf93c7eacaf932a2b1a3 Mon Sep 17 00:00:00 2001
+From: Julia Suvorova <jusual@redhat.com>
+Date: Fri, 27 Sep 2024 12:47:41 +0200
+Subject: [PATCH 2/2] target/i386/kvm: Report which action failed in
+ kvm_arch_put/get_registers
+
+To help debug and triage future failure reports (akin to [1,2]) that
+may occur during kvm_arch_put/get_registers, the error path of each
+action is accompanied by unique error message.
+
+[1] https://issues.redhat.com/browse/RHEL-7558
+[2] https://issues.redhat.com/browse/RHEL-21761
+
+Signed-off-by: Julia Suvorova <jusual@redhat.com>
+Reviewed-by: Peter Xu <peterx@redhat.com>
+Link: https://lore.kernel.org/r/20240927104743.218468-3-jusual@redhat.com
+Signed-off-by: Paolo Bonzini <pbonzini@redhat.com>
+(cherry picked from commit fc058618d1596d29e89016750a1aaf64c9fe8832)
+---
+ target/i386/kvm/kvm.c | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/target/i386/kvm/kvm.c b/target/i386/kvm/kvm.c
+index ab0c6499f5..b61b32ca01 100644
+--- a/target/i386/kvm/kvm.c
++++ b/target/i386/kvm/kvm.c
+@@ -4567,6 +4567,7 @@ int kvm_arch_put_registers(CPUState *cpu, int level, Error **errp)
+     if (level >= KVM_PUT_RESET_STATE) {
+         ret = kvm_put_msr_feature_control(x86_cpu);
+         if (ret < 0) {
++            error_setg_errno(errp, -ret, "Failed to set feature control MSR");
+             return ret;
+         }
+     }
+@@ -4574,12 +4575,14 @@ int kvm_arch_put_registers(CPUState *cpu, int level, Error **errp)
+     /* must be before kvm_put_nested_state so that EFER.SVME is set */
+     ret = has_sregs2 ? kvm_put_sregs2(x86_cpu) : kvm_put_sregs(x86_cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to set special registers");
+         return ret;
+     }
+ 
+     if (level >= KVM_PUT_RESET_STATE) {
+         ret = kvm_put_nested_state(x86_cpu);
+         if (ret < 0) {
++            error_setg_errno(errp, -ret, "Failed to set nested state");
+             return ret;
+         }
+     }
+@@ -4597,6 +4600,7 @@ int kvm_arch_put_registers(CPUState *cpu, int level, Error **errp)
+     if (xen_mode == XEN_EMULATE && level == KVM_PUT_FULL_STATE) {
+         ret = kvm_put_xen_state(cpu);
+         if (ret < 0) {
++            error_setg_errno(errp, -ret, "Failed to set Xen state");
+             return ret;
+         }
+     }
+@@ -4604,37 +4608,45 @@ int kvm_arch_put_registers(CPUState *cpu, int level, Error **errp)
+ 
+     ret = kvm_getput_regs(x86_cpu, 1);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to set general purpose registers");
+         return ret;
+     }
+     ret = kvm_put_xsave(x86_cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to set XSAVE");
+         return ret;
+     }
+     ret = kvm_put_xcrs(x86_cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to set XCRs");
+         return ret;
+     }
+     ret = kvm_put_msrs(x86_cpu, level);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to set MSRs");
+         return ret;
+     }
+     ret = kvm_put_vcpu_events(x86_cpu, level);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to set vCPU events");
+         return ret;
+     }
+     if (level >= KVM_PUT_RESET_STATE) {
+         ret = kvm_put_mp_state(x86_cpu);
+         if (ret < 0) {
++            error_setg_errno(errp, -ret, "Failed to set MP state");
+             return ret;
+         }
+     }
+ 
+     ret = kvm_put_tscdeadline_msr(x86_cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to set TSC deadline MSR");
+         return ret;
+     }
+     ret = kvm_put_debugregs(x86_cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to set debug registers");
+         return ret;
+     }
+     return 0;
+@@ -4649,6 +4661,7 @@ int kvm_arch_get_registers(CPUState *cs, Error **errp)
+ 
+     ret = kvm_get_vcpu_events(cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to get vCPU events");
+         goto out;
+     }
+     /*
+@@ -4657,44 +4670,54 @@ int kvm_arch_get_registers(CPUState *cs, Error **errp)
+      */
+     ret = kvm_get_mp_state(cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to get MP state");
+         goto out;
+     }
+     ret = kvm_getput_regs(cpu, 0);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to get general purpose registers");
+         goto out;
+     }
+     ret = kvm_get_xsave(cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to get XSAVE");
+         goto out;
+     }
+     ret = kvm_get_xcrs(cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to get XCRs");
+         goto out;
+     }
+     ret = has_sregs2 ? kvm_get_sregs2(cpu) : kvm_get_sregs(cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to get special registers");
+         goto out;
+     }
+     ret = kvm_get_msrs(cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to get MSRs");
+         goto out;
+     }
+     ret = kvm_get_apic(cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to get APIC");
+         goto out;
+     }
+     ret = kvm_get_debugregs(cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to get debug registers");
+         goto out;
+     }
+     ret = kvm_get_nested_state(cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to get nested state");
+         goto out;
+     }
+ #ifdef CONFIG_XEN_EMU
+     if (xen_mode == XEN_EMULATE) {
+         ret = kvm_get_xen_state(cs);
+         if (ret < 0) {
++            error_setg_errno(errp, -ret, "Failed to get Xen state");
+             goto out;
+         }
+     }
+-- 
+2.43.0
+

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -951,6 +951,12 @@ parts:
       # Apply patches from Ubuntu sources.
       QUILT_PATCHES=debian/patches quilt push -a
 
+      # Apply custom patches
+      # These patches enable more accurate error message returned in case of CPU registers mismatches.
+      # This is backported from QEMU v9.2.2.
+      patch -p1 < "${CRAFT_PROJECT_DIR}/patches/qemu-0001-kvm-Allow-kvm_arch_get-put_registers-to-accept-Error.patch"
+      patch -p1 < "${CRAFT_PROJECT_DIR}/patches/qemu-0002-target-i386-kvm-Report-which-action-failed-in-kvm_ar.patch"
+
       sed -i "s/^unset target_list$/target_list=\"${QEMUARCH}-softmmu\"/" configure
       sed -i 's#libseccomp_minver=".*#libseccomp_minver="0.0"#g' configure
 


### PR DESCRIPTION
This should bring more visibility about what is failing when an error occurs in the `kvm_arch_get/put_registers` function calls.

These issues might arise when migrating a VM from CPU A to similar CPU B (even if we keep a common set of CPU flags between CPU A and B) Now, we should be able to see what the exact issue is.