### PR TITLE
lxd: Don't shallow checkout (latest-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1404,8 +1404,6 @@ parts:
 
   lxd:
     source: https://github.com/canonical/lxd
-    # XXX: We often cherry-pick for candidate builds so don't do shallow clone
-    source-depth: 1
     source-commit: 16f4b95e8a4e03c3814c40b2782b4bceb8ffce08 # pre lxd-6.7
     source-type: git
     after:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1310,7 +1310,7 @@ parts:
 
   lxcfs:
     source: https://github.com/lxc/lxcfs
-    source-commit: 16503df8e814d29b348e61abebc4f89b2e20f440 # v6.0.5
+    source-commit: 7ff173bfdb01bc10ab92c3d083a868d8f7fdd94d # v6.0.6
     source-depth: 1
     source-type: git
     build-packages:


### PR DESCRIPTION
And bump LXCFS to v6.0.6 to include ZFS swap accounting from https://github.com/lxc/lxcfs/pull/686 from @kadinsayani 