### PR TITLE
snapcraft: nvidia-container: go back to 1.17.6

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -593,12 +593,12 @@ parts:
 
   nvidia-container:
     source: https://github.com/NVIDIA/libnvidia-container
-    source-commit: d26524ab5db96a55ae86033f53de50d3794fb547 # v1.17.7
+    source-commit: a198166e1c1166f4847598438115ea97dacc7a92 # v1.17.6
     source-depth: 1
     source-type: git
     plugin: make
     build-environment:
-      - GIT_TAG: "1.17.7" # Enables source-depth: 1, should match git tag without "v" prefix.
+      - GIT_TAG: "1.17.6" # Enables source-depth: 1, should match git tag without "v" prefix.
     build-packages:
       - to amd64:
         - bmake


### PR DESCRIPTION
Avoid regression caused by https://github.com/NVIDIA/libnvidia-container/commit/8ed5824a077afca42b54b7ad0b2b621f00d6127f