### PR TITLE
lxd-ui: update 0.15.1 tag (5.21-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1618,7 +1618,7 @@ parts:
     source: https://github.com/canonical/lxd-ui
     source-depth: 1
     source-type: git
-    source-commit: 9275167fe13162233bb9d7d1353d298539305b9d # 0.15
+    source-commit: b702d714cbeabef462db379362d9b878b8b13d13 # 0.15.1
     plugin: nil
     override-prime: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
* use lxd-ui tag https://github.com/canonical/lxd-ui/releases/tag/0.15.1
* it includes everything in main up to 0.16 tag, and some additional fixes.