### PR TITLE
Don't use Go toolchain (5.21-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -716,6 +716,9 @@ parts:
       [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "ppc64le" ] && [ "$(uname -m)" != "s390x" ] && exit 0
       set -ex
 
+      # Setup build environment
+      export GOTOOLCHAIN="local"
+
       make binaries
       mkdir -p "${CRAFT_PART_INSTALL}/bin/"
       cp nvidia-ctk "${CRAFT_PART_INSTALL}/bin/"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -676,6 +676,9 @@ parts:
       [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
       set -ex
 
+      # Setup build environment
+      export GOTOOLCHAIN="local"
+
       # Git cherry-picks
       git config user.email "noreply@lists.canonical.com"
       git config user.name "LXD snap builder"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1543,6 +1543,7 @@ parts:
       set -ex
 
       # Setup build environment
+      export GOTOOLCHAIN="local"
       export GOPATH="$(realpath ./.go)"
 
       # Setup the GOPATH
@@ -1561,6 +1562,7 @@ parts:
       git config user.name "LXD snap builder"
 
       # Setup build environment
+      export GOTOOLCHAIN="local"
       export GOPATH="$(realpath ./.go)"
       export CGO_CFLAGS="-I${CRAFT_STAGE}/include/ -I${CRAFT_STAGE}/usr/local/include/"
       export CGO_LDFLAGS="-L${CRAFT_STAGE}/lib/ -L${CRAFT_STAGE}/usr/local/lib/"


### PR DESCRIPTION
Before #813, LP builders tried to update the Go tools:

```
:: + craftctl default
[20/May/2025:16:40:04 +0000] "CONNECT github.com:443 HTTP/1.1" 200 9696216 "-" "git/2.43.0"
[20/May/2025:16:40:58 +0000] "CONNECT github.com:443 HTTP/1.1" 200 122589035 "-" "git/2.43.0"
:: + set -ex
:: ++ realpath ./.go
:: + export GOPATH=/build/lxd/parts/lxd/src/.go
:: + GOPATH=/build/lxd/parts/lxd/src/.go
:: + rm -Rf /build/lxd/parts/lxd/src/.go
:: + mkdir -p /build/lxd/parts/lxd/src/.go/src/github.com/canonical
:: ++ pwd
:: + ln -s /build/lxd/parts/lxd/src /build/lxd/parts/lxd/src/.go/src/github.com/canonical/lxd
:: + go get -v ./...
:: go: downloading go1.24.2 (linux/arm)
```

But we don't want silent upgrades happening.