### PR TITLE
lxd: explicitly use git full clone (5.21-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1576,7 +1576,8 @@ parts:
   lxd:
     source: https://github.com/canonical/lxd
     source-branch: stable-5.21
-    source-depth: 1
+    # XXX: We often cherry-pick for candidate builds so don't do shallow clone (0 means full clone).
+    source-depth: 0
     source-type: git
     after:
       - lxc


### PR DESCRIPTION
The docs need some history for the "last updated" date.