### PR TITLE
edk2-vars-generator/UEFI/Qemu.py: correct QemuEfiFlashSize

### DIFF
--- a/edk2-vars-generator/UEFI/Qemu.py
+++ b/edk2-vars-generator/UEFI/Qemu.py
@@ -37,7 +37,7 @@ class QemuEfiVariant(enum.Enum):
 
 
 class QemuEfiFlashSize(enum.Enum):
-    DEFAULT = enum.auto
+    DEFAULT = enum.auto()
     SIZE_2MB = enum.auto()
     SIZE_4MB = enum.auto()
 


### PR DESCRIPTION
Add missing parentheses to avoid an error

    TypeError: unable to increment <class 'enum.auto'>

when running ./edk2-vars-generator --help.

Fixes: 3e4c24ee2b86 ("qemu-ovmf-secureboot: Move to edk2-vars-generator")