### PR TITLE
lxd-qemu-snap: bump QEMU/virglrenderer versions

### DIFF
--- a/lxd-qemu-snap/snapcraft.yaml
+++ b/lxd-qemu-snap/snapcraft.yaml
@@ -56,7 +56,7 @@ parts:
 
   virgl:
     source: https://gitlab.freedesktop.org/virgl/virglrenderer.git
-    source-tag: virglrenderer-1.0.1
+    source-tag: virglrenderer-1.1.0
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -70,7 +70,7 @@ parts:
     after:
       - virgl
     source: https://gitlab.com/qemu-project/qemu
-    source-commit: 6a54d5cf55b446ec50d5c5a0b0568a7b28e2913e # v9.0.3
+    source-commit: ea35a5082a5fe81ce8fd184b0e163cd7b08b7ff7 # v9.2.2
     source-depth: 1
     source-submodules: []
     source-type: git


### PR DESCRIPTION
Bump QEMU to v9.2.2
virglrenderer to v1.1.0

Manually tested.