### PR TITLE
criu: provide empty `stage-packages` list for `armhf`

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -306,8 +306,7 @@ parts:
         - protobuf-compiler
         - xmlto
     stage-packages:
-      - to riscv64:
-        - acl      # placeholder pkg (actually used by lxd part) to avoid installing stage-packages on unsupported arches
+      - to armhf: []
       - else:
         - libnet1
         - libprotobuf-c1


### PR DESCRIPTION
Even if that part is not shipped in `riscv64` builds, those packages are available.