### PR TITLE
snapcraft: Replace deprecated AGPL-3.0 identifier (latest-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -5,7 +5,7 @@ assumes:
 version: "6.4"
 grade: stable
 summary: LXD - container and VM manager
-license: AGPL-3.0
+license: AGPL-3.0-only
 title: LXD
 description: |-
  LXD is a system container and virtual machine manager.


### PR DESCRIPTION
One should either use AGPL-3.0-only or AGPL-3.0-or-later.

(cherry picked from commit a88da5dcd500e77bedc83194c7f466ab83e21043)