### PR TITLE
lxd-ui: use 0.17.1 tag (latest-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1653,7 +1653,7 @@ parts:
     source: https://github.com/canonical/lxd-ui
     source-depth: 1
     source-type: git
-    source-commit: 4d18330fb56946a8c356d1ccfe2efb0fe621adbf # 0.17
+    source-commit: f5d65e9fa1b25b20052a044c6a4cc48608f49158 # 0.17.1
     plugin: nil
     override-prime: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
* include fix for cluster member management, see https://github.com/canonical/lxd-ui/releases/tag/0.17.1

Fixes https://github.com/canonical/lxd-ui/issues/1291