### PR TITLE
dqlite: Pin to dqlite v1.18.x branch (latest-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -298,6 +298,7 @@ parts:
 
   dqlite:
     source: https://github.com/canonical/dqlite
+    source-branch: v1.18.x
     source-depth: 1
     source-type: git
     plugin: autotools


### PR DESCRIPTION
Ready for 26.04 LTS.