### PR TITLE
Drop `ui.enable` config

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -51,7 +51,6 @@ description: |-
    - openvswitch.builtin: Run a snap-specific OVS daemon [default=false]
    - openvswitch.external: Use the system's OVS tools (ignores openvswitch.builtin) [default=false]
    - ovn.builtin: Use snap-specific OVN configuration [default=false]
-   - ui.enable: Enable the web interface [default=true]
    - zfs.external: Use the system's ZFS tools [default=false]
 
  For system-wide configuration of the CLI, place your configuration in

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -552,8 +552,8 @@ if [ "$(stat -c '%u' /proc)" = 0 ]; then
     manage_apparmor_restrictions
 fi
 
-# Setup UI
-if [ "${ui_enable:-"false"}" = "true" ]; then
+# Setup UI (missing on riscv64 due to https://github.com/nodejs/snap/issues/77)
+if [ -d "${SNAP_CURRENT}/share/lxd-ui/" ]; then
     echo "==> Enabling LXD UI"
     export LXD_UI="${SNAP_CURRENT}/share/lxd-ui/"
 fi

--- a/snapcraft/hooks/configure
+++ b/snapcraft/hooks/configure
@@ -57,7 +57,6 @@ minio_path="$(snapctl get minio.path)"
 openvswitch_builtin=$(get_bool "$(snapctl get openvswitch.builtin)")
 openvswitch_external=$(get_bool "$(snapctl get openvswitch.external)")
 ovn_builtin=$(get_bool "$(snapctl get ovn.builtin)")
-ui_enable=$(get_bool "$(snapctl get ui.enable)")
 zfs_external=$(get_bool "$(snapctl get zfs.external)")
 
 # Special-handling of daemon.preseed
@@ -89,7 +88,6 @@ minio_path=${minio_path:-""}
 openvswitch_builtin=${openvswitch_builtin:-"false"}
 openvswitch_external=${openvswitch_external:-"false"}
 ovn_builtin=${ovn_builtin:-"false"}
-ui_enable=${ui_enable:-"true"}
 zfs_external=${zfs_external:-"false"}
 EOC
 


### PR DESCRIPTION
It makes very little sense to disable the LXD UI so let's have it always on[*].

*: except on `riscv64` where it is not available due to https://github.com/nodejs/snap/issues/77