### PR TITLE
lxd-ui: update 0.20 tag (latest-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1556,7 +1556,7 @@ parts:
     source: https://github.com/canonical/lxd-ui
     source-depth: 1
     source-type: git
-    source-commit: f2d6f4f695ef0db60ba31bea76b701546aad9102 # 0.20
+    source-commit: 24ef73e5e5cf336a411a8fb43e49d848facad6c3 # 0.20
     plugin: nil
     override-prime: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
full changelog in https://github.com/canonical/lxd-ui/releases/tag/0.20

new items:

fix(initial access): Change temporary to initial, prevent changing group by @kimanhou in #1823
fix(network) show warning on peering target network when access is not restricted with ACLs by @edlerd in #1826
feat(instance config): Add custom ISOs in devices > disk by @kimanhou in #1816
fix(favicon) use microcloud favicon with root path by @edlerd in #1824