### PR TITLE
nvidia: update nvidia-container and toolkit to 1.18.1

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -537,12 +537,12 @@ parts:
 
   nvidia-container:
     source: https://github.com/NVIDIA/libnvidia-container
-    source-commit: 889a3bb5408c195ed7897ba2cb8341c7d249672f # v1.18.0
+    source-commit: 889a3bb5408c195ed7897ba2cb8341c7d249672f # v1.18.1
     source-depth: 1
     source-type: git
     plugin: make
     build-environment:
-      - GIT_TAG: "1.18.0" # Enables source-depth: 1, should match git tag without "v" prefix.
+      - GIT_TAG: "1.18.1" # Enables source-depth: 1, should match git tag without "v" prefix.
     build-packages:
       - to amd64:
         - bmake
@@ -599,7 +599,7 @@ parts:
   nvidia-container-toolkit:
     source: https://github.com/NVIDIA/nvidia-container-toolkit
     source-depth: 1
-    source-commit: f8daa5e26de9fd7eb79259040b6dd5a52060048c # v1.18.0
+    source-commit: efe99418ef87500dbe059cadc9ab418b2815b9d5 # v1.18.1
     source-type: git
     build-snaps:
       - go/1.25/stable


### PR DESCRIPTION
Update `nvidia-container` and `nvidia-container-toolkit` versions to `1.18.1` for LXD `latest/edge`.

Follow-up to https://github.com/canonical/lxd/pull/17188.