### PR TITLE
qemu: bump to 8.2.2+ds-0ubuntu1.11

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -785,7 +785,7 @@ parts:
       - libatomic
       - spice-server
     source: https://git.launchpad.net/ubuntu/+source/qemu
-    source-commit: bc0011afab01de8c41ec80fc8c24dd33fb30cd90 # import/1%8.2.2+ds-0ubuntu1.10
+    source-commit: 39c97e9014101799b4c942e22af322d9ae84f6c0 # import/1%8.2.2+ds-0ubuntu1.11
     source-depth: 1
     source-type: git
     plugin: autotools


### PR DESCRIPTION
```
qemu (1:8.2.2+ds-0ubuntu1.11) noble; urgency=medium

  * smbios: Fix buffer overrun when using path= option (LP: #2127974)
  * debian/.gitignore: unignore patches

 -- Nick Rosbrook <enr0n@ubuntu.com>  Thu, 20 Nov 2025 16:08:18 -0500
```