### PR TITLE
daemon.start: Link the pro command to the run-host wrapper (5.0-candidate)

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -199,6 +199,9 @@ fi
 # Redirect getent to the host
 ln -s "${SNAP}/wrappers/run-host" "/run/bin/getent"
 
+# Redirect pro to the host
+ln -s "${SNAP}/wrappers/run-host" "/run/bin/pro"
+
 # Avoid xtables talking to nft
 ln -s "${SNAP}/bin/arptables-legacy" "/run/bin/arptables"
 ln -s "${SNAP}/bin/ebtables-legacy" "/run/bin/ebtables"


### PR DESCRIPTION
`5.0/edge` has switched to `core22` some time ago.

`5.0/candidate` is still using `core20` and it's too late in the life of LXD 5.0 to justify a base switch. As such, it's best to backport the Pro command availability to `5.0/candidate` as there won't be any more `5.0/edge`->`5.0/candidate` promotion.