### PR TITLE
Use empty `build-packages` and `stage-packages` list instead of placeholder package

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -219,8 +219,7 @@ parts:
     plugin: nil
     stage-packages:
       # XXX: explicitly depend on libsnappy1v5 due to https://bugs.launchpad.net/ubuntu/+source/ceph/+bug/2072656
-      - to armhf:
-        - acl      # placeholder pkg (actually used by lxd part) to avoid installing stage-packages on unsupported arches
+      - to armhf: []
       - else:
         - ceph-common
         - libsnappy1v5

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -701,8 +701,7 @@ parts:
   openvswitch:
     plugin: nil
     stage-packages:
-      - to armhf:
-        - acl      # placeholder pkg (actually used by lxd part) to avoid installing stage-packages on unsupported arches
+      - to armhf: []
       - else:
         - openvswitch-common
         - openvswitch-switch

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1262,8 +1262,7 @@ parts:
       - --prefix=/
       - --with-config=user
     build-packages:
-      - to armhf:
-        - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
+      - to armhf: []
       - else:
         - libblkid-dev
         - libssl-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -788,8 +788,7 @@ parts:
         - meson
         - ninja-build
     stage-packages:
-      - to armhf:
-        - acl      # placeholder pkg (actually used by lxd part) to avoid installing stage-packages on unsupported arches
+      - to armhf: []
       - else:
         - libjpeg-turbo8
         - libpixman-1-0

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1213,8 +1213,7 @@ parts:
       - --prefix=/
       - --with-config=user
     build-packages:
-      - to armhf:
-        - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
+      - to armhf: []
       - else:
         - libblkid-dev
         - libssl-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1164,8 +1164,7 @@ parts:
       - --prefix=/
       - --with-config=user
     build-packages:
-      - to armhf:
-        - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
+      - to armhf: []
       - else:
         - libblkid-dev
         - libssl-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -779,8 +779,7 @@ parts:
       - -Dsmartcard=disabled
       - -Dtests=false
     build-packages:
-      - to armhf:
-        - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
+      - to armhf: []
       - else:
         - libspice-protocol-dev
         - libjpeg-turbo8-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -919,8 +919,7 @@ parts:
         - quilt
         - librbd-dev
     stage-packages:
-      - to armhf:
-        - acl      # placeholder pkg (actually used by lxd part) to avoid installing stage-packages on unsupported arches
+      - to armhf: []
       - else:
         - genisoimage
         - ipxe-qemu # This is needed due to --disable-install-blobs.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -294,8 +294,7 @@ parts:
     source-type: git
     plugin: nil
     build-packages:
-      - to armhf:
-        - cmake      # placeholder pkg (actually used by lxd part) to avoid installing build-packages on unsupported arches
+      - to armhf: []
       - else:
         - asciidoc
         - libcap-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -736,8 +736,7 @@ parts:
       - openvswitch
     plugin: nil
     stage-packages:
-      - to armhf:
-        - acl      # placeholder pkg (actually used by lxd part) to avoid installing stage-packages on unsupported arches
+      - to armhf: []
       - else:
         - ovn-common
     override-stage: |-

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -900,8 +900,7 @@ parts:
       - --localstatedir=/var/
       - --disable-install-blobs # Ubuntu sources don't have the ROM blobs in them.
     build-packages:
-      - to armhf:
-        - cmake      # placeholder pkg (actually used by lxd part) to avoid installing stage-packages on unsupported arches
+      - to armhf: []
       - else:
         - bison
         - bzip2

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1079,8 +1079,7 @@ parts:
   virtiofsd:
     plugin: nil
     stage-packages:
-      - to armhf:
-        - acl      # placeholder pkg (actually used by lxd part) to avoid installing stage-packages on unsupported arches
+      - to armhf: []
       - else:
         - virtiofsd
     organize:


### PR DESCRIPTION
As noted by @tomponline the kludge of providing an unrelated package to the `armhf` list was quite confusing and turned out to not be needed. I probably had tried an empty list but with this bogus syntax:

```
    stage-packages:
      - to armhf:
      - else:
        ...
```

and (wrongly) concluded that empty lists were not possible while in fact it just needs to be properly formatted:

```
    stage-packages:
      - to armhf: []
      - else:
        ...
```