### PR TITLE
lxd-ui: update 0.17 tag (latest-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1647,7 +1647,7 @@ parts:
     source: https://github.com/canonical/lxd-ui
     source-depth: 1
     source-type: git
-    source-commit: eeeb93abe12a72f2a4a5b1388120b08485f76d0f # 0.17
+    source-commit: 1462784c997678ef4795a01d7750003b509ce643 # 0.17
     plugin: nil
     override-prime: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
# More fixes for issues surfaced in QA
- fix(acl) move acl button to empty state center
- fix(networks) read only yaml editor for unamanged networks
- fix(networks) hide acl field on unmanaged networks
- fix(instances) handle duplicate instance names from different projects
well on the all project instance list
- fix(groups) show plus icon next to create group and idp group button
- fix(warnings) rely on can_edit server permission for deleting warnings
- fix(identities) avoid closing tab on deleting identity

see https://github.com/canonical/lxd-ui/pull/1266 https://github.com/canonical/lxd-ui/pull/1265 https://github.com/canonical/lxd-ui/pull/1264