### PR TITLE
nvidia: update nvidia-container and nvidia-container-toolkit version to 1.18.0

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -537,12 +537,12 @@ parts:
 
   nvidia-container:
     source: https://github.com/NVIDIA/libnvidia-container
-    source-commit: e78456a41c71d73eabf7a85d1e531a108789349b # v1.17.9
+    source-commit: 889a3bb5408c195ed7897ba2cb8341c7d249672f # v1.18.0
     source-depth: 1
     source-type: git
     plugin: make
     build-environment:
-      - GIT_TAG: "1.17.9" # Enables source-depth: 1, should match git tag without "v" prefix.
+      - GIT_TAG: "1.18.0" # Enables source-depth: 1, should match git tag without "v" prefix.
     build-packages:
       - to amd64:
         - bmake
@@ -599,7 +599,7 @@ parts:
   nvidia-container-toolkit:
     source: https://github.com/NVIDIA/nvidia-container-toolkit
     source-depth: 1
-    source-commit: b3b37f91ea8f36d61df47135ea5abe6d26b4ec4f # v1.17.9
+    source-commit: f8daa5e26de9fd7eb79259040b6dd5a52060048c # v1.18.0
     source-type: git
     build-snaps:
       - go/1.25/stable


### PR DESCRIPTION
Update nvidia-container and nvidia-container-toolkit versions to `1.18.0` for LXD `latest/edge`.