### PR TITLE
edk2: ship secureboot and non-secureboot firmware variants

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1408,7 +1408,8 @@ parts:
       - lib/python3/dist-packages/pyuefivars*
 
   lxd:
-    source: https://github.com/canonical/lxd
+    source: https://github.com/simondeziel/lxd
+    source-branch: edk2-code-vars-files
     # XXX: We often cherry-pick for candidate builds so don't do shallow clone (0 means full clone).
     source-depth: 0
     source-type: git

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -477,52 +477,6 @@ parts:
       # Build Debug
       run_build DEBUG ".debug"
 
-      # Firmware files summary
-      #
-      # The snap ships the following real files per architecture:
-      #
-      #   x86_64:
-      #     File                     | Role               | Used by
-      #     OVMF_CODE_4M.ms.fd       | SB CODE            | new LXD (secureboot)
-      #     OVMF_CODE_4M.fd          | non-SB CODE        | new LXD (non-secureboot)
-      #     OVMF_CODE_4M.ms.debug.fd | SB CODE (debug)    | new LXD (debug secureboot)
-      #     OVMF_CODE_4M.debug.fd    | non-SB CODE (debug)| new LXD (debug non-secureboot)
-      #     OVMF_VARS_4M.ms.fd       | pre-enrolled VARS  | new LXD (secureboot)
-      #     OVMF_VARS_4M.fd          | empty VARS         | new LXD (non-secureboot)
-      #
-      #   arm64:
-      #     File                     | Role               | Used by
-      #     AAVMF_CODE.ms.fd         | SB CODE            | new LXD (secureboot)
-      #     AAVMF_CODE.fd            | non-SB CODE        | new LXD (non-secureboot)
-      #     AAVMF_CODE.ms.debug.fd   | SB CODE (debug)    | new LXD (debug secureboot)
-      #     AAVMF_CODE.debug.fd      | non-SB CODE (debug)| new LXD (debug non-secureboot)
-      #     AAVMF_VARS.ms.fd         | pre-enrolled VARS  | new LXD (secureboot)
-      #     AAVMF_VARS.fd            | empty VARS         | new LXD (non-secureboot)
-      #
-      # Backward-compat symlinks for the LXD binary currently shipped in this
-      # snap, which still looks for the legacy OVMF_*.4MB* names on both arches.
-      # TODO: Remove these once the bundled LXD uses the new firmware names.
-      #
-      #   Symlink (both arches)    | Target
-      #   OVMF_CODE.4MB.fd         | SB CODE (was the only CODE shipped before)
-      #   OVMF_CODE.4MB.debug.fd   | SB CODE debug
-      #   OVMF_VARS.4MB.fd         | empty VARS
-      #   OVMF_VARS.4MB.ms.fd      | pre-enrolled VARS
-      #
-      DEST="${CRAFT_PART_INSTALL}/share/qemu"
-      if [ "$(uname -m)" = "x86_64" ]; then
-          ln -sf OVMF_CODE_4M.ms.fd        "${DEST}/OVMF_CODE.4MB.fd"
-          ln -sf OVMF_CODE_4M.ms.debug.fd  "${DEST}/OVMF_CODE.4MB.debug.fd"
-          ln -sf OVMF_VARS_4M.fd           "${DEST}/OVMF_VARS.4MB.fd"
-          ln -sf OVMF_VARS_4M.ms.fd        "${DEST}/OVMF_VARS.4MB.ms.fd"
-      elif [ "$(uname -m)" = "aarch64" ]; then
-          # Old snap shipped OVMF_*.4MB* on arm64 too
-          ln -sf AAVMF_CODE.ms.fd          "${DEST}/OVMF_CODE.4MB.fd"
-          ln -sf AAVMF_CODE.ms.debug.fd    "${DEST}/OVMF_CODE.4MB.debug.fd"
-          ln -sf AAVMF_VARS.fd             "${DEST}/OVMF_VARS.4MB.fd"
-          ln -sf AAVMF_VARS.ms.fd          "${DEST}/OVMF_VARS.4MB.ms.fd"
-      fi
-
       # Cleanup debug vars
       rm "${CRAFT_PART_INSTALL}/share/qemu/${DST_VARS}.debug.fd"
     prime:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -405,11 +405,16 @@ parts:
 
       if [ "$(uname -m)" = "x86_64" ]; then
           DSC="OvmfPkg/OvmfPkgX64.dsc"
-          BUILD_TARGET="install-ovmf"
+          BUILD_TARGETS="install-ovmf-secboot install-ovmf-no-secboot"
           SRC_DIR="debian/tmp/usr/share/OVMF"
-          SRC_CODE="OVMF_CODE_4M.secboot.fd"
+          SRC_CODE="OVMF_CODE_4M.ms.fd"
+          SRC_CODE_NOSB="OVMF_CODE_4M.fd"
           SRC_VARS="OVMF_VARS_4M.fd"
           SRC_VARS_MS="OVMF_VARS_4M.ms.fd"
+          DST_CODE="OVMF_CODE_4M.ms"
+          DST_CODE_NOSB="OVMF_CODE_4M"
+          DST_VARS="OVMF_VARS_4M"
+          DST_VARS_MS="OVMF_VARS_4M.ms"
           # Add DEBUG_VERBOSE to print error level for DEBUG build
           # * 0x80000000 (DEBUG_ERROR)
           # * 0x00000040 (DEBUG_INFO)
@@ -419,11 +424,19 @@ parts:
           SED_EXPR="s#PcdDebugPrintErrorLevel|0x8000004F#PcdDebugPrintErrorLevel|0x8040004F#g"
       elif [ "$(uname -m)" = "aarch64" ]; then
           DSC="ArmVirtPkg/ArmVirt.dsc.inc"
-          BUILD_TARGET="install-qemu-efi-aarch64"
+          BUILD_TARGETS="install-qemu-efi-aarch64-secboot install-qemu-efi-aarch64-no-secboot"
           SRC_DIR="debian/tmp/usr/share/AAVMF"
-          SRC_CODE="AAVMF_CODE.secboot.fd"
+          SRC_CODE="AAVMF_CODE.ms.fd"
+          # XXX: The package doesn't create AAVMF_CODE.fd for this
+          # non-secureboot variant, but we need a consistent name for the snap,
+          # so we copy it from the .no-secboot.fd file.
+          SRC_CODE_NOSB="AAVMF_CODE.no-secboot.fd"
           SRC_VARS="AAVMF_VARS.fd"
           SRC_VARS_MS="AAVMF_VARS.ms.fd"
+          DST_CODE="AAVMF_CODE.ms"
+          DST_CODE_NOSB="AAVMF_CODE"
+          DST_VARS="AAVMF_VARS"
+          DST_VARS_MS="AAVMF_VARS.ms"
           # See note in `x86_64` section for DEBUG_VERBOSE explanation
           SED_EXPR="s#DEBUG_PRINT_ERROR_LEVEL = 0x8000004F#DEBUG_PRINT_ERROR_LEVEL = 0x8040004F#g"
       fi
@@ -443,17 +456,18 @@ parts:
               sed --in-place=.bak "${SED_EXPR}" "${DSC}"
           fi
 
-          /usr/bin/make -f debian/rules "${BUILD_TARGET}" BUILD_TYPE="${TYPE}"
+          /usr/bin/make -f debian/rules ${BUILD_TARGETS} BUILD_TYPE="${TYPE}"
 
           if [ "${TYPE}" = "DEBUG" ] && [ -f "${DSC}.bak" ]; then
               mv "${DSC}.bak" "${DSC}"
           fi
 
-          cp "${SRC_DIR}/${SRC_CODE}" "${CRAFT_PART_INSTALL}/share/qemu/OVMF_CODE.4MB${SUFFIX}.fd"
-          cp "${SRC_DIR}/${SRC_VARS}" "${CRAFT_PART_INSTALL}/share/qemu/OVMF_VARS.4MB${SUFFIX}.fd"
+          cp "${SRC_DIR}/${SRC_CODE}" "${CRAFT_PART_INSTALL}/share/qemu/${DST_CODE}${SUFFIX}.fd"
+          cp "${SRC_DIR}/${SRC_CODE_NOSB}" "${CRAFT_PART_INSTALL}/share/qemu/${DST_CODE_NOSB}${SUFFIX}.fd"
+          cp "${SRC_DIR}/${SRC_VARS}" "${CRAFT_PART_INSTALL}/share/qemu/${DST_VARS}${SUFFIX}.fd"
 
           if [ "${TYPE}" = "RELEASE" ]; then
-               cp "${SRC_DIR}/${SRC_VARS_MS}" "${CRAFT_PART_INSTALL}/share/qemu/OVMF_VARS.4MB.ms.fd"
+               cp "${SRC_DIR}/${SRC_VARS_MS}" "${CRAFT_PART_INSTALL}/share/qemu/${DST_VARS_MS}.fd"
           fi
       }
 
@@ -463,8 +477,54 @@ parts:
       # Build Debug
       run_build DEBUG ".debug"
 
+      # Firmware files summary
+      #
+      # The snap ships the following real files per architecture:
+      #
+      #   x86_64:
+      #     File                     | Role               | Used by
+      #     OVMF_CODE_4M.ms.fd       | SB CODE            | new LXD (secureboot)
+      #     OVMF_CODE_4M.fd          | non-SB CODE        | new LXD (non-secureboot)
+      #     OVMF_CODE_4M.ms.debug.fd | SB CODE (debug)    | new LXD (debug secureboot)
+      #     OVMF_CODE_4M.debug.fd    | non-SB CODE (debug)| new LXD (debug non-secureboot)
+      #     OVMF_VARS_4M.ms.fd       | pre-enrolled VARS  | new LXD (secureboot)
+      #     OVMF_VARS_4M.fd          | empty VARS         | new LXD (non-secureboot)
+      #
+      #   arm64:
+      #     File                     | Role               | Used by
+      #     AAVMF_CODE.ms.fd         | SB CODE            | new LXD (secureboot)
+      #     AAVMF_CODE.fd            | non-SB CODE        | new LXD (non-secureboot)
+      #     AAVMF_CODE.ms.debug.fd   | SB CODE (debug)    | new LXD (debug secureboot)
+      #     AAVMF_CODE.debug.fd      | non-SB CODE (debug)| new LXD (debug non-secureboot)
+      #     AAVMF_VARS.ms.fd         | pre-enrolled VARS  | new LXD (secureboot)
+      #     AAVMF_VARS.fd            | empty VARS         | new LXD (non-secureboot)
+      #
+      # Backward-compat symlinks for the LXD binary currently shipped in this
+      # snap, which still looks for the legacy OVMF_*.4MB* names on both arches.
+      # TODO: Remove these once the bundled LXD uses the new firmware names.
+      #
+      #   Symlink (both arches)    | Target
+      #   OVMF_CODE.4MB.fd         | SB CODE (was the only CODE shipped before)
+      #   OVMF_CODE.4MB.debug.fd   | SB CODE debug
+      #   OVMF_VARS.4MB.fd         | empty VARS
+      #   OVMF_VARS.4MB.ms.fd      | pre-enrolled VARS
+      #
+      DEST="${CRAFT_PART_INSTALL}/share/qemu"
+      if [ "$(uname -m)" = "x86_64" ]; then
+          ln -sf OVMF_CODE_4M.ms.fd        "${DEST}/OVMF_CODE.4MB.fd"
+          ln -sf OVMF_CODE_4M.ms.debug.fd  "${DEST}/OVMF_CODE.4MB.debug.fd"
+          ln -sf OVMF_VARS_4M.fd           "${DEST}/OVMF_VARS.4MB.fd"
+          ln -sf OVMF_VARS_4M.ms.fd        "${DEST}/OVMF_VARS.4MB.ms.fd"
+      elif [ "$(uname -m)" = "aarch64" ]; then
+          # Old snap shipped OVMF_*.4MB* on arm64 too
+          ln -sf AAVMF_CODE.ms.fd          "${DEST}/OVMF_CODE.4MB.fd"
+          ln -sf AAVMF_CODE.ms.debug.fd    "${DEST}/OVMF_CODE.4MB.debug.fd"
+          ln -sf AAVMF_VARS.fd             "${DEST}/OVMF_VARS.4MB.fd"
+          ln -sf AAVMF_VARS.ms.fd          "${DEST}/OVMF_VARS.4MB.ms.fd"
+      fi
+
       # Cleanup debug vars
-      rm "${CRAFT_PART_INSTALL}/share/qemu/OVMF_VARS.4MB.debug.fd"
+      rm "${CRAFT_PART_INSTALL}/share/qemu/${DST_VARS}.debug.fd"
     prime:
       - share/qemu/*
 


### PR DESCRIPTION
Previously, the snap only shipped the secureboot CODE variant
(`SMM_REQUIRE=TRUE` on x86_64), which was used for all VMs regardless of their
SB setting. Being built with `SMM_REQUIRE=TRUE` meant that all UEFI variable
access (reads and writes to NVRAM) goes through System Management Mode, which
forces every vCPU into a synchronous rendezvous. This happens even when no
Secure Boot keys are enrolled. Incidentally, when `boot.mode=uefi-nosecureboot`
was used, the SB CODE was simply paired with empty VARS which puts the firmware
into "Setup Mode" (SB-capable, keys not yet enrolled). The entire Secure Boot
infrastructure is initialized: signature databases, certificate stores, the
SecureBootEnable variable, etc.

A non-SB CODE genuinely doesn't have Secure Boot support compiled in so there's
no Setup Mode ambiguity, and guest OS/bootloaders that check SecureBoot EFI
variables see a clear "not supported" rather than "supported but not
configured."

The solution is to ship both secureboot (`.ms`) and non-secureboot CODE
firmware files which will allow LXD to avoid the SMM overhead for VMs that
don't need it (`boot.mode=uefi-nosecureboot`).

This is done by switching build targets from the monolithic
`install-ovmf`/`install-aarch64` to the split `install-*-secboot` +
`install-*-no-secboot` targets available in edk2 2025.11.

At the same time, adopt names from the Ubuntu edk2 package (`OVMF_CODE_4M`/
`AAVMF_CODE` on the non-SB side, `OVMF_CODE_4M.ms`/`AAVMF_CODE.ms` on the SB
side). This also uncovered that LXD uses `OVMF` even on `arm64` where it should
instead be `AAMF`.

Until the LXD side can be updated to use different CODE for SB and non-SB and
also use the proper `AAVMF` name, backward-compat symlinks are added. This is
just a temporary situation and this will be removed once current LXD is
updated.