### PR TITLE
lxd-ui: update 0.18 tag with additional changes (latest-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1583,7 +1583,7 @@ parts:
     source: https://github.com/canonical/lxd-ui
     source-depth: 1
     source-type: git
-    source-commit: 5e7cb040fe079c6026e08391f9c0550f3cb26109 # 0.18
+    source-commit: efe590ef394dcb79c2ea3f0391c17d1be8f8e7ca # 0.18
     plugin: nil
     override-prime: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
see https://github.com/canonical/lxd-ui/releases/tag/0.18

fix(vm) shortcuts sent to vms should release modifiers with a slight delay by @edlerd in https://github.com/canonical/lxd-ui/pull/1405