### PR TITLE
lxd: build `lxc` statically and bypass confinement for completions

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1468,7 +1468,8 @@ parts:
       export CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
 
       # Build the binaries
-      go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/lxc" github.com/canonical/lxd/lxc
+      # lxc is built statically (CGO_ENABLED=0) so it can be executed unconfined on hosts with different libc during shell completion
+      CGO_ENABLED=0 go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/lxc" -tags netgo github.com/canonical/lxd/lxc
 
       # Build LXD server binary into ${CRAFT_PART_INSTALL}/sbin/lxd so that it does not conflict with the
       # lxd-stophook wrapper script which is stored in ${CRAFT_PART_INSTALL}/bin/lxd.
@@ -1515,8 +1516,8 @@ parts:
       set_cols='s/# $COLUMNS.*/COLUMN="$(tput cols)"  \# store the current shell width./'
       # When executed by snapd, the `compopt` support detection doesn't work so fake that it is always `builtin`
       set_compopt='s|$(type -t compopt)|"builtin"|'
-      # Modify requestComp variable to use lxc based on context ($SNAP/bin/lxc in Snap environment)
-      set_request_comp='s|requestComp="${words\[0\]} __complete ${args\[\*\]}"|requestComp="/snap/lxd/current/commands/lxc __complete ${args[*]}"|'
+      # Modify requestComp variable to invoke the raw unconfined binary to avoid AppArmor denials and snap run overhead
+      set_request_comp='s|requestComp="${words\[0\]} __complete ${args\[\*\]}"|requestComp="/snap/lxd/current/bin/lxc __complete ${args[*]}"|'
       # Generate completions script
       "${CRAFT_PART_INSTALL}/bin/lxc" completion bash | sed -e "${set_cmds}" -e "${set_cols}" -e "${set_compopt}" -e "${set_request_comp}" > "${CRAFT_PART_INSTALL}/lxc-completer.sh"
       chmod +x "${CRAFT_PART_INSTALL}/lxc-completer.sh"


### PR DESCRIPTION
When doing (inside my home):

```
$ cd ~
$ lxc file push <tab><tab>
...
```

Files in the current directory are listed as they should. However that is kind of by accident as the snap confinement is preventing the `lxc` command from doing the actual completion as we can see from this Apparmor denial:

```
audit: type=1400 audit(1772570126.835:3554): apparmor="DENIED" operation="open" class="file" profile="snap.lxd.lxc" name="/home/sdeziel/" pid=626160 comm="bash" requested_mask="r" denied_mask="r" fsuid=1000 ouid=1000
```

The [Go code](https://github.com/canonical/lxd/blob/main/lxc/completion.go#L1703-L1710) looks like this:

```go
	// Early return when no instances are found.
	if len(instances) == 0 {
		if includeLocalFiles {
			return nil, cobra.ShellCompDirectiveDefault
		}

		return instances, directives
	}
```

And `cobra.ShellCompDirectiveDefault == 0` which in turn is gracefully handled by the `lxc-completer.sh` script that has some fallback logic:

```shell
if (((directive & shellCompDirectiveNoFileComp) == 0)); then
      __lxc_debug "Listing files"
      _filedir
fi
```

Relying on the fallback logic is slower and cause log noise so instead, directly invoke the `lxc` command to bypass the confinement entirely and avoid the problem.

By statically compiling the `lxc` binary, it should be also be faster for all use as it will avoid the overhead of the dynamic linker and the CGO overhead.