### PR TITLE
daemon.start: don't manage Apparmor related sysctl if not active

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -458,6 +458,9 @@ manage_apparmor_restrictions() {
     # sysctl override snippet
     SYSCTL_FILE="/var/lib/snapd/hostfs/run/sysctl.d/zz-lxd.conf"
 
+    # Nothing to do if Apparmor is NOT active
+    [ -d /sys/kernel/security/apparmor ] || return
+
     # Check if sysctl settings need to be altered and always write the override snippet
     if [ "${apparmor_unprivileged_restrictions_disable:-"true"}" = "true" ]; then
         KEY_USERNS="kernel.apparmor_restrict_unprivileged_userns"


### PR DESCRIPTION
Closes https://github.com/canonical/lxd/issues/17012

Fixes regression introduced by 79b82e48eebf80b6ee0aa6d68d19b2cc25a68b5f