### PR TITLE
strip: truncate outdated cacert.pem from Python certifi

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1689,6 +1689,13 @@ parts:
 
       # Fixup logrotate.conf permissions to not be group writable
       chmod g-w "${CRAFT_PRIME}/etc/logrotate.conf"
+
+      # XXX: do not keep the duplicated and often outdated CA certificates
+      # store from Python `certifi`. This file is not even used as the
+      # `python3-certifi` package providing it is patched to always use:
+      # `/etc/ssl/certs/ca-certificates.crt`
+      truncate --no-create --size=0 "${CRAFT_PRIME}/lib/python3/dist-packages/certifi/cacert.pem"
+
       exit 0
 
   wrappers:


### PR DESCRIPTION
This should silence alerts like https://github.com/canonical/lxd/security/code-scanning/693