### PR TITLE
qemu: fetch just enough history to allow restoring python wheels (5.0-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -838,6 +838,9 @@ parts:
       QEMUARCH="$(uname -m)"
       [ "${QEMUARCH}" = "ppc64le" ] && QEMUARCH="ppc64"
 
+      # Fetch enough history to have the commit we need for git restore
+      git fetch https://git.launchpad.net/ubuntu/+source/qemu 4769f7051b0753455b775ab10c9226e149ed6237 --depth=2
+
       # Apply patches from Ubuntu sources.
       QUILT_PATCHES=debian/patches quilt push -a
 


### PR DESCRIPTION
An alternative would be to do a full clone by dropping `source-depth: 1` but this results in more data being pulled from git:

```
$ du -sm qemu/ qemu+fetch/ qemu-full/
431	qemu/
461	qemu+fetch/
591	qemu-full/
```