### PR TITLE
lxd: explicitly use git full clone (latest-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1405,6 +1405,8 @@ parts:
   lxd:
     source: https://github.com/canonical/lxd
     source-commit: 16f4b95e8a4e03c3814c40b2782b4bceb8ffce08 # pre lxd-6.7
+    # XXX: We often cherry-pick for candidate builds so don't do shallow clone (0 means full clone).
+    source-depth: 0
     source-type: git
     after:
       - lxc


### PR DESCRIPTION
The docs need some history for the "last updated" date.