### PR TITLE
Add `ovn-env` plug for connecting with MicroOVN slot

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -72,6 +72,9 @@ plugs:
  ovn-chassis:
    interface: content
    target: "$SNAP_DATA/microovn/chassis"
+ ovn-env:
+   interface: content
+   target: "$SNAP_DATA/microovn/ovn-env"
  gpu-2404:
    interface: content
    target: $SNAP/gpu-2404


### PR DESCRIPTION
This PR adds a new `ovn-env` plug for connecting with MicroOVN slot [`ovn-env`](https://github.com/canonical/microovn/blob/e860d3abf65c077a1b6524e11459e90e1c10a106/snap/snapcraft.yaml#L22-L26). It allows sourcing `ovn.env` file inside of the LXD snap to determine the connection string for OVN Northbound database when using MicroOVN.

This should be merged together with https://github.com/canonical/lxd/pull/17874.