### PR TITLE
lxc: remove unused libexec setting

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1362,10 +1362,8 @@ parts:
       - -Dselinux=true
       - -Dcapabilities=true
       - -Drootfs-mount-path=/var/snap/lxd/common/lxc/
-      - -Dlibexecdir=/snap/lxd/current/libexec/
     organize:
       snap/lxd/current/lxc: lxc
-      snap/lxd/current/libexec: libexec
       share/lxc/hooks: lxc/hooks
     prime:
       - bin/lxc-checkconfig


### PR DESCRIPTION
The libexec bits were added by commit 87c043cada69319fa9ac9e0ba0b27b5a34a98dd0 for using `lxc-monitord` in the LXD snap but that binary was later removed from the snap in commit 8259f0b2518d47b2f65759a902589a186ef02b09

The `libexec` directory has been missing in the LXD snap for a while:

```
$ ll /snap/lxd/current/libexec/
ls: cannot access '/snap/lxd/current/libexec/': No such file or directory
```