### PR TITLE
daemon.start: make `/run/sysctl.d/zz-lxd.conf` world readable

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -483,6 +483,7 @@ manage_apparmor_restrictions() {
 
         # Save the overrides in a snippet file if content differs or any file is missing
         if ! cmp --quiet "${tmpf}" "${SYSCTL_FILE}"; then
+            chmod a+r "${tmpf}"
             mv "${tmpf}" "${SYSCTL_FILE}"
         else
             rm "${tmpf}"


### PR DESCRIPTION
`mktemp` creates files with `0600` permissions which works fine with tools using it but since its content is not secret, it should be world readable.