### PR TITLE
snapcraft: fix copy-n-pasto in cherry-pick list (latest-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1482,7 +1482,7 @@ parts:
 
       git cherry-pick -x c6bc0a628ffbe18f65cb2a26b3d8d03d2911adb1 # lxd/api_project: Fix condition checking associated profiles in projectIsEmpty
       git cherry-pick -x 731bd0b5b38829a89c071b0477f773ca2601b559 # lxd/storage/drivers/pure: Unmap volume when connection is freshly created
-      git cherry-pick -x fad58d709b92a2c13bd35865810e96f4c907372e # cloud-init: Allow none for cloud-init.ssh-keys.*
+      git cherry-pick -x 0d3f8d25a9dbbdf22a8b05631d6f494c9971a5d7 # shared/validate: Support none for `cloud-init.ssh-keys.*`
       git cherry-pick -x 197a0238f7f7d80c123f6e0c1716f4efc0e8de2f # lxd/network/driver_bridge: add "/" back into fanAddress() output
       git revert cd8966843783eee339329f13e06f68cd2cfbb902 --no-edit # lxd/loki: Add checkLoki function to ensure Loki is ready when creating a new Loki client
 


### PR DESCRIPTION
The snap builds failed because one of the cherry-picked commit is a merge one:

```
:: + git cherry-pick -x fad58d709b92a2c13bd35865810e96f4c907372e
:: error: commit fad58d709b92a2c13bd35865810e96f4c907372e is a merge but no -m option was given.
:: fatal: cherry-pick failed
'override-build' in part 'lxd' failed with code 128.
Detailed information: 
:: + git cherry-pick -x fad58d709b92a2c13bd35865810e96f4c907372e
:: error: commit fad58d709b92a2c13bd35865810e96f4c907372e is a merge but no -m option was given.
:: fatal: cherry-pick failed
```