### PR TITLE
nvidia: update nvidia-container and toolkit to 1.18.0 (5.21-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -652,12 +652,12 @@ parts:
 
   nvidia-container:
     source: https://github.com/NVIDIA/libnvidia-container
-    source-commit: d26524ab5db96a55ae86033f53de50d3794fb547 # v1.17.7
+    source-commit: 889a3bb5408c195ed7897ba2cb8341c7d249672f # v1.18.0
     source-depth: 1
     source-type: git
     plugin: make
     build-environment:
-      - GIT_TAG: "1.17.7" # Enables source-depth: 1, should match git tag without "v" prefix.
+      - GIT_TAG: "1.18.0" # Enables source-depth: 1, should match git tag without "v" prefix.
     build-packages:
       - to amd64:
         - bmake
@@ -714,7 +714,7 @@ parts:
   nvidia-container-toolkit:
     source: https://github.com/NVIDIA/nvidia-container-toolkit
     source-depth: 1
-    source-commit: bae3e7842ebe26812d8bd6a9be6a14a83dc91d8f # v1.17.7
+    source-commit: f8daa5e26de9fd7eb79259040b6dd5a52060048c # v1.18.0
     source-type: git
     build-snaps:
       - go/1.24/stable


### PR DESCRIPTION
Update nvidia-container and nvidia-container-toolkit versions to `1.18.0` for LXD `5.21/edge`.