### PR TITLE
Save Apparmor `sysctl` changes to a `/run/sysctl.d` dropin

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -58,7 +58,7 @@ fi
 nsenter -t 1 -m systemd-run -u snap."${SNAP_INSTANCE_NAME}".workaround -p Delegate=yes -r /bin/true >/dev/null 2>&1 || true
 
 # Workaround to ensure LXD is stopped before MicroCeph/MicroOVN
-SYSTEMD_OVERRIDE_DIR="/run/systemd/system/snap.lxd.daemon.service.d"
+SYSTEMD_OVERRIDE_DIR="/var/lib/snapd/hostfs/run/systemd/system/snap.lxd.daemon.service.d"
 if [ ! -e "${SYSTEMD_OVERRIDE_DIR}/lxd-shutdown.conf" ]; then
     mkdir -p "${SYSTEMD_OVERRIDE_DIR}"
     echo "[Unit]

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -172,7 +172,7 @@ if [ -e "/run/.lxd_generated" ]; then
 fi
 mount -t tmpfs tmpfs /run -o mode=0755,nosuid,nodev,size=4M
 touch /run/.lxd_generated
-for entry in NetworkManager resolvconf netconfig snapd snapd.socket snapd-snap.socket systemd udev user; do
+for entry in NetworkManager resolvconf netconfig snapd snapd.socket snapd-snap.socket sysctl.d systemd udev user; do
     [ -e "/var/lib/snapd/hostfs/run/${entry}" ] || [ -L "/var/lib/snapd/hostfs/run/${entry}" ] || continue
     ln -s "/var/lib/snapd/hostfs/run/${entry}" "/run/${entry}"
 done
@@ -454,6 +454,52 @@ else
     fi
 fi
 
+manage_apparmor_restrictions() {
+    # sysctl override snippet
+    SYSCTL_FILE="/var/lib/snapd/hostfs/run/sysctl.d/zz-lxd.conf"
+
+    # Check if sysctl settings need to be altered
+    if [ "${apparmor_unprivileged_restrictions_disable:-"true"}" = "true" ]; then
+        KEY_USERNS="kernel.apparmor_restrict_unprivileged_userns"
+        KEY_UNCONFINED="kernel.apparmor_restrict_unprivileged_unconfined"
+        mkdir -p /var/lib/snapd/hostfs/run/sysctl.d
+        tmpf="$(mktemp "${SYSCTL_FILE}".XXXXXX)"
+
+        # userns restriction
+        if [ "$(sysctl -n -e "${KEY_USERNS}")" = "1" ]; then
+            echo "==> Disabling Apparmor unprivileged userns mediation"
+            sysctl -w -e "${KEY_USERNS}=0"
+            echo "${KEY_USERNS} = 0" >> "${tmpf}"
+        fi
+
+        # unconfined restriction
+        if [ "$(sysctl -n -e "${KEY_UNCONFINED}")" = "1" ]; then
+            echo "==> Disabling Apparmor unprivileged unconfined mediation"
+            sysctl -w -e "${KEY_UNCONFINED}=0"
+            echo "${KEY_UNCONFINED} = 0" >> "${tmpf}"
+        fi
+
+        # Save the overrides in a snippet file if content differs or any file is missing
+        if ! cmp --quiet "${tmpf}" "${SYSCTL_FILE}"; then
+            mv "${tmpf}" "${SYSCTL_FILE}"
+        else
+            rm "${tmpf}"
+        fi
+
+        # Done
+        return
+    fi
+
+    # Check if an old override snippet needs to be unapplied
+    [ -f "${SYSCTL_FILE}" ] || return
+
+    echo "==> Restoring Apparmor unprivileged userns and unconfined mediations"
+
+    # Remove the old override snippet before applying system rules
+    rm "${SYSCTL_FILE}"
+    nsenter -t 1 -m systemctl restart systemd-sysctl.service || true
+}
+
 # Update system limits
 if [ "$(stat -c '%u' /proc)" = 0 ]; then
     ## prlimits
@@ -497,21 +543,7 @@ if [ "$(stat -c '%u' /proc)" = 0 ]; then
         fi
     fi
 
-    if [ "${apparmor_unprivileged_restrictions_disable:-"true"}" = "true" ]; then
-        if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
-            if [ "$(cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" = "1" ]; then
-                echo "==> Disabling Apparmor unprivileged userns mediation"
-                echo 0 > /proc/sys/kernel/apparmor_restrict_unprivileged_userns || true
-            fi
-        fi
-
-        if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_unconfined ]; then
-            if [ "$(cat /proc/sys/kernel/apparmor_restrict_unprivileged_unconfined)" = "1" ]; then
-                echo "==> Disabling Apparmor unprivileged unconfined mediation"
-                echo 0 > /proc/sys/kernel/apparmor_restrict_unprivileged_unconfined || true
-            fi
-        fi
-    fi
+    manage_apparmor_restrictions
 fi
 
 # Setup UI

--- a/snapcraft/hooks/remove
+++ b/snapcraft/hooks/remove
@@ -18,7 +18,7 @@ done
 nsenter -t 1 -m systemctl stop snap.lxd.workaround >/dev/null 2>&1 || true
 
 # Remove systemd override snippet
-SYSTEMD_OVERRIDE_DIR="/run/systemd/system/snap.lxd.daemon.service.d"
+SYSTEMD_OVERRIDE_DIR="/var/lib/snapd/hostfs/run/systemd/system/snap.lxd.daemon.service.d"
 if [ -e "${SYSTEMD_OVERRIDE_DIR}/lxd-shutdown.conf" ]; then
     rm "${SYSTEMD_OVERRIDE_DIR}/lxd-shutdown.conf" || true
     rmdir --ignore-fail-on-non-empty "${SYSTEMD_OVERRIDE_DIR}"

--- a/snapcraft/hooks/remove
+++ b/snapcraft/hooks/remove
@@ -25,4 +25,12 @@ if [ -e "${SYSTEMD_OVERRIDE_DIR}/lxd-shutdown.conf" ]; then
     nsenter -t 1 -m systemctl daemon-reload || true
 fi
 
+# Remove sysctl override snippet
+SYSCTL_OVERRIDE_DIR="/var/lib/snapd/hostfs/run/sysctl.d"
+if [ -e "${SYSCTL_OVERRIDE_DIR}/zz-lxd.conf" ]; then
+    rm "${SYSCTL_OVERRIDE_DIR}/zz-lxd.conf" || true
+    rmdir --ignore-fail-on-non-empty "${SYSCTL_OVERRIDE_DIR}"
+    nsenter -t 1 -m systemctl restart systemd-sysctl.service || true
+fi
+
 exit 0


### PR DESCRIPTION
The path fix for `/run/systemd/system/snap.lxd.daemon.service.d` to use the `/var/lib/snapd/hostfs` prefix is mostly for consistency as on a real system, it was still doing the right thing thanks for the symlink trickery done earlier in `daemon.start` where the host's `/run/systemd` directory was symlinked into the snap env because the host's dir normally exist.

Now on my test machine, the host had no `/run/sysctl.d` so the this clued me into adding the missing prefix.