### PR TITLE
dqlite: add `xfslibs-dev` to build-packages to enable async-IO on XFS

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -302,6 +302,7 @@ parts:
       - liblz4-dev
       - libsqlite3-dev
       - libuv1-dev
+      - xfslibs-dev
     organize:
       usr/bin/: bin/
       usr/lib/: lib/


### PR DESCRIPTION
Companion PR to https://github.com/canonical/lxd/pull/16748