### PR TITLE
lxd-ui: new 0.19 tag (latest-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1610,7 +1610,7 @@ parts:
     source: https://github.com/canonical/lxd-ui
     source-depth: 1
     source-type: git
-    source-commit: e2bdafc1616d6ec0dc3df435a09b32b724f8b7bb # 0.18
+    source-commit: de92e3544b1db6f30e16b215ee5f8d65b127b7d6 # 0.19
     plugin: nil
     override-prime: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
see https://github.com/canonical/lxd-ui/releases/tag/0.19