### PR TITLE
Bring updates from latest-edge and bump lxc, lxcfs and lxd dependencies (latest-candidate)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -23,7 +23,7 @@ jobs:
       BRANCH: ${{ github.ref_name }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: canonical/lxd/.github/actions/lp-snap-build@main
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,9 @@ jobs:
           # A non-shallow clone is needed for the Differential ShellCheck
           fetch-depth: 0
 
+      - name: Require GHA pinning
+        uses: canonical/lxd/.github/actions/require-gha-pinning@main
+
       - id: ShellCheck
         name: Differential ShellCheck
         uses: redhat-plumbers-in-action/differential-shellcheck@dd551ce780d8af741f8cd8bab6982667b906b457  # v5.5.3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # A non-shallow clone is needed for the Differential ShellCheck
           fetch-depth: 0
@@ -33,7 +33,7 @@ jobs:
 
       - id: ShellCheck
         name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@dd551ce780d8af741f8cd8bab6982667b906b457  # v5.5.3
+        uses: redhat-plumbers-in-action/differential-shellcheck@dd551ce780d8af741f8cd8bab6982667b906b457 # v5.5.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
         if: github.event_name == 'pull_request'

--- a/README.md
+++ b/README.md
@@ -19,7 +19,5 @@ To build the snap for multiple architectures, Launchpad builders can be used.
 They are available for various architectures (`amd64`, `armhf`, `arm64`, `ppc64el`, `riscv64` and `s390x`) and you can ask for multiple to be built in parallel. Here's how to build for both `amd64` and `arm64`:
 
 ```
-snapcraft remote-build --launchpad-accept-public-upload --platform amd64,arm64
+snapcraft remote-build --launchpad-accept-public-upload --build-for amd64,arm64
 ```
-
-*Note*: if the snap being built is using an older core (like `core22` and earlier), replace `--platform` by `--build-for`.

--- a/lxd-qemu-snap/snapcraft.yaml
+++ b/lxd-qemu-snap/snapcraft.yaml
@@ -56,7 +56,7 @@ parts:
 
   virgl:
     source: https://gitlab.freedesktop.org/virgl/virglrenderer.git
-    source-tag: virglrenderer-1.0.1
+    source-tag: virglrenderer-1.1.0
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -70,7 +70,7 @@ parts:
     after:
       - virgl
     source: https://gitlab.com/qemu-project/qemu
-    source-commit: 6a54d5cf55b446ec50d5c5a0b0568a7b28e2913e # v9.0.3
+    source-commit: ea35a5082a5fe81ce8fd184b0e163cd7b08b7ff7 # v9.2.2
     source-depth: 1
     source-submodules: []
     source-type: git

--- a/patches/qemu-0001-kvm-Allow-kvm_arch_get-put_registers-to-accept-Error.patch
+++ b/patches/qemu-0001-kvm-Allow-kvm_arch_get-put_registers-to-accept-Error.patch
@@ -1,4 +1,4 @@
-From fc5c0b38724b2d4435696c6e4f254c4392311f42 Mon Sep 17 00:00:00 2001
+From e04094aafb65ecb0cc2bd71b64df1950fc372bcf Mon Sep 17 00:00:00 2001
 From: Julia Suvorova <jusual@redhat.com>
 Date: Fri, 27 Sep 2024 12:47:40 +0200
 Subject: [PATCH 1/2] kvm: Allow kvm_arch_get/put_registers to accept Error**
@@ -10,15 +10,18 @@ Reviewed-by: Peter Xu <peterx@redhat.com>
 Link: https://lore.kernel.org/r/20240927104743.218468-2-jusual@redhat.com
 Signed-off-by: Paolo Bonzini <pbonzini@redhat.com>
 (cherry picked from commit a1676bb3047f28b292ecbce3a378ccc0b4721d47)
+(cherry picked from commit fc5c0b38724b2d4435696c6e4f254c4392311f42)
+Signed-off-by: Gabriel Mougard <gabriel.mougard@canonical.com>
 ---
  accel/kvm/kvm-all.c        | 41 +++++++++++++++++++++++++++++---------
  include/sysemu/kvm.h       |  4 ++--
+ target/arm/kvm64.c         |  4 ++--
  target/i386/kvm/kvm.c      |  4 ++--
  target/mips/kvm.c          |  4 ++--
  target/ppc/kvm.c           |  4 ++--
  target/riscv/kvm/kvm-cpu.c |  4 ++--
  target/s390x/kvm/kvm.c     |  4 ++--
- 7 files changed, 44 insertions(+), 21 deletions(-)
+ 8 files changed, 46 insertions(+), 23 deletions(-)
 
 diff --git a/accel/kvm/kvm-all.c b/accel/kvm/kvm-all.c
 index e39a810a4e..e6a3bb67f7 100644
@@ -119,6 +122,28 @@ index d614878164..eaba7fc319 100644
  
  int kvm_arch_get_default_type(MachineState *ms);
  
+diff --git a/target/arm/kvm64.c b/target/arm/kvm64.c
+index 3c175c93a7..6b7560a194 100644
+--- a/target/arm/kvm64.c
++++ b/target/arm/kvm64.c
+@@ -782,7 +782,7 @@ static int kvm_arch_put_sve(CPUState *cs)
+     return 0;
+ }
+ 
+-int kvm_arch_put_registers(CPUState *cs, int level)
++int kvm_arch_put_registers(CPUState *cs, int level, Error **errp)
+ {
+     uint64_t val;
+     uint32_t fpr;
+@@ -968,7 +968,7 @@ static int kvm_arch_get_sve(CPUState *cs)
+     return 0;
+ }
+ 
+-int kvm_arch_get_registers(CPUState *cs)
++int kvm_arch_get_registers(CPUState *cs, Error **errp)
+ {
+     uint64_t val;
+     unsigned int el;
 diff --git a/target/i386/kvm/kvm.c b/target/i386/kvm/kvm.c
 index a0bc9ea7b1..ab0c6499f5 100644
 --- a/target/i386/kvm/kvm.c

--- a/patches/qemu-0001-kvm-Allow-kvm_arch_get-put_registers-to-accept-Error.patch
+++ b/patches/qemu-0001-kvm-Allow-kvm_arch_get-put_registers-to-accept-Error.patch
@@ -1,0 +1,234 @@
+From fc5c0b38724b2d4435696c6e4f254c4392311f42 Mon Sep 17 00:00:00 2001
+From: Julia Suvorova <jusual@redhat.com>
+Date: Fri, 27 Sep 2024 12:47:40 +0200
+Subject: [PATCH 1/2] kvm: Allow kvm_arch_get/put_registers to accept Error**
+
+This is necessary to provide discernible error messages to the caller.
+
+Signed-off-by: Julia Suvorova <jusual@redhat.com>
+Reviewed-by: Peter Xu <peterx@redhat.com>
+Link: https://lore.kernel.org/r/20240927104743.218468-2-jusual@redhat.com
+Signed-off-by: Paolo Bonzini <pbonzini@redhat.com>
+(cherry picked from commit a1676bb3047f28b292ecbce3a378ccc0b4721d47)
+---
+ accel/kvm/kvm-all.c        | 41 +++++++++++++++++++++++++++++---------
+ include/sysemu/kvm.h       |  4 ++--
+ target/i386/kvm/kvm.c      |  4 ++--
+ target/mips/kvm.c          |  4 ++--
+ target/ppc/kvm.c           |  4 ++--
+ target/riscv/kvm/kvm-cpu.c |  4 ++--
+ target/s390x/kvm/kvm.c     |  4 ++--
+ 7 files changed, 44 insertions(+), 21 deletions(-)
+
+diff --git a/accel/kvm/kvm-all.c b/accel/kvm/kvm-all.c
+index e39a810a4e..e6a3bb67f7 100644
+--- a/accel/kvm/kvm-all.c
++++ b/accel/kvm/kvm-all.c
+@@ -2700,9 +2700,15 @@ bool kvm_cpu_check_are_resettable(void)
+ static void do_kvm_cpu_synchronize_state(CPUState *cpu, run_on_cpu_data arg)
+ {
+     if (!cpu->vcpu_dirty) {
+-        int ret = kvm_arch_get_registers(cpu);
++        Error *err = NULL;
++        int ret = kvm_arch_get_registers(cpu, &err);
+         if (ret) {
+-            error_report("Failed to get registers: %s", strerror(-ret));
++            if (err) {
++                error_reportf_err(err, "Failed to synchronize CPU state: ");
++            } else {
++                error_report("Failed to get registers: %s", strerror(-ret));
++            }
++
+             cpu_dump_state(cpu, stderr, CPU_DUMP_CODE);
+             vm_stop(RUN_STATE_INTERNAL_ERROR);
+         }
+@@ -2720,9 +2726,15 @@ void kvm_cpu_synchronize_state(CPUState *cpu)
+ 
+ static void do_kvm_cpu_synchronize_post_reset(CPUState *cpu, run_on_cpu_data arg)
+ {
+-    int ret = kvm_arch_put_registers(cpu, KVM_PUT_RESET_STATE);
++    Error *err = NULL;
++    int ret = kvm_arch_put_registers(cpu, KVM_PUT_RESET_STATE, &err);
+     if (ret) {
+-        error_report("Failed to put registers after reset: %s", strerror(-ret));
++        if (err) {
++            error_reportf_err(err, "Restoring resisters after reset: ");
++        } else {
++            error_report("Failed to put registers after reset: %s",
++                         strerror(-ret));
++        }
+         cpu_dump_state(cpu, stderr, CPU_DUMP_CODE);
+         vm_stop(RUN_STATE_INTERNAL_ERROR);
+     }
+@@ -2737,9 +2749,15 @@ void kvm_cpu_synchronize_post_reset(CPUState *cpu)
+ 
+ static void do_kvm_cpu_synchronize_post_init(CPUState *cpu, run_on_cpu_data arg)
+ {
+-    int ret = kvm_arch_put_registers(cpu, KVM_PUT_FULL_STATE);
++    Error *err = NULL;
++    int ret = kvm_arch_put_registers(cpu, KVM_PUT_FULL_STATE, &err);
+     if (ret) {
+-        error_report("Failed to put registers after init: %s", strerror(-ret));
++        if (err) {
++            error_reportf_err(err, "Putting registers after init: ");
++        } else {
++            error_report("Failed to put registers after init: %s",
++                         strerror(-ret));
++        }
+         exit(1);
+     }
+ 
+@@ -2835,10 +2853,15 @@ int kvm_cpu_exec(CPUState *cpu)
+         MemTxAttrs attrs;
+ 
+         if (cpu->vcpu_dirty) {
+-            ret = kvm_arch_put_registers(cpu, KVM_PUT_RUNTIME_STATE);
++            Error *err = NULL;
++            ret = kvm_arch_put_registers(cpu, KVM_PUT_RUNTIME_STATE, &err);
+             if (ret) {
+-                error_report("Failed to put registers after init: %s",
+-                             strerror(-ret));
++                if (err) {
++                    error_reportf_err(err, "Putting registers after init: ");
++                } else {
++                    error_report("Failed to put registers after init: %s",
++                                 strerror(-ret));
++                }
+                 ret = -1;
+                 break;
+             }
+diff --git a/include/sysemu/kvm.h b/include/sysemu/kvm.h
+index d614878164..eaba7fc319 100644
+--- a/include/sysemu/kvm.h
++++ b/include/sysemu/kvm.h
+@@ -326,7 +326,7 @@ int kvm_arch_handle_exit(CPUState *cpu, struct kvm_run *run);
+ 
+ int kvm_arch_process_async_events(CPUState *cpu);
+ 
+-int kvm_arch_get_registers(CPUState *cpu);
++int kvm_arch_get_registers(CPUState *cpu, Error **errp);
+ 
+ /* state subset only touched by the VCPU itself during runtime */
+ #define KVM_PUT_RUNTIME_STATE   1
+@@ -335,7 +335,7 @@ int kvm_arch_get_registers(CPUState *cpu);
+ /* full state set, modified during initialization or on vmload */
+ #define KVM_PUT_FULL_STATE      3
+ 
+-int kvm_arch_put_registers(CPUState *cpu, int level);
++int kvm_arch_put_registers(CPUState *cpu, int level, Error **errp);
+ 
+ int kvm_arch_get_default_type(MachineState *ms);
+ 
+diff --git a/target/i386/kvm/kvm.c b/target/i386/kvm/kvm.c
+index a0bc9ea7b1..ab0c6499f5 100644
+--- a/target/i386/kvm/kvm.c
++++ b/target/i386/kvm/kvm.c
+@@ -4552,7 +4552,7 @@ static int kvm_get_nested_state(X86CPU *cpu)
+     return ret;
+ }
+ 
+-int kvm_arch_put_registers(CPUState *cpu, int level)
++int kvm_arch_put_registers(CPUState *cpu, int level, Error **errp)
+ {
+     X86CPU *x86_cpu = X86_CPU(cpu);
+     int ret;
+@@ -4640,7 +4640,7 @@ int kvm_arch_put_registers(CPUState *cpu, int level)
+     return 0;
+ }
+ 
+-int kvm_arch_get_registers(CPUState *cs)
++int kvm_arch_get_registers(CPUState *cs, Error **errp)
+ {
+     X86CPU *cpu = X86_CPU(cs);
+     int ret;
+diff --git a/target/mips/kvm.c b/target/mips/kvm.c
+index e22e24ed97..6bf2a9b76e 100644
+--- a/target/mips/kvm.c
++++ b/target/mips/kvm.c
+@@ -1179,7 +1179,7 @@ static int kvm_mips_get_cp0_registers(CPUState *cs)
+     return ret;
+ }
+ 
+-int kvm_arch_put_registers(CPUState *cs, int level)
++int kvm_arch_put_registers(CPUState *cs, int level, Error **errp)
+ {
+     MIPSCPU *cpu = MIPS_CPU(cs);
+     CPUMIPSState *env = &cpu->env;
+@@ -1215,7 +1215,7 @@ int kvm_arch_put_registers(CPUState *cs, int level)
+     return ret;
+ }
+ 
+-int kvm_arch_get_registers(CPUState *cs)
++int kvm_arch_get_registers(CPUState *cs, Error **errp)
+ {
+     MIPSCPU *cpu = MIPS_CPU(cs);
+     CPUMIPSState *env = &cpu->env;
+diff --git a/target/ppc/kvm.c b/target/ppc/kvm.c
+index 9b1abe2fc4..c84a252f0a 100644
+--- a/target/ppc/kvm.c
++++ b/target/ppc/kvm.c
+@@ -897,7 +897,7 @@ int kvmppc_put_books_sregs(PowerPCCPU *cpu)
+     return kvm_vcpu_ioctl(CPU(cpu), KVM_SET_SREGS, &sregs);
+ }
+ 
+-int kvm_arch_put_registers(CPUState *cs, int level)
++int kvm_arch_put_registers(CPUState *cs, int level, Error **errp)
+ {
+     PowerPCCPU *cpu = POWERPC_CPU(cs);
+     CPUPPCState *env = &cpu->env;
+@@ -1202,7 +1202,7 @@ static int kvmppc_get_books_sregs(PowerPCCPU *cpu)
+     return 0;
+ }
+ 
+-int kvm_arch_get_registers(CPUState *cs)
++int kvm_arch_get_registers(CPUState *cs, Error **errp)
+ {
+     PowerPCCPU *cpu = POWERPC_CPU(cs);
+     CPUPPCState *env = &cpu->env;
+diff --git a/target/riscv/kvm/kvm-cpu.c b/target/riscv/kvm/kvm-cpu.c
+index 117e33cf90..529381dd5f 100644
+--- a/target/riscv/kvm/kvm-cpu.c
++++ b/target/riscv/kvm/kvm-cpu.c
+@@ -964,7 +964,7 @@ const KVMCapabilityInfo kvm_arch_required_capabilities[] = {
+     KVM_CAP_LAST_INFO
+ };
+ 
+-int kvm_arch_get_registers(CPUState *cs)
++int kvm_arch_get_registers(CPUState *cs, Error **errp)
+ {
+     int ret = 0;
+ 
+@@ -1004,7 +1004,7 @@ int kvm_riscv_sync_mpstate_to_kvm(RISCVCPU *cpu, int state)
+     return 0;
+ }
+ 
+-int kvm_arch_put_registers(CPUState *cs, int level)
++int kvm_arch_put_registers(CPUState *cs, int level, Error **errp)
+ {
+     int ret = 0;
+ 
+diff --git a/target/s390x/kvm/kvm.c b/target/s390x/kvm/kvm.c
+index 33ab3551f4..26a5b4e804 100644
+--- a/target/s390x/kvm/kvm.c
++++ b/target/s390x/kvm/kvm.c
+@@ -472,7 +472,7 @@ static int can_sync_regs(CPUState *cs, int regs)
+ #define KVM_SYNC_REQUIRED_REGS (KVM_SYNC_GPRS | KVM_SYNC_ACRS | \
+                                 KVM_SYNC_CRS | KVM_SYNC_PREFIX)
+ 
+-int kvm_arch_put_registers(CPUState *cs, int level)
++int kvm_arch_put_registers(CPUState *cs, int level, Error **errp)
+ {
+     S390CPU *cpu = S390_CPU(cs);
+     CPUS390XState *env = &cpu->env;
+@@ -599,7 +599,7 @@ int kvm_arch_put_registers(CPUState *cs, int level)
+     return 0;
+ }
+ 
+-int kvm_arch_get_registers(CPUState *cs)
++int kvm_arch_get_registers(CPUState *cs, Error **errp)
+ {
+     S390CPU *cpu = S390_CPU(cs);
+     CPUS390XState *env = &cpu->env;
+-- 
+2.43.0
+

--- a/patches/qemu-0002-target-i386-kvm-Report-which-action-failed-in-kvm_ar.patch
+++ b/patches/qemu-0002-target-i386-kvm-Report-which-action-failed-in-kvm_ar.patch
@@ -1,0 +1,169 @@
+From f680584567227c2af540cf93c7eacaf932a2b1a3 Mon Sep 17 00:00:00 2001
+From: Julia Suvorova <jusual@redhat.com>
+Date: Fri, 27 Sep 2024 12:47:41 +0200
+Subject: [PATCH 2/2] target/i386/kvm: Report which action failed in
+ kvm_arch_put/get_registers
+
+To help debug and triage future failure reports (akin to [1,2]) that
+may occur during kvm_arch_put/get_registers, the error path of each
+action is accompanied by unique error message.
+
+[1] https://issues.redhat.com/browse/RHEL-7558
+[2] https://issues.redhat.com/browse/RHEL-21761
+
+Signed-off-by: Julia Suvorova <jusual@redhat.com>
+Reviewed-by: Peter Xu <peterx@redhat.com>
+Link: https://lore.kernel.org/r/20240927104743.218468-3-jusual@redhat.com
+Signed-off-by: Paolo Bonzini <pbonzini@redhat.com>
+(cherry picked from commit fc058618d1596d29e89016750a1aaf64c9fe8832)
+---
+ target/i386/kvm/kvm.c | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/target/i386/kvm/kvm.c b/target/i386/kvm/kvm.c
+index ab0c6499f5..b61b32ca01 100644
+--- a/target/i386/kvm/kvm.c
++++ b/target/i386/kvm/kvm.c
+@@ -4567,6 +4567,7 @@ int kvm_arch_put_registers(CPUState *cpu, int level, Error **errp)
+     if (level >= KVM_PUT_RESET_STATE) {
+         ret = kvm_put_msr_feature_control(x86_cpu);
+         if (ret < 0) {
++            error_setg_errno(errp, -ret, "Failed to set feature control MSR");
+             return ret;
+         }
+     }
+@@ -4574,12 +4575,14 @@ int kvm_arch_put_registers(CPUState *cpu, int level, Error **errp)
+     /* must be before kvm_put_nested_state so that EFER.SVME is set */
+     ret = has_sregs2 ? kvm_put_sregs2(x86_cpu) : kvm_put_sregs(x86_cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to set special registers");
+         return ret;
+     }
+ 
+     if (level >= KVM_PUT_RESET_STATE) {
+         ret = kvm_put_nested_state(x86_cpu);
+         if (ret < 0) {
++            error_setg_errno(errp, -ret, "Failed to set nested state");
+             return ret;
+         }
+     }
+@@ -4597,6 +4600,7 @@ int kvm_arch_put_registers(CPUState *cpu, int level, Error **errp)
+     if (xen_mode == XEN_EMULATE && level == KVM_PUT_FULL_STATE) {
+         ret = kvm_put_xen_state(cpu);
+         if (ret < 0) {
++            error_setg_errno(errp, -ret, "Failed to set Xen state");
+             return ret;
+         }
+     }
+@@ -4604,37 +4608,45 @@ int kvm_arch_put_registers(CPUState *cpu, int level, Error **errp)
+ 
+     ret = kvm_getput_regs(x86_cpu, 1);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to set general purpose registers");
+         return ret;
+     }
+     ret = kvm_put_xsave(x86_cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to set XSAVE");
+         return ret;
+     }
+     ret = kvm_put_xcrs(x86_cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to set XCRs");
+         return ret;
+     }
+     ret = kvm_put_msrs(x86_cpu, level);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to set MSRs");
+         return ret;
+     }
+     ret = kvm_put_vcpu_events(x86_cpu, level);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to set vCPU events");
+         return ret;
+     }
+     if (level >= KVM_PUT_RESET_STATE) {
+         ret = kvm_put_mp_state(x86_cpu);
+         if (ret < 0) {
++            error_setg_errno(errp, -ret, "Failed to set MP state");
+             return ret;
+         }
+     }
+ 
+     ret = kvm_put_tscdeadline_msr(x86_cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to set TSC deadline MSR");
+         return ret;
+     }
+     ret = kvm_put_debugregs(x86_cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to set debug registers");
+         return ret;
+     }
+     return 0;
+@@ -4649,6 +4661,7 @@ int kvm_arch_get_registers(CPUState *cs, Error **errp)
+ 
+     ret = kvm_get_vcpu_events(cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to get vCPU events");
+         goto out;
+     }
+     /*
+@@ -4657,44 +4670,54 @@ int kvm_arch_get_registers(CPUState *cs, Error **errp)
+      */
+     ret = kvm_get_mp_state(cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to get MP state");
+         goto out;
+     }
+     ret = kvm_getput_regs(cpu, 0);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to get general purpose registers");
+         goto out;
+     }
+     ret = kvm_get_xsave(cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to get XSAVE");
+         goto out;
+     }
+     ret = kvm_get_xcrs(cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to get XCRs");
+         goto out;
+     }
+     ret = has_sregs2 ? kvm_get_sregs2(cpu) : kvm_get_sregs(cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to get special registers");
+         goto out;
+     }
+     ret = kvm_get_msrs(cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to get MSRs");
+         goto out;
+     }
+     ret = kvm_get_apic(cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to get APIC");
+         goto out;
+     }
+     ret = kvm_get_debugregs(cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to get debug registers");
+         goto out;
+     }
+     ret = kvm_get_nested_state(cpu);
+     if (ret < 0) {
++        error_setg_errno(errp, -ret, "Failed to get nested state");
+         goto out;
+     }
+ #ifdef CONFIG_XEN_EMU
+     if (xen_mode == XEN_EMULATE) {
+         ret = kvm_get_xen_state(cs);
+         if (ret < 0) {
++            error_setg_errno(errp, -ret, "Failed to get Xen state");
+             goto out;
+         }
+     }
+-- 
+2.43.0
+

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -290,7 +290,7 @@ parts:
 
   criu:
     source: https://github.com/checkpoint-restore/criu
-    source-commit: c2b48ff423aa663b3534a5ba96907366e4c1b408 # v4.0
+    source-commit: b6059ff193a9b0dff98e997134d662c3ccfd1600 # v4.1
     source-depth: 1
     source-type: git
     plugin: nil

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -295,7 +295,7 @@ parts:
     source-type: git
     plugin: nil
     build-packages:
-      - to riscv64:
+      - to armhf:
         - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
       - else:
         - asciidoc
@@ -314,15 +314,19 @@ parts:
         - libnet1
         - libprotobuf-c1
     override-stage: |-
+      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-prime: |-
+      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-pull: |-
+      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-build: |-
+      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       set -ex
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1325,7 +1325,6 @@ parts:
     source-depth: 1
     source-type: git
     build-packages:
-      - dpkg-dev
       - libapparmor-dev
       - libcap-dev
       - libdbus-1-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -590,12 +590,12 @@ parts:
 
   nvidia-container:
     source: https://github.com/NVIDIA/libnvidia-container
-    source-commit: f23e5e55ea27b3680aef363436d4bcf7659e0bfc # v1.17.4
+    source-commit: a198166e1c1166f4847598438115ea97dacc7a92 # v1.17.6
     source-depth: 1
     source-type: git
     plugin: make
     build-environment:
-      - GIT_TAG: "1.17.4" # Enables source-depth: 1, should match git tag without "v" prefix.
+      - GIT_TAG: "1.17.6" # Enables source-depth: 1, should match git tag without "v" prefix.
     build-packages:
       - to amd64:
         - bmake

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1369,8 +1369,8 @@ parts:
       git config user.name "LXD snap builder"
 
       # lxc-checkconfig.in does not need any preprocessing
-      mkdir -p bin
-      install --mode=0755 src/lxc/cmd/lxc-checkconfig.in bin/lxc-checkconfig
+      mkdir -p "${CRAFT_PART_INSTALL}/bin/"
+      install --mode=0755 src/lxc/cmd/lxc-checkconfig.in "${CRAFT_PART_INSTALL}/bin/lxc-checkconfig"
 
       cd ../build
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -612,7 +612,7 @@ parts:
         - lsb-release
         - libtirpc-dev
     build-snaps:
-      - go/1.23/stable
+      - go/1.24/stable
     override-stage: |-
       [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
       craftctl default
@@ -652,7 +652,7 @@ parts:
     source-commit: e627eb2e21e167988e04c0579a1c941c1e263ff6 # v1.17.6
     source-type: git
     build-snaps:
-      - go/1.23/stable
+      - go/1.24/stable
     plugin: make
     override-stage: |-
       [ "$(uname -m)" = "armv7l" ] && exit 0
@@ -1494,7 +1494,7 @@ parts:
       - python3-pip
       - python3-venv
     build-snaps:
-      - go/1.23/stable
+      - go/1.24/stable
     stage-packages:
       - acl
       - attr

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1328,7 +1328,6 @@ parts:
       - libapparmor-dev
       - libcap-dev
       - libseccomp-dev
-      - libselinux1-dev
       - pkg-config
       - meson
       - ninja-build
@@ -1345,7 +1344,7 @@ parts:
       - -Dprefix=/
       - -Drootfs-mount-path=/var/snap/lxd/common/lxc/
       - -Dseccomp=true
-      - -Dselinux=true
+      - -Dselinux=false
       - -Dtests=false
       - -Dtools=false
     organize:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1347,6 +1347,7 @@ parts:
       - -Drootfs-mount-path=/var/snap/lxd/common/lxc/
       - -Dseccomp=true
       - -Dselinux=false
+      - -Dspecfile=false
       - -Dtests=false
       - -Dtools=false
     organize:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1347,10 +1347,8 @@ parts:
       - -Dselinux=true
       - -Dcapabilities=true
       - -Drootfs-mount-path=/var/snap/lxd/common/lxc/
-      - -Dlibexecdir=/snap/lxd/current/libexec/
     organize:
       snap/lxd/current/lxc: lxc
-      snap/lxd/current/libexec: libexec
       share/lxc/hooks: lxc/hooks
     prime:
       - bin/lxc-checkconfig

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1495,7 +1495,7 @@ parts:
     source: https://github.com/canonical/lxd
     # XXX: We often cherry-pick for candidate builds so don't do shallow clone
     #source-depth: 1
-    source-commit: b11db8442a9a097aef9b191e0482c3db1e2271e4 # lxd-6.3
+    source-commit: bafdc4c506f0c9a3fac6ee41705b9d883fa53b5f # pre lxd-6.34
     source-type: git
     after:
       - lxc
@@ -1551,14 +1551,6 @@ parts:
       cd ../src
       git config user.email "noreply@lists.canonical.com"
       git config user.name "LXD snap builder"
-
-      git cherry-pick -x c6bc0a628ffbe18f65cb2a26b3d8d03d2911adb1 # lxd/api_project: Fix condition checking associated profiles in projectIsEmpty
-      git cherry-pick -x 731bd0b5b38829a89c071b0477f773ca2601b559 # lxd/storage/drivers/pure: Unmap volume when connection is freshly created
-      git cherry-pick -x 0d3f8d25a9dbbdf22a8b05631d6f494c9971a5d7 # shared/validate: Support none for `cloud-init.ssh-keys.*`
-      git cherry-pick -x 197a0238f7f7d80c123f6e0c1716f4efc0e8de2f # lxd/network/driver_bridge: add "/" back into fanAddress() output
-      git revert cd8966843783eee339329f13e06f68cd2cfbb902 --no-edit # lxd/loki: Add checkLoki function to ensure Loki is ready when creating a new Loki client
-      git cherry-pick -x 77fa926d19ba16f57337f13e9d8a5aa434f302ae # lxd/firewall/drivers/driver/nftables: Fix regression in nftables port range rules
-      git cherry-pick -x efbf416099f1f6a56934d8a26d6e8e003ab4f2d6 # Revert "lxd/ubuntu-pro: Change Ubuntu Pro directory."
 
       # Setup build environment
       export GOTOOLCHAIN="local"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -674,6 +674,9 @@ parts:
       [ "$(uname -m)" = "riscv64" ] && exit 0
       set -ex
 
+      # Setup build environment
+      export GOTOOLCHAIN="local"
+
       make binaries
       mkdir -p "${CRAFT_PART_INSTALL}/bin/"
       cp nvidia-ctk "${CRAFT_PART_INSTALL}/bin/"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1399,7 +1399,7 @@ parts:
 
   lxcfs:
     source: https://github.com/lxc/lxcfs
-    source-commit: 998ed0e374f515ad09d88745a085e277ab4da7a6 # v6.0.3
+    source-commit: 45d026e3e7e46fbb293d977ef20854527b363e2a # v6.0.4
     source-depth: 1
     source-type: git
     build-packages:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -595,7 +595,7 @@ parts:
     source-type: git
     plugin: make
     build-environment:
-      - GIT_TAG: "1.17.6" # Enables source-depth: 1, should match git tag without "v" prefix.
+      - GIT_TAG: "1.17.7" # Enables source-depth: 1, should match git tag without "v" prefix.
     build-packages:
       - to amd64:
         - bmake

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -590,7 +590,7 @@ parts:
 
   nvidia-container:
     source: https://github.com/NVIDIA/libnvidia-container
-    source-commit: a198166e1c1166f4847598438115ea97dacc7a92 # v1.17.6
+    source-commit: d26524ab5db96a55ae86033f53de50d3794fb547 # v1.17.7
     source-depth: 1
     source-type: git
     plugin: make

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1335,18 +1335,18 @@ parts:
       - ninja-build
     plugin: meson
     meson-parameters:
-      - -Dprefix=/
+      - -Dapparmor=true
+      - -Dcapabilities=true
       - -Dexamples=false
       - -Dman=false
-      - -Dopenssl=false
-      - -Dtools=false
-      - -Dtests=false
       - -Dmemfd-rexec=false
-      - -Dapparmor=true
+      - -Dopenssl=false
+      - -Dprefix=/
+      - -Drootfs-mount-path=/var/snap/lxd/common/lxc/
       - -Dseccomp=true
       - -Dselinux=true
-      - -Dcapabilities=true
-      - -Drootfs-mount-path=/var/snap/lxd/common/lxc/
+      - -Dtests=false
+      - -Dtools=false
     organize:
       snap/lxd/current/lxc: lxc
       share/lxc/hooks: lxc/hooks

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1338,6 +1338,8 @@ parts:
       - -Dcommands=false
       - -Ddbus=false
       - -Dexamples=false
+      - -Dinstall-init-files=false
+      - -Dinstall-state-dirs=false
       - -Dman=false
       - -Dmemfd-rexec=false
       - -Dopenssl=false

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1576,6 +1576,16 @@ parts:
       CGO_ENABLED=0 go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/lxd-agent" -tags=agent,netgo github.com/canonical/lxd/lxd-agent
       CGO_ENABLED=0 go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/lxd-user" -tags netgo github.com/canonical/lxd/lxd-user
 
+      # Check which Go version was used to compile each of the lxc/lxd binaries
+      # XXX: fail if an unexpected version (like a Go toolchain) was used
+      GOVER="$(snap list go | awk '{if ($1 == "go") print $2}')"
+      UNEXPECTED_GO_VER="$(go version -v "${CRAFT_PART_INSTALL}/bin/lxc"* "${CRAFT_PART_INSTALL}/bin/lxd"* | grep -vF ": go${GOVER}" || true)"
+      if [ -n "${UNEXPECTED_GO_VER:-}" ]; then
+        echo "Some binaries were compiled with an unexpected Go version (!= ${GOVER}):"
+        echo "${UNEXPECTED_GO_VER}"
+        exit 1
+      fi
+
       # Some python dependencies are not available for armhf/riscv64 or just require a build from source.
       # Not worth the effort for now.
       if [ "$(uname -m)" != "armv7l" ] && [ "$(uname -m)" != "riscv64" ]; then

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -649,7 +649,7 @@ parts:
   nvidia-container-toolkit:
     source: https://github.com/NVIDIA/nvidia-container-toolkit
     source-depth: 1
-    source-commit: 9b69590c7428470a72f2ae05f826412976af1395 # v1.17.4
+    source-commit: e627eb2e21e167988e04c0579a1c941c1e263ff6 # v1.17.6
     source-type: git
     build-snaps:
       - go/1.23/stable

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1366,6 +1366,10 @@ parts:
       git config user.email "noreply@lists.canonical.com"
       git config user.name "LXD snap builder"
 
+      # lxc-checkconfig.in does not need any preprocessing
+      mkdir -p bin
+      install --mode=0755 src/lxc/cmd/lxc-checkconfig.in bin/lxc-checkconfig
+
       cd ../build
 
       set +ex

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1337,7 +1337,7 @@ parts:
     after:
       - apparmor
     source: https://github.com/lxc/lxc
-    source-commit: fe31d844e882d5cc176a7935a93b14b4b2823992 # v6.0.3
+    source-commit: 0fb6eb66d4641f6d791f8524154a18482d523ea3 # v6.0.4
     source-depth: 1
     source-type: git
     build-packages:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -953,6 +953,12 @@ parts:
       # Apply patches from Ubuntu sources.
       QUILT_PATCHES=debian/patches quilt push -a
 
+      # Apply custom patches
+      # These patches enable more accurate error message returned in case of CPU registers mismatches.
+      # This is backported from QEMU v9.2.2.
+      patch -p1 < "${CRAFT_PROJECT_DIR}/patches/qemu-0001-kvm-Allow-kvm_arch_get-put_registers-to-accept-Error.patch"
+      patch -p1 < "${CRAFT_PROJECT_DIR}/patches/qemu-0002-target-i386-kvm-Report-which-action-failed-in-kvm_ar.patch"
+
       sed -i "s/^unset target_list$/target_list=\"${QEMUARCH}-softmmu\"/" configure
       sed -i 's#libseccomp_minver=".*#libseccomp_minver="0.0"#g' configure
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1336,6 +1336,7 @@ parts:
     meson-parameters:
       - -Dapparmor=true
       - -Dcapabilities=true
+      - -Dcommands=false
       - -Ddbus=false
       - -Dexamples=false
       - -Dman=false

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1327,7 +1327,6 @@ parts:
     build-packages:
       - libapparmor-dev
       - libcap-dev
-      - libdbus-1-dev
       - libseccomp-dev
       - libselinux1-dev
       - pkg-config
@@ -1337,6 +1336,7 @@ parts:
     meson-parameters:
       - -Dapparmor=true
       - -Dcapabilities=true
+      - -Ddbus=false
       - -Dexamples=false
       - -Dman=false
       - -Dmemfd-rexec=false

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1333,6 +1333,7 @@ parts:
       - ninja-build
     plugin: meson
     meson-parameters:
+      - "--buildtype=release"
       - -Dapparmor=true
       - -Dcapabilities=true
       - -Dcommands=false

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -836,7 +836,7 @@ parts:
       - libatomic
       - spice-server
     source: https://git.launchpad.net/ubuntu/+source/qemu
-    source-commit: ea5d82865d36eb3052a3090db27cf96d1bf09da5 # import/1%8.2.2+ds-0ubuntu1.6
+    source-commit: ed8ba3428bff0004d8b4961a85225a6ceb443d52 # import/1%8.2.2+ds-0ubuntu1.7
     source-depth: 1
     source-type: git
     plugin: autotools

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1787,6 +1787,13 @@ parts:
 
       # Fixup logrotate.conf permissions to not be group writable
       chmod g-w "${CRAFT_PRIME}/etc/logrotate.conf"
+
+      # XXX: do not keep the duplicated and often outdated CA certificates
+      # store from Python `certifi`. This file is not even used as the
+      # `python3-certifi` package providing it is patched to always use:
+      # `/etc/ssl/certs/ca-certificates.crt`
+      truncate --no-create --size=0 "${CRAFT_PRIME}/lib/python3/dist-packages/certifi/cacert.pem"
+
       exit 0
 
   wrappers:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1335,7 +1335,7 @@ parts:
       - ninja-build
     plugin: meson
     meson-parameters:
-      - --prefix=/
+      - -Dprefix=/
       - -Dexamples=false
       - -Dman=false
       - -Dopenssl=false

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1249,7 +1249,7 @@ parts:
 
   zfs-2-3:
     source: https://github.com/openzfs/zfs
-    source-commit: f3e4043a36942e67ccbc05318479a07d242fc611 # zfs-2.3.1
+    source-commit: 92f430b00f42964b63aee373fbf6598a20f6c0cc # zfs-2.3.2
     source-depth: 1
     source-type: git
     plugin: autotools

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1329,9 +1329,9 @@ parts:
       - libapparmor-dev
       - libcap-dev
       - libdbus-1-dev
-      - libgnutls28-dev
       - libseccomp-dev
       - libselinux1-dev
+      - libssl-dev
       - pkg-config
       - meson
       - ninja-build

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1530,6 +1530,7 @@ parts:
       set -ex
 
       # Setup build environment
+      export GOTOOLCHAIN="local"
       export GOPATH="$(realpath ./.go)"
 
       # Setup the GOPATH
@@ -1556,6 +1557,7 @@ parts:
       git cherry-pick -x efbf416099f1f6a56934d8a26d6e8e003ab4f2d6 # Revert "lxd/ubuntu-pro: Change Ubuntu Pro directory."
 
       # Setup build environment
+      export GOTOOLCHAIN="local"
       export GOPATH="$(realpath ./.go)"
       export CGO_CFLAGS="-I${CRAFT_STAGE}/include/ -I${CRAFT_STAGE}/usr/local/include/"
       export CGO_LDFLAGS="-L${CRAFT_STAGE}/lib/ -L${CRAFT_STAGE}/usr/local/lib/"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -649,7 +649,7 @@ parts:
   nvidia-container-toolkit:
     source: https://github.com/NVIDIA/nvidia-container-toolkit
     source-depth: 1
-    source-commit: e627eb2e21e167988e04c0579a1c941c1e263ff6 # v1.17.6
+    source-commit: bae3e7842ebe26812d8bd6a9be6a14a83dc91d8f # v1.17.7
     source-type: git
     build-snaps:
       - go/1.24/stable

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -626,6 +626,9 @@ parts:
       [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
       set -ex
 
+      # Setup build environment
+      export GOTOOLCHAIN="local"
+
       # Git cherry-picks
       git config user.email "noreply@lists.canonical.com"
       git config user.name "LXD snap builder"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1331,7 +1331,6 @@ parts:
       - libdbus-1-dev
       - libseccomp-dev
       - libselinux1-dev
-      - libssl-dev
       - pkg-config
       - meson
       - ninja-build
@@ -1340,6 +1339,7 @@ parts:
       - --prefix=/
       - -Dexamples=false
       - -Dman=false
+      - -Dopenssl=false
       - -Dtools=false
       - -Dtests=false
       - -Dmemfd-rexec=false

--- a/snapcraft/commands/buginfo
+++ b/snapcraft/commands/buginfo
@@ -36,7 +36,7 @@ echo ""
 
 echo "# Detailed snap information"
 echo '```'
-nsenter -t 1 -m snap info lxd
+nsenter -t 1 -m snap list --all lxd core20 core22 core24 snapd
 echo '```'
 echo ""
 

--- a/snapcraft/commands/buginfo
+++ b/snapcraft/commands/buginfo
@@ -31,7 +31,6 @@ fi
 echo " - Kernel version: $(uname -a)"
 echo " - LXC version: $(lxc --version)"
 echo " - LXD version: $(lxd --version)"
-echo " - Snap revision: ${SNAP_REVISION}"
 echo ""
 
 echo "# Detailed snap information"

--- a/snapcraft/commands/buginfo
+++ b/snapcraft/commands/buginfo
@@ -115,5 +115,5 @@ echo ""
 
 echo "# Systemd log (last 50 lines)"
 echo '```'
-nsenter -t 1 -m journalctl -u snap.lxd.daemon -n50 | cat
+nsenter -t 1 -m journalctl --no-pager -u snap.lxd.daemon -n50
 echo '```'

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -177,7 +177,7 @@ echo "==> Preparing a clean copy of /run"
 if [ -e "/run/.lxd_generated" ]; then
     umount -l /run
 fi
-mount -t tmpfs tmpfs /run -o mode=0755,nosuid,nodev
+mount -t tmpfs tmpfs /run -o mode=0755,nosuid,nodev,size=4M
 touch /run/.lxd_generated
 for entry in NetworkManager resolvconf netconfig snapd snapd.socket snapd-snap.socket systemd udev user; do
     [ -e "/var/lib/snapd/hostfs/run/${entry}" ] || [ -L "/var/lib/snapd/hostfs/run/${entry}" ] || continue

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -264,7 +264,7 @@ echo "==> Preparing a clean copy of /etc"
 if [ -e "/etc/.lxd_generated" ]; then
     umount -l /etc
 fi
-mount -t tmpfs tmpfs /etc -o mode=0755
+mount -t tmpfs tmpfs /etc -o mode=0755,nosuid,nodev,size=4M
 touch /etc/.lxd_generated
 
 ## Generate a new ld.so.cache

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -116,7 +116,7 @@ fi
 
 # Setup rshared propagation on mount holding paths
 for path in "${SNAP_COMMON}/lxd/storage-pools" "${SNAP_COMMON}/lxd/devices"; do
-    if ! cut -d' ' -f5 /proc/self/mountinfo | grep -qF "${path}"; then
+    if ! cut -d' ' -f5 /proc/self/mountinfo | grep -qxF "${path}"; then
         echo "==> Setting up mount propagation on ${path}"
         if [ ! -e "${path}" ]; then
             mkdir -p "${path}"

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -305,7 +305,7 @@ echo "==> Preparing a clean copy of /usr/share/misc"
 if [ -e "/usr/share/misc/.lxd_generated" ]; then
     umount -l /usr/share/misc
 fi
-mount -t tmpfs tmpfs /usr/share/misc -o mode=0755
+mount -t tmpfs tmpfs /usr/share/misc -o mode=0755,nosuid,nodev,size=4M
 touch /usr/share/misc/.lxd_generated
 ln -s "${SNAP_CURRENT}/share/misc/pci.ids" /usr/share/misc/
 ln -s "${SNAP_CURRENT}/share/misc/usb.ids" /usr/share/misc/

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -537,7 +537,6 @@ export LXD_DOCUMENTATION="${SNAP_CURRENT}/share/lxd-documentation"
 # LXC
 ## Host specific overrides
 mkdir -p "${SNAP_COMMON}/lxc"
-touch "${SNAP_COMMON}/lxc/local.conf"
 if [ -d /sys/kernel/security/apparmor ] && ! grep -qF -- "-Ubuntu" /proc/version; then
     echo "==> Detected kernel with partial AppArmor support"
     echo "lxc.apparmor.allow_incomplete = 1" > "${SNAP_COMMON}/lxc/local.conf"

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -107,13 +107,6 @@ if [ ! -e "${SNAP_COMMON}/mntns" ] || [ -L "${SNAP_COMMON}/mntns" ]; then
     ln -s /proc/$$/root "${SNAP_COMMON}/mntns"
 fi
 
-# Fix /dev/pts
-if [ "$(grep -F "devpts /dev/pts " /proc/self/mountinfo)" = "2" ]; then
-    echo "==> Setting up /dev/pts"
-    umount -l /dev/ptmx
-    umount -l /dev/pts
-fi
-
 # Setup rshared propagation on mount holding paths
 for path in "${SNAP_COMMON}/lxd/storage-pools" "${SNAP_COMMON}/lxd/devices"; do
     if ! cut -d' ' -f5 /proc/self/mountinfo | grep -qxF "${path}"; then

--- a/snapcraft/wrappers/kmod
+++ b/snapcraft/wrappers/kmod
@@ -6,7 +6,7 @@ NAME="${0##*/}"
 # Detect base name
 SNAP_BASE="$(sed -n '/^name:/ s/^name:\s*\(core[0-9]\{2\}\)/\1/p' /meta/snap.yaml)"
 
-if [ "$(id -u)" != "0" ] && [ "${NAME}" = "modinfo" ]; then
+if [ "${NAME}" = "modinfo" ] && [ "$(id -u)" != "0" ]; then
     TMPDIR="$(mktemp -d)"
     ln -s "/snap/${SNAP_BASE}/current/bin/kmod" "${TMPDIR}/modinfo"
     "${TMPDIR}/modinfo" "$@"

--- a/snapcraft/wrappers/nvidia-container-cli
+++ b/snapcraft/wrappers/nvidia-container-cli
@@ -6,9 +6,9 @@
 # mesa-2404 snap with NVIDIA drivers connected to it. (At least, I don't know one.)
 # Let's do this like that for now at least for PoC purpose.
 #
-if snapctl is-connected gpu-2404 &&
-   [ -f "${SNAP}/gpu-2404-2/usr/lib/x86_64-linux-gnu/libnvidia-ml.so" ] &&
-   [ -f "${SNAP}/gpu-2404-2/usr/lib/x86_64-linux-gnu/libcuda.so" ];
+if [ -f "${SNAP}/gpu-2404-2/usr/lib/x86_64-linux-gnu/libnvidia-ml.so" ] &&
+   [ -f "${SNAP}/gpu-2404-2/usr/lib/x86_64-linux-gnu/libcuda.so" ] &&
+   snapctl is-connected gpu-2404;
 then
     # We have NVIDIA drivers snap connected, let's use it
     exec nvidia-container-cli.real "$@"


### PR DESCRIPTION
Bumps lxd to equivalent of `latest/edge` ready for pre-LXD 6.4 testing.