### PR TITLE
Simplify how Apparmor confinement is detected

### DIFF
--- a/snapcraft/commands/buginfo
+++ b/snapcraft/commands/buginfo
@@ -2,11 +2,9 @@
 set -u
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current 2>/dev/null)"
-  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
-    exec aa-exec -p unconfined -- "$0" "$@"
-  fi
+label="$(cat /proc/self/attr/current 2>/dev/null || echo "unconfined")"
+if [ "${label}" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+  exec aa-exec -p unconfined -- "$0" "$@"
 fi
 
 # Check that we're root

--- a/snapcraft/commands/daemon.activate
+++ b/snapcraft/commands/daemon.activate
@@ -2,17 +2,15 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current 2>/dev/null)"
-  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
-    if ! aa-exec --help >/dev/null 2>&1; then
-        echo "The LXD snap was unable to run aa-exec, this usually indicates a LXD sideload." >&2
-        echo "When sideloading, make sure to manually connect all interfaces." >&2
-        exit 0
-    fi
-
-    exec aa-exec -p unconfined -- "$0" "$@" || true
+label="$(cat /proc/self/attr/current 2>/dev/null || echo "unconfined")"
+if [ "${label}" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+  if ! aa-exec --help >/dev/null 2>&1; then
+      echo "The LXD snap was unable to run aa-exec, this usually indicates a LXD sideload." >&2
+      echo "When sideloading, make sure to manually connect all interfaces." >&2
+      exit 0
   fi
+
+  exec aa-exec -p unconfined -- "$0" "$@" || true
 fi
 
 # shellcheck disable=SC2155

--- a/snapcraft/commands/daemon.reload
+++ b/snapcraft/commands/daemon.reload
@@ -2,11 +2,9 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current 2>/dev/null)"
-  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
-    exec aa-exec -p unconfined -- "$0" "$@"
-  fi
+label="$(cat /proc/self/attr/current 2>/dev/null || echo "unconfined")"
+if [ "${label}" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+  exec aa-exec -p unconfined -- "$0" "$@"
 fi
 
 echo reload > "${SNAP_COMMON}/state"

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -2,11 +2,9 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current 2>/dev/null)"
-  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
-    exec aa-exec -p unconfined -- "$0" "$@"
-  fi
+label="$(cat /proc/self/attr/current 2>/dev/null || echo "unconfined")"
+if [ "${label}" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+  exec aa-exec -p unconfined -- "$0" "$@"
 fi
 
 echo "=> Preparing the system (${SNAP_REVISION})"

--- a/snapcraft/commands/daemon.stop
+++ b/snapcraft/commands/daemon.stop
@@ -2,11 +2,9 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current 2>/dev/null)"
-  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
-    exec aa-exec -p unconfined -- "$0" "$@"
-  fi
+label="$(cat /proc/self/attr/current 2>/dev/null || echo "unconfined")"
+if [ "${label}" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+  exec aa-exec -p unconfined -- "$0" "$@"
 fi
 
 reason="host shutdown"

--- a/snapcraft/commands/lxc
+++ b/snapcraft/commands/lxc
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -eu
 
+# Re-exec outside of apparmor confinement
+label="$(cat /proc/self/attr/current 2>/dev/null || echo "unconfined")"
+if [ "${label}" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+  exec aa-exec -p unconfined -- "$0" "$@"
+fi
+
 # Fill SNAP_REAL_HOME if missing
 if [ -z "${SNAP_REAL_HOME:-""}" ]; then
     SNAP_REAL_HOME="${HOME}"
@@ -38,11 +44,6 @@ export PATH="/run/bin:${PATH}"
 LXC="${SNAP}/bin/lxc"
 if [ -x "${SNAP_COMMON}/lxc.debug" ]; then
     LXC="${SNAP_COMMON}/lxc.debug"
-fi
-
-# Run lxc itself outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ]; then
-  exec /usr/bin/aa-exec -p unconfined -- "${LXC}" "$@"
 fi
 
 # Run lxc itself

--- a/snapcraft/commands/lxd
+++ b/snapcraft/commands/lxd
@@ -2,11 +2,9 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current 2>/dev/null)"
-  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
-    exec aa-exec -p unconfined -- "$0" "$@"
-  fi
+label="$(cat /proc/self/attr/current 2>/dev/null || echo "unconfined")"
+if [ "${label}" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+  exec aa-exec -p unconfined -- "$0" "$@"
 fi
 
 # shellcheck disable=SC2155

--- a/snapcraft/commands/lxd-check-kernel
+++ b/snapcraft/commands/lxd-check-kernel
@@ -2,11 +2,9 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current 2>/dev/null)"
-  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
-    exec aa-exec -p unconfined -- "$0" "$@"
-  fi
+label="$(cat /proc/self/attr/current 2>/dev/null || echo "unconfined")"
+if [ "${label}" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+  exec aa-exec -p unconfined -- "$0" "$@"
 fi
 
 exec lxc-checkconfig

--- a/snapcraft/commands/lxd-user
+++ b/snapcraft/commands/lxd-user
@@ -2,11 +2,9 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current 2>/dev/null)"
-  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
-    exec aa-exec -p unconfined -- "$0" "$@"
-  fi
+label="$(cat /proc/self/attr/current 2>/dev/null || echo "unconfined")"
+if [ "${label}" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+  exec aa-exec -p unconfined -- "$0" "$@"
 fi
 
 # Set the environment

--- a/snapcraft/hooks/configure
+++ b/snapcraft/hooks/configure
@@ -2,11 +2,9 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current 2>/dev/null)"
-  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
-    exec aa-exec -p unconfined -- "$0" "$@"
-  fi
+label="$(cat /proc/self/attr/current 2>/dev/null || echo "unconfined")"
+if [ "${label}" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+  exec aa-exec -p unconfined -- "$0" "$@"
 fi
 
 # Utility functions

--- a/snapcraft/hooks/connect-plug-ceph-conf
+++ b/snapcraft/hooks/connect-plug-ceph-conf
@@ -2,11 +2,9 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current 2>/dev/null)"
-  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
-    exec aa-exec -p unconfined -- "$0" "$@"
-  fi
+label="$(cat /proc/self/attr/current 2>/dev/null || echo "unconfined")"
+if [ "${label}" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+  exec aa-exec -p unconfined -- "$0" "$@"
 fi
 
 # Utility functions

--- a/snapcraft/hooks/connect-plug-ovn-certificates
+++ b/snapcraft/hooks/connect-plug-ovn-certificates
@@ -2,11 +2,9 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current 2>/dev/null)"
-  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
-    exec aa-exec -p unconfined -- "$0" "$@"
-  fi
+label="$(cat /proc/self/attr/current 2>/dev/null || echo "unconfined")"
+if [ "${label}" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+  exec aa-exec -p unconfined -- "$0" "$@"
 fi
 
 # Utility functions

--- a/snapcraft/hooks/connect-plug-ovn-chassis
+++ b/snapcraft/hooks/connect-plug-ovn-chassis
@@ -2,11 +2,9 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current 2>/dev/null)"
-  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
-    exec aa-exec -p unconfined -- "$0" "$@"
-  fi
+label="$(cat /proc/self/attr/current 2>/dev/null || echo "unconfined")"
+if [ "${label}" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+  exec aa-exec -p unconfined -- "$0" "$@"
 fi
 
 # Utility functions

--- a/snapcraft/hooks/connect-plug-qemu-external
+++ b/snapcraft/hooks/connect-plug-qemu-external
@@ -2,11 +2,9 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current 2>/dev/null)"
-  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
-    exec aa-exec -p unconfined -- "$0" "$@"
-  fi
+label="$(cat /proc/self/attr/current 2>/dev/null || echo "unconfined")"
+if [ "${label}" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+  exec aa-exec -p unconfined -- "$0" "$@"
 fi
 
 echo 1 > "${SNAP_COMMON}/use-qemu-external-snap"

--- a/snapcraft/hooks/disconnect-plug-ceph-conf
+++ b/snapcraft/hooks/disconnect-plug-ceph-conf
@@ -2,11 +2,9 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current 2>/dev/null)"
-  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
-    exec aa-exec -p unconfined -- "$0" "$@"
-  fi
+label="$(cat /proc/self/attr/current 2>/dev/null || echo "unconfined")"
+if [ "${label}" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+  exec aa-exec -p unconfined -- "$0" "$@"
 fi
 
 # Utility functions

--- a/snapcraft/hooks/disconnect-plug-ovn-certificates
+++ b/snapcraft/hooks/disconnect-plug-ovn-certificates
@@ -2,11 +2,9 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current 2>/dev/null)"
-  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
-    exec aa-exec -p unconfined -- "$0" "$@"
-  fi
+label="$(cat /proc/self/attr/current 2>/dev/null || echo "unconfined")"
+if [ "${label}" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+  exec aa-exec -p unconfined -- "$0" "$@"
 fi
 
 # Utility functions

--- a/snapcraft/hooks/disconnect-plug-ovn-chassis
+++ b/snapcraft/hooks/disconnect-plug-ovn-chassis
@@ -2,11 +2,9 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current 2>/dev/null)"
-  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
-    exec aa-exec -p unconfined -- "$0" "$@"
-  fi
+label="$(cat /proc/self/attr/current 2>/dev/null || echo "unconfined")"
+if [ "${label}" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+  exec aa-exec -p unconfined -- "$0" "$@"
 fi
 
 # Utility functions

--- a/snapcraft/hooks/disconnect-plug-qemu-external
+++ b/snapcraft/hooks/disconnect-plug-qemu-external
@@ -2,11 +2,9 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current 2>/dev/null)"
-  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
-    exec aa-exec -p unconfined -- "$0" "$@"
-  fi
+label="$(cat /proc/self/attr/current 2>/dev/null || echo "unconfined")"
+if [ "${label}" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+  exec aa-exec -p unconfined -- "$0" "$@"
 fi
 
 rm -f "${SNAP_COMMON}/use-qemu-external-snap"

--- a/snapcraft/hooks/remove
+++ b/snapcraft/hooks/remove
@@ -2,11 +2,9 @@
 set -eu
 
 # Re-exec outside of apparmor confinement
-if [ -d /sys/kernel/security/apparmor ]; then
-  label="$(cat /proc/self/attr/current 2>/dev/null)"
-  if [ "$label" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
-    exec aa-exec -p unconfined -- "$0" "$@"
-  fi
+label="$(cat /proc/self/attr/current 2>/dev/null || echo "unconfined")"
+if [ "${label}" != "unconfined" ] && [ -n "${label##*(unconfined)}" ]; then
+  exec aa-exec -p unconfined -- "$0" "$@"
 fi
 
 # Unmount potential LXD paths.


### PR DESCRIPTION
When a kernel does not support Apparmor, trying to read `/proc/self/attr/current` will generate an error which is fine as we already ignore read error.

Force disable Apparmor:
```
# cat /proc/cmdline 
BOOT_IMAGE=/vmlinuz-6.8.0-87-generic root=PARTUUID=bab9fa8e-4c00-4a73-9282-a72caa795cf5 ro console=tty1 console=ttyS0 apparmor=0 panic=-1
```

Confirm the behavior when reading the `attr/current` file:
```
# cat /proc/self/attr/current 
cat: /proc/self/attr/current: Invalid argument
# cat /proc/self/attr/current 2>/dev/null
#
```