### PR TITLE
lxd: Cherry-pick fix for CDI device cleanup (latest-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1510,6 +1510,7 @@ parts:
       git cherry-pick -x b104b62bca5ac797aaa496be728329190506552f # lxd/storage/patches: Drop `size` from instance volume config on update
       git cherry-pick -x 3944bcf24661b066991370bcbb55d2814a6502f0 # lxd/storage/patches: Remove nested cluster transaction
       git cherry-pick -x 70f259fdad6890a7af20ed78695a671d681c8add # lxd/storage/patches: Remove more nested cluster transactions
+      git cherry-pick -x ddad511605a57c07ae88d5b5e3514d44a6a9b99c # lxd/device/gpu_physical: fix stale CDI-related files cleanup logic
 
       # Setup build environment
       export GOTOOLCHAIN="local"


### PR DESCRIPTION
Cherry-picks fix from https://github.com/canonical/lxd/pull/16600