### PR TITLE
lxd-ui: new 0.15.3 tag (5.21-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1704,7 +1704,7 @@ parts:
     source: https://github.com/canonical/lxd-ui
     source-depth: 1
     source-type: git
-    source-commit: be4a54b930be1463761878288576ea8c69424fbd # 0.15.2
+    source-commit: 24404265326b24488765708702ced3f386b2d6ba # 0.15.3
     plugin: nil
     override-prime: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
see https://github.com/canonical/lxd-ui/releases/tag/0.15.3