### PR TITLE
snapcraft: Replace deprecated AGPL-3.0 identifier

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -5,7 +5,7 @@ assumes:
 version: git
 grade: devel
 summary: LXD - container and VM manager
-license: AGPL-3.0
+license: AGPL-3.0-only
 title: LXD
 description: |-
  LXD is a system container and virtual machine manager.


### PR DESCRIPTION
One should either use AGPL-3.0-only or AGPL-3.0-or-later.