### PR TITLE
lxd-ui: update 0.18 tag with additional fixes (latest-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1583,7 +1583,7 @@ parts:
     source: https://github.com/canonical/lxd-ui
     source-depth: 1
     source-type: git
-    source-commit: 6e98da6d111c77abf09b0f7fac8845198afff41d # 0.18
+    source-commit: 5e7cb040fe079c6026e08391f9c0550f3cb26109 # 0.18
     plugin: nil
     override-prime: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
# Done
new release, see https://github.com/canonical/lxd-ui/releases/tag/0.18
additional commits:

fix(test) ensure doc links test uses updated title of documentation article by @edlerd in https://github.com/canonical/lxd-ui/pull/1398
fix(test) doc caption change will be backported to 5.21, so we always expect the new copy by @edlerd in https://github.com/canonical/lxd-ui/pull/1400
Fixes by @edlerd in https://github.com/canonical/lxd-ui/pull/1401
fix(instance) avoid many queries when showing instance log files by @edlerd in https://github.com/canonical/lxd-ui/pull/1404