### PR TITLE
snapcraft: Set correct tag for dqlite v1.17.2 release tag (5.21-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -305,7 +305,7 @@ parts:
       - sqlite
     source: https://github.com/canonical/dqlite
     source-depth: 1
-    source-commit: b18dfbc3f9f89ed219611e88bad1fa17d1e9e818 # v1.17.2 LTS
+    source-commit: 1c3f95492dfb4c649356d5b6f2c031bcd3fd7c0f # v1.17.2 LTS
     source-type: git
     plugin: autotools
     autotools-configure-parameters:


### PR DESCRIPTION
The commit doesn't anymore match the release tag.
See https://github.com/canonical/dqlite/releases/tag/v1.17.2