### PR TITLE
lxd-ui: new 0.18 tag (latest-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1653,7 +1653,7 @@ parts:
     source: https://github.com/canonical/lxd-ui
     source-depth: 1
     source-type: git
-    source-commit: 6607f2f9dc34a16577b741a4015e4f1d7a9840f8 # 0.17.2
+    source-commit: c38fea4ffcb5716b4ab6ee24d2234187ac2ffa9a # 0.18
     plugin: nil
     override-prime: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
content details in https://github.com/canonical/lxd-ui/releases/tag/0.18