### PR TITLE
Smaller liblxc.so

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1350,6 +1350,7 @@ parts:
     meson-parameters:
       - -Dapparmor=true
       - -Dcapabilities=true
+      - -Dcommands=false
       - -Ddbus=false
       - -Dexamples=false
       - -Dman=false

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1341,7 +1341,6 @@ parts:
     build-packages:
       - libapparmor-dev
       - libcap-dev
-      - libdbus-1-dev
       - libseccomp-dev
       - libselinux1-dev
       - pkg-config
@@ -1351,6 +1350,7 @@ parts:
     meson-parameters:
       - -Dapparmor=true
       - -Dcapabilities=true
+      - -Ddbus=false
       - -Dexamples=false
       - -Dman=false
       - -Dmemfd-rexec=false

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1349,7 +1349,7 @@ parts:
       - ninja-build
     plugin: meson
     meson-parameters:
-      - --prefix=/
+      - -Dprefix=/
       - -Dexamples=false
       - -Dman=false
       - -Dopenssl=false

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1342,7 +1342,6 @@ parts:
       - libapparmor-dev
       - libcap-dev
       - libseccomp-dev
-      - libselinux1-dev
       - pkg-config
       - meson
       - ninja-build
@@ -1359,7 +1358,7 @@ parts:
       - -Dprefix=/
       - -Drootfs-mount-path=/var/snap/lxd/common/lxc/
       - -Dseccomp=true
-      - -Dselinux=true
+      - -Dselinux=false
       - -Dtests=false
       - -Dtools=false
     organize:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1380,6 +1380,10 @@ parts:
       git config user.email "noreply@lists.canonical.com"
       git config user.name "LXD snap builder"
 
+      # lxc-checkconfig.in does not need any preprocessing
+      mkdir -p bin
+      install --mode=0755 src/lxc/cmd/lxc-checkconfig.in bin/lxc-checkconfig
+
       cd ../build
 
       set +ex

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1349,18 +1349,18 @@ parts:
       - ninja-build
     plugin: meson
     meson-parameters:
-      - -Dprefix=/
+      - -Dapparmor=true
+      - -Dcapabilities=true
       - -Dexamples=false
       - -Dman=false
-      - -Dopenssl=false
-      - -Dtools=false
-      - -Dtests=false
       - -Dmemfd-rexec=false
-      - -Dapparmor=true
+      - -Dopenssl=false
+      - -Dprefix=/
+      - -Drootfs-mount-path=/var/snap/lxd/common/lxc/
       - -Dseccomp=true
       - -Dselinux=true
-      - -Dcapabilities=true
-      - -Drootfs-mount-path=/var/snap/lxd/common/lxc/
+      - -Dtests=false
+      - -Dtools=false
     organize:
       snap/lxd/current/lxc: lxc
       share/lxc/hooks: lxc/hooks

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1352,6 +1352,8 @@ parts:
       - -Dcommands=false
       - -Ddbus=false
       - -Dexamples=false
+      - -Dinstall-init-files=false
+      - -Dinstall-state-dirs=false
       - -Dman=false
       - -Dmemfd-rexec=false
       - -Dopenssl=false


### PR DESCRIPTION
Moves from compiling ~550 units down to 62. This list of meson parameter is also what's being tested in https://github.com/canonical/lxd/pull/15541.

It intentionally omits building the `lxc-*` tools and also disables bits that are not required by LXD (dbus and SELinux support). Here's what the before/after looks like:

```
# latest/edge
root@v1:~# ldd /snap/lxd/33692/lib/x86_64-linux-gnu/liblxc.so.1.8.0 
	linux-vdso.so.1 (0x00007ffdadfc0000)
	libdbus-1.so.3 => /lib/x86_64-linux-gnu/libdbus-1.so.3 (0x000072a3802b0000)
	libseccomp.so.2 => /lib/x86_64-linux-gnu/libseccomp.so.2 (0x000072a380290000)
	libselinux.so.1 => /lib/x86_64-linux-gnu/libselinux.so.1 (0x000072a380263000)
	libapparmor.so.1 => /lib/x86_64-linux-gnu/libapparmor.so.1 (0x000072a38024f000)
	libcap.so.2 => /lib/x86_64-linux-gnu/libcap.so.2 (0x000072a380242000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x000072a380212000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x000072a380000000)
	/lib64/ld-linux-x86-64.so.2 (0x000072a380499000)
	libsystemd.so.0 => /lib/x86_64-linux-gnu/libsystemd.so.0 (0x000072a37ff20000)
	libpcre2-8.so.0 => /lib/x86_64-linux-gnu/libpcre2-8.so.0 (0x000072a37fe86000)
	libgcrypt.so.20 => /lib/x86_64-linux-gnu/libgcrypt.so.20 (0x000072a37fd3e000)
	liblz4.so.1 => /lib/x86_64-linux-gnu/liblz4.so.1 (0x000072a37fd1a000)
	liblzma.so.5 => /lib/x86_64-linux-gnu/liblzma.so.5 (0x000072a37fce8000)
	libzstd.so.1 => /lib/x86_64-linux-gnu/libzstd.so.1 (0x000072a37fc2e000)
	libgpg-error.so.0 => /lib/x86_64-linux-gnu/libgpg-error.so.0 (0x000072a37fc09000)

# this PR
root@v1:~# ldd /snap/lxd/x1/lib/x86_64-linux-gnu/liblxc.so.1.8.0 
	linux-vdso.so.1 (0x00007ffceb64c000)
	libseccomp.so.2 => /lib/x86_64-linux-gnu/libseccomp.so.2 (0x00007037e78f0000)
	libapparmor.so.1 => /lib/x86_64-linux-gnu/libapparmor.so.1 (0x00007037e78dc000)
	libcap.so.2 => /lib/x86_64-linux-gnu/libcap.so.2 (0x00007037e78cf000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007037e78a1000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007037e7600000)
	/lib64/ld-linux-x86-64.so.2 (0x00007037e7a41000)
```

So no `dbus`,  `gcrypt`, `gpg-error`, `pcre`, `selinux` nor `systemd` which brought the famous [`liblzma`](https://en.wikipedia.org/wiki/XZ_Utils_backdoor) and other unwanted compression libs.

It also results in a smaller `liblxc.so`:

```
# latest/edge
root@v1:~# ls -hl /snap/lxd/33692/lib/x86_64-linux-gnu/liblxc.so.1.8.0
-rwxr-xr-x 1 root root 1.6M May 13 10:22 /snap/lxd/33692/lib/x86_64-linux-gnu/liblxc.so.1.8.0

# this PR
root@v1:~# ls -lh /snap/lxd/x1/lib/x86_64-linux-gnu/liblxc.so.1.8.0 
-rwxr-xr-x 1 root root 1.2M May 14  2025 /snap/lxd/x1/lib/x86_64-linux-gnu/liblxc.so.1.8.0
```