### PR TITLE
commands/daemon: redirect multipath tool to the host

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -244,6 +244,9 @@ ln -s "${SNAP}/wrappers/run-host" "/run/bin/pro"
 # Redirect iscsiadm to the host.
 ln -s "${SNAP}/wrappers/run-host" "/run/bin/iscsiadm"
 
+# Redirect multipath to the host.
+ln -s "${SNAP}/wrappers/run-host" "/run/bin/multipath"
+
 # Avoid xtables talking to nft
 ln -s "${SNAP}/bin/arptables-legacy" "/run/bin/arptables"
 ln -s "${SNAP}/bin/ebtables-legacy" "/run/bin/ebtables"


### PR DESCRIPTION
Required for proper HPE Alletra iSCSI mode support.

I've already tested that this helps on my development environment. So it is good to be merged.