### PR TITLE
spice-server: enable `lz4` compression

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -861,6 +861,7 @@ parts:
         - liburing-dev
         - libusb-1.0-0-dev
         - libusbredirparser-dev
+        - liblz4-dev
         - quilt
         - librbd-dev
     stage-packages:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -718,7 +718,6 @@ parts:
       - --prefix=/
       - -Dgstreamer=no
       - -Dmanual=false
-      - -Dlz4=false
       - -Dsasl=false
       - -Dopus=disabled
       - -Dsmartcard=disabled
@@ -728,6 +727,7 @@ parts:
       - else:
         - libspice-protocol-dev
         - libjpeg-turbo8-dev
+        - liblz4-dev
         - python3-pyparsing
         - python3-six
         - meson


### PR DESCRIPTION
The Ubuntu package is built with `lz4` compression (https://packages.ubuntu.com/noble/libspice-server1) and since the snap already includes the `liblz4.so` it is mostly free in terms of space consumption.

This may improve the performance of `lxc console --type=vga` when used with remote instances.