### PR TITLE
snapcraft: switch to Go 1.24/stable (5.21-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -665,7 +665,7 @@ parts:
       - lsb-release
       - libtirpc-dev
     build-snaps:
-      - go/1.23/stable
+      - go/1.24/stable
     override-prime: |-
       [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
       craftctl default
@@ -701,7 +701,7 @@ parts:
     source-commit: fa66e4cd562804509055e44a88f666673e6d27c0 # v1.17.2
     source-type: git
     build-snaps:
-      - go/1.23/stable
+      - go/1.24/stable
     plugin: make
     override-prime: |-
       [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "ppc64le" ] && [ "$(uname -m)" != "s390x" ] && exit 0
@@ -1518,7 +1518,7 @@ parts:
       - python3-pip
       - python3-venv
     build-snaps:
-      - go/1.23/stable
+      - go/1.24/stable
     stage-packages:
       - acl
       - attr


### PR DESCRIPTION
(cherry picked from commit 644b813ab8e1a4acfb181ca69e9aa1a5ca58d5a6)