### PR TITLE
lxd-ui: new 0.15.2 tag (5.21-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1649,7 +1649,7 @@ parts:
     source: https://github.com/canonical/lxd-ui
     source-depth: 1
     source-type: git
-    source-commit: 39d3dec7d0d571fb87545fc0aa3913007a7cef75 # 0.15.1
+    source-commit: 1662dfc5aa0dc251a28b8eddcb959d68ec621114 # 0.15.2
     plugin: nil
     override-prime: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
# Done
- use new tag 0.15.2 
- for full changelist see https://github.com/canonical/lxd-ui/releases/tag/0.15.2