### PR TITLE
lxd-ui: new 0.20 tag (latest-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1558,7 +1558,7 @@ parts:
     source: https://github.com/canonical/lxd-ui
     source-depth: 1
     source-type: git
-    source-commit: 69fa2699fe6a91754cc825bdca27d64bc6e39b2e # 0.19
+    source-commit: f2d6f4f695ef0db60ba31bea76b701546aad9102 # 0.20
     plugin: nil
     override-prime: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
* full list of changes in https://github.com/canonical/lxd-ui/releases/tag/0.20