### PR TITLE
lxd-ui: update 0.17 tag (latest-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1647,7 +1647,7 @@ parts:
     source: https://github.com/canonical/lxd-ui
     source-depth: 1
     source-type: git
-    source-commit: 8712272891f0763088a945e9ebae90c24d8dbd05 # 0.17
+    source-commit: eeeb93abe12a72f2a4a5b1388120b08485f76d0f # 0.17
     plugin: nil
     override-prime: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
- update export instance modal help text
- fix onboarding group reference "admin" vs "admins"