### PR TITLE
Fix editor mount namespace blocking ZFS/LVM storage operations

### DIFF
--- a/snapcraft/wrappers/editor
+++ b/snapcraft/wrappers/editor
@@ -16,8 +16,11 @@ run_cmd() {
         fi
     fi
 
+    # Use --propagation slave so unmounts in the parent namespace propagate to
+    # the editor's namespace. This prevents leftover mounts (ZFS/LVM) from
+    # blocking storage delete operations while the editor is open.
     # shellcheck disable=SC2145
-    exec unshare --kill-child -U -m -p -r -f --root="/var/lib/snapd/hostfs/" "/bin/sh" -c "mount -t proc proc /proc 2>/dev/null || true; exec \"${CMD}\" ${IGNORERCFILES} \"$@\""
+    exec unshare --kill-child -U -m --propagation slave -p -r -f --root="/var/lib/snapd/hostfs/" "/bin/sh" -c "mount -t proc proc /proc 2>/dev/null || true; exec \"${CMD}\" ${IGNORERCFILES} \"$@\""
 }
 
 # Detect base name


### PR DESCRIPTION
## Problem
When running `lxc delete -f <instance>` while `lxc profile edit` has an editor open, ZFS and LVM containers fail to delete with "busy dataset/volume" error as mentioned in https://github.com/canonical/lxd/issues/15664.

## Root Cause
The editor wrapper script uses `unshare -m` to create a new mount namespace for the editor process. The system's mounts have shared propagation by default, so the new namespace inherits copies of all current mounts, including ZFS dataset and LVM logical volume mounts.
When `lxc delete -f` runs, LXD unmounts the storage in the main namespace, but the mount reference still exists in the editor's namespace. ZFS/LVM refuse to destroy the dataset because it's still mounted somewhere.

## Fix
Add `--propagation slave` to the `unshare` command. This ensures unmounts in the parent namespace propagate to the editor's namespace, preventing leftover mounts from blocking storage operations.

`--propagation private` was also considered but it doesn't work with ZFS block mode (volume.zfs.block_mode=true) the mount remains in the editor's namespace and blocks deletion. With slave mode, the unmount propagates from parent to child, cleanly removing the mount reference.

Fixes: https://github.com/canonical/lxd/issues/15664