### PR TITLE
Drop ZFS 2.1 (incompatible with Ubuntu 5.15 and earlier kernels)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1591,7 +1591,6 @@ parts:
       - xz
       - wrappers
       - xtables
-      - zfs-2-1
       - zfs-2-2
       - zfs-2-3
       - zstd

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1104,55 +1104,6 @@ parts:
       # Include the lzma symlink
       ln -s xz "${CRAFT_PART_INSTALL}/usr/bin/lzma"
 
-  zfs-2-1:
-    source: https://github.com/openzfs/zfs
-    source-commit: a7186651d3306debca6b4f72797239eea61db36c # zfs-2.1.16
-    source-depth: 1
-    source-type: git
-    plugin: autotools
-    autotools-configure-parameters:
-      - --prefix=/
-      - --with-config=user
-    build-packages:
-      - to armhf: []
-      - else:
-        - libblkid-dev
-        - libssl-dev
-        - uuid-dev
-        - zlib1g-dev
-        - libtirpc-dev
-    override-stage: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
-      [ "$(uname -m)" = "riscv64" ] && exit 0
-      craftctl default
-    override-prime: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
-      [ "$(uname -m)" = "riscv64" ] && exit 0
-      craftctl default
-    override-pull: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
-      [ "$(uname -m)" = "riscv64" ] && exit 0
-      craftctl default
-    override-build: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
-      [ "$(uname -m)" = "riscv64" ] && exit 0
-      craftctl default
-      set -ex
-
-      ZFS_VER="2.1"
-
-      mv "${CRAFT_PART_INSTALL}" "${CRAFT_PART_INSTALL}.tmp"
-      mkdir -p "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin" "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/lib"
-      mv "${CRAFT_PART_INSTALL}.tmp/sbin/zfs" "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin/"
-      mv "${CRAFT_PART_INSTALL}.tmp/sbin/zpool" "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin/"
-      mv "${CRAFT_PART_INSTALL}.tmp/lib/udev/zvol_id" "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/bin/"
-      mv "${CRAFT_PART_INSTALL}.tmp/lib/"*so* "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/lib/"
-      rm -Rf "${CRAFT_PART_INSTALL}.tmp"
-
-      # unused .so
-      rm "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/lib/libzfsbootenv.so"*
-      rm "${CRAFT_PART_INSTALL}/zfs-${ZFS_VER}/lib/libzpool.so"*
-
   zfs-2-2:
     source: https://github.com/openzfs/zfs
     source-commit: 079ba86d71571bf997ff688da061d8c4aa2fd052 # zfs-2.2.9

--- a/snapcraft/commands/lxd
+++ b/snapcraft/commands/lxd
@@ -22,8 +22,8 @@ export PATH="${PATH}:${SNAP_CURRENT}/bin"
 export LXD_DIR="${LXD_DIR:-"${SNAP_COMMON}/lxd/"}"
 
 # Make sure we have a ZFS binary on the path
-export LD_LIBRARY_PATH="${SNAP_CURRENT}/zfs-2.1/lib/:${LD_LIBRARY_PATH}"
-export PATH="${SNAP_CURRENT}/zfs-2.1/bin:${PATH}"
+export LD_LIBRARY_PATH="${SNAP_CURRENT}/zfs-2.2/lib/:${LD_LIBRARY_PATH}"
+export PATH="${SNAP_CURRENT}/zfs-2.2/bin:${PATH}"
 
 LXD="lxd"
 if [ -x "${SNAP_COMMON}/lxd.debug" ]; then


### PR DESCRIPTION
Ubuntu 24.04 GA kernel and 22.04 HWE kernel now become the minimum supported
kernels.

This means that 22.04 GA kernel (5.15) won't work anymore as it bundles ZFS 2.1
kmod.

This is in line with https://github.com/canonical/lxd/issues/16559