### PR TITLE
snapcraft: use `notify` mode instead of `simple` for LXD daemon

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -106,7 +106,7 @@ apps:
     stop-command: commands/daemon.stop
     stop-timeout: 600s
     restart-condition: on-failure
-    daemon: simple
+    daemon: notify
     slots:
       - lxd
     plugs:

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -245,6 +245,9 @@ ln -s "${SNAP}/wrappers/run-host" "/run/bin/getent"
 # Redirect journalctl to the host
 ln -s "${SNAP}/wrappers/run-host" "/run/bin/journalctl"
 
+# Redirect systemctl to the host
+ln -s "${SNAP}/wrappers/run-host" "/run/bin/systemctl"
+
 # Redirect pro to the host
 ln -s "${SNAP}/wrappers/run-host" "/run/bin/pro"
 


### PR DESCRIPTION
This will allow the LXD daemon app to augment the stop-timeout of 600s if needed