### PR TITLE
Drop `armhf` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ snapcraft
 
 To build the snap for multiple architectures, Launchpad builders can be used.
 
-They are available for various architectures (`amd64`, `armhf`, `arm64`, `ppc64el`, `riscv64` and `s390x`) and you can ask for multiple to be built in parallel. Here's how to build for both `amd64` and `arm64`:
+They are available for various architectures (`amd64`, `arm64`, `ppc64el`, `riscv64` and `s390x`) and you can ask for multiple to be built in parallel. Here's how to build for both `amd64` and `arm64`:
 
 ```
 snapcraft remote-build --launchpad-accept-public-upload --build-for amd64,arm64

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -218,7 +218,7 @@ parts:
     plugin: nil
     stage-packages:
       # XXX: explicitly depend on libsnappy1v5 due to https://bugs.launchpad.net/ubuntu/+source/ceph/+bug/2072656
-      - to armhf: []
+      - to riscv64: []
       - else:
         - ceph-common
         - libsnappy1v5
@@ -226,19 +226,15 @@ parts:
       usr/bin/: bin/
       usr/lib/: lib/
     override-stage: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     prime:
@@ -604,19 +600,15 @@ parts:
       - go/1.24/stable
     plugin: make
     override-stage: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       set -ex
 
@@ -645,24 +637,20 @@ parts:
   openvswitch:
     plugin: nil
     stage-packages:
-      - to armhf: []
+      - to riscv64: []
       - else:
         - openvswitch-common
         - openvswitch-switch
     override-stage: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     organize:
@@ -680,23 +668,19 @@ parts:
       - openvswitch
     plugin: nil
     stage-packages:
-      - to armhf: []
+      - to riscv64: []
       - else:
         - ovn-common
     override-stage: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     organize:
@@ -723,7 +707,7 @@ parts:
       - -Dsmartcard=disabled
       - -Dtests=false
     build-packages:
-      - to armhf: []
+      - to riscv64: []
       - else:
         - libspice-protocol-dev
         - libjpeg-turbo8-dev
@@ -732,24 +716,20 @@ parts:
         - meson
         - ninja-build
     stage-packages:
-      - to armhf: []
+      - to riscv64: []
       - else:
         - libjpeg-turbo8
         - libpixman-1-0
     override-stage: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
 
       # Apply patches from Ubuntu sources.
@@ -844,7 +824,7 @@ parts:
       - --localstatedir=/var/
       - --disable-install-blobs # Ubuntu sources don't have the ROM blobs in them.
     build-packages:
-      - to armhf: []
+      - to riscv64: []
       - else:
         - bison
         - bzip2
@@ -863,7 +843,7 @@ parts:
         - quilt
         - librbd-dev
     stage-packages:
-      - to armhf: []
+      - to riscv64: []
       - else:
         - genisoimage
         - ipxe-qemu # This is needed due to --disable-install-blobs.
@@ -877,19 +857,15 @@ parts:
         - seabios # This is needed due to --disable-install-blobs.
         - qemu-system-data # This is needed due to --disable-install-blobs.
     override-stage: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       set -ex
       # Mangle the configure a bit
@@ -1023,7 +999,7 @@ parts:
   virtiofsd:
     plugin: nil
     stage-packages:
-      - to armhf: []
+      - to riscv64: []
       - else:
         - virtiofsd
     organize:
@@ -1031,19 +1007,15 @@ parts:
     prime:
       - bin/virtiofsd*
     override-stage: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
 
@@ -1108,7 +1080,7 @@ parts:
       - --prefix=/
       - --with-config=user
     build-packages:
-      - to armhf: []
+      - to riscv64: []
       - else:
         - libblkid-dev
         - libssl-dev
@@ -1116,19 +1088,15 @@ parts:
         - zlib1g-dev
         - libtirpc-dev
     override-stage: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
       set -ex
@@ -1157,7 +1125,7 @@ parts:
       - --prefix=/
       - --with-config=user
     build-packages:
-      - to armhf: []
+      - to riscv64: []
       - else:
         - libblkid-dev
         - libssl-dev
@@ -1165,19 +1133,15 @@ parts:
         - zlib1g-dev
         - libtirpc-dev
     override-stage: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
       set -ex
@@ -1206,7 +1170,7 @@ parts:
       - --prefix=/
       - --with-config=user
     build-packages:
-      - to armhf: []
+      - to riscv64: []
       - else:
         - libblkid-dev
         - libssl-dev
@@ -1214,19 +1178,15 @@ parts:
         - zlib1g-dev
         - libtirpc-dev
     override-stage: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
       set -ex
@@ -1510,9 +1470,9 @@ parts:
         exit 1
       fi
 
-      # Some python dependencies are not available for armhf/riscv64 or just require a build from source.
+      # Some python dependencies are not available for riscv64 or just require a build from source.
       # Not worth the effort for now.
-      if [ "$(uname -m)" != "armv7l" ] && [ "$(uname -m)" != "riscv64" ]; then
+      if [ "$(uname -m)" != "riscv64" ]; then
         # Build the static website
         make doc
 


### PR DESCRIPTION
It this PR is merged, the snap package recipes on LP should be updated to remove ARMv7.

* https://launchpad.net/~lxd-snap/lxd/+snap/lxd-latest-edge/+edit
* https://launchpad.net/~lxd-snap/lxd/+snap/lxd-latest-candidate/+edit
