### PR TITLE
daemon.reload: wait for the signaled daemon PID to vanish

### DIFF
--- a/snapcraft/commands/daemon.reload
+++ b/snapcraft/commands/daemon.reload
@@ -11,4 +11,19 @@ fi
 
 echo reload > "${SNAP_COMMON}/state"
 read -r PID < "${SNAP_COMMON}/lxd.pid"
-exec kill "$PID"
+kill "$PID"
+
+# Wait for the old daemon to exit so that callers don't
+# race with a dying daemon when checking readiness.
+i=0
+while [ "${i}" -lt 25 ]; do
+    if ! kill -0 "$PID" 2>/dev/null; then
+        exit 0
+    fi
+
+    sleep 0.2
+    i=$((i + 1))
+done
+
+echo "Timed out waiting for daemon to exit" >&2
+exit 1


### PR DESCRIPTION
The common idiom:

```
systemctl reload snap.lxd.daemon.service
lxd waitready --timeout=300
```

is racy due `systemctl reload` returning (immediately) before the new daemon is ready. This means that `lxd waitready` might start waiting on the old daemon that is shutting down.