### PR TITLE
enable non-shallow clone for lxd

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1479,7 +1479,7 @@ parts:
 
   lxd:
     source: https://github.com/canonical/lxd
-    source-depth: 1
+    source-depth: 0
     source-type: git
     after:
       - lxc


### PR DESCRIPTION
LXD documentation requires `sphinx-last-updated-by-git`, which requires a non-shallow clone to enable both sitemap `<lastmod>` and the `Last updated on <date>` notice on each docs page.