### PR TITLE
daemon.start: check if the host's `/var/lib/snapd/cgroup/snap.lxd.device` exists (latest-candidate)

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -41,8 +41,8 @@ SNAP_BASE="$(sed -n '/^name:/ s/^name:\s*\(core[0-9]\{2\}\)/\1/p' /meta/snap.yam
 
 # Temporary hack to workaround systemctl reload snap.lxd.daemon
 # problem with core24-based LXD snap
-if [ "${SNAP_BASE}" = "core24" ]; then
-    _LXD_SNAP_DEVCGROUP_CONFIG="/var/lib/snapd/hostfs/var/lib/snapd/cgroup/snap.lxd.device"
+_LXD_SNAP_DEVCGROUP_CONFIG="/var/lib/snapd/hostfs/var/lib/snapd/cgroup/snap.lxd.device"
+if [ "${SNAP_BASE}" = "core24" ] && [ -e "${_LXD_SNAP_DEVCGROUP_CONFIG}" ]; then
     grep -qxF 'self-managed=true' "${_LXD_SNAP_DEVCGROUP_CONFIG}" || echo 'self-managed=true' >> "${_LXD_SNAP_DEVCGROUP_CONFIG}"
 fi
 


### PR DESCRIPTION
This file is missing at least on Debian 11 with snapd 2.61.4 and kernel 5.10.0-34-amd64, see:
https://discourse.ubuntu.com/t/lxd-doesn-t-start-snap-lxd-device-directory-nonexistent/59785

Signed-off-by: Simon Deziel <simon.deziel@canonical.com>
(cherry picked from commit defaeb8c7bb70dd855ebc46274c60afaffa0d57e)