### PR TITLE
libnvidia-container: prime `libnvidia-container-go.so` that is `dlopen`'ed

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -643,6 +643,7 @@ parts:
     prime:
       - bin/nvidia-container-cli*
       - lib/libnvidia-container.so*
+      - lib/libnvidia-container-go.so*  # dlopen()'ed by libnvidia-container.so
 
   nvidia-container-toolkit:
     source: https://github.com/NVIDIA/nvidia-container-toolkit


### PR DESCRIPTION
As found by Tom while doing tests with NVIDIA cards, the `-go.so` file is needed as `libnvidia-container.so` will [`dlopen()` it](https://github.com/NVIDIA/libnvidia-container/blob/95d3e86522976061e856724867ebcaf75c4e9b60/src/nvcgo.c#L113).

That `dlopen()` is also why the snapcraft linter and my `ldd` tests didn't catch this runtime dependency.

Fixes bcb80f7d4dfb765dc14efeb774b45eeb707a056b