### PR TITLE
virtiofsd: only build and prime on `amd64`

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1024,28 +1024,23 @@ parts:
   virtiofsd:
     plugin: nil
     stage-packages:
-      - to armhf: []
-      - else:
+      - to amd64:
         - virtiofsd
     organize:
       usr/libexec/: bin/
     prime:
       - bin/virtiofsd*
     override-stage: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
-      [ "$(uname -m)" = "riscv64" ] && exit 0
+      [ "$(uname -m)" != "x86_64" ] && exit 0
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
-      [ "$(uname -m)" = "riscv64" ] && exit 0
+      [ "$(uname -m)" != "x86_64" ] && exit 0
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
-      [ "$(uname -m)" = "riscv64" ] && exit 0
+      [ "$(uname -m)" != "x86_64" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
-      [ "$(uname -m)" = "riscv64" ] && exit 0
+      [ "$(uname -m)" != "x86_64" ] && exit 0
       craftctl default
 
   xfs:


### PR DESCRIPTION
LXD (currently) only supports `virtiofsd` on Intel 64 bits: https://github.com/canonical/lxd/blob/ca08ba1dd14ca1e2fefa8424e78268e8c9679ae5/lxd/device/device_utils_disk.go#L400-L404

Fixes https://github.com/canonical/lxd/issues/12655