### PR TITLE
github: Update repo of lp-snap-build (latest-candidate)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -19,7 +19,7 @@ jobs:
     env:
       SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       PACKAGE: "lxd"
-      REPO: "git+ssh://lxdbot@git.launchpad.net/~canonical-lxd/lxd"
+      REPO: "git+ssh://lxdbot@git.launchpad.net/~lxd-snap/lxd"
       BRANCH: ${{ github.ref_name }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
Moving to https://launchpad.net/~lxd-snap/+snaps


(cherry picked from commit 3f316ca0807edd1ccd3095d100c6adb909925e50)