### PR TITLE
Use `ln -snf` to create symlinks in OVN disconnect hooks

### DIFF
--- a/snapcraft/hooks/disconnect-plug-ovn-certificates
+++ b/snapcraft/hooks/disconnect-plug-ovn-certificates
@@ -38,8 +38,8 @@ if [ -e "/etc/.lxd_generated" ]; then
   ovn_builtin=$(get_bool "$(snapctl get ovn.builtin)")
   if [ "${ovn_builtin:-"false"}" = "true" ]; then
       mkdir -p "${SNAP_COMMON}/ovn"
-      ln -s "${SNAP_COMMON}/ovn" /etc/ovn
+      ln -snf "${SNAP_COMMON}/ovn" /etc/ovn
   else
-      ln -s /var/lib/snapd/hostfs/etc/ovn /etc/ovn
+      ln -snf /var/lib/snapd/hostfs/etc/ovn /etc/ovn
   fi
 fi

--- a/snapcraft/hooks/disconnect-plug-ovn-chassis
+++ b/snapcraft/hooks/disconnect-plug-ovn-chassis
@@ -57,6 +57,6 @@ if [ -e "/etc/.lxd_generated" ]; then
           )
       )
   else
-      ln -s /var/lib/snapd/hostfs/run/openvswitch /run/openvswitch
+      ln -snf /var/lib/snapd/hostfs/run/openvswitch /run/openvswitch
   fi
 fi


### PR DESCRIPTION
This mimics Ceph hooks and also the OVN connect hooks.