### PR TITLE
nvidia: update nvidia-container-toolkit to 1.19.0

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -561,12 +561,12 @@ parts:
 
   nvidia-container:
     source: https://github.com/NVIDIA/libnvidia-container
-    source-commit: 584976abaef996d9466232a9bc7426fcdb0ed1e0 # v1.18.2
+    source-commit: 7585946c6471402577e14474d7c56ca5be0348d7 # v1.19.0
     source-depth: 1
     source-type: git
     plugin: make
     build-environment:
-      - GIT_TAG: "1.18.2" # Enables source-depth: 1, should match git tag without "v" prefix.
+      - GIT_TAG: "1.19.0" # Enables source-depth: 1, should match git tag without "v" prefix.
     build-packages:
       - to amd64:
         - bmake
@@ -623,7 +623,7 @@ parts:
   nvidia-container-toolkit:
     source: https://github.com/NVIDIA/nvidia-container-toolkit
     source-depth: 1
-    source-commit: 9e88ed39710fd94c7e49fbb26d96492c45e574fb # v1.18.2
+    source-commit: ec7b4e2fa2caecad6d89be4a26029b831fe7503a # v1.19.0
     source-type: git
     build-snaps:
       - go/1.25/stable


### PR DESCRIPTION
This PR updates `nvidia-container-toolkit` and `libnvidia-container` versions to `1.19.0` for LXD `latest/edge`.

Follow-up to https://github.com/canonical/lxd/pull/17865.

I've tested this on a TF machine and the tests are passing (with the exception of Ubuntu Core where it fails at the same step).