### PR TITLE
lxc: replace build deps from GnuTLS to OpenSSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,5 @@ To build the snap for multiple architectures, Launchpad builders can be used.
 They are available for various architectures (`amd64`, `armhf`, `arm64`, `ppc64el`, `riscv64` and `s390x`) and you can ask for multiple to be built in parallel. Here's how to build for both `amd64` and `arm64`:
 
 ```
-snapcraft remote-build --launchpad-accept-public-upload --platform amd64,arm64
+snapcraft remote-build --launchpad-accept-public-upload --build-for amd64,arm64
 ```
-
-*Note*: if the snap being built is using an older core (like `core22` and earlier), replace `--platform` by `--build-for`.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1343,9 +1343,9 @@ parts:
       - libapparmor-dev
       - libcap-dev
       - libdbus-1-dev
-      - libgnutls28-dev
       - libseccomp-dev
       - libselinux1-dev
+      - libssl-dev
       - pkg-config
       - meson
       - ninja-build


### PR DESCRIPTION
Upstream replaced GnuTLS with OpenSSL in https://github.com/lxc/lxc/commit/fa2bb6ba532c5e7f92df8cbae50a68af519f9997