### PR TITLE
Avoid noise during `lxd init`

### DIFF
--- a/snapcraft/commands/lxd
+++ b/snapcraft/commands/lxd
@@ -23,7 +23,7 @@ export LXD_DIR="${LXD_DIR:-"${SNAP_COMMON}/lxd/"}"
 
 # Set up ZFS userspace tools matching the loaded kernel module
 # shellcheck source=snapcraft/commands/setup-zfs
-. "${SNAP}/commands/setup-zfs"
+. "${SNAP}/commands/setup-zfs" >/dev/null
 
 LXD="lxd"
 if [ -x "${SNAP_COMMON}/lxd.debug" ]; then

--- a/snapcraft/commands/setup-zfs
+++ b/snapcraft/commands/setup-zfs
@@ -30,11 +30,11 @@ else
         export LD_LIBRARY_PATH="${SNAP_CURRENT}/zfs-${_ZFS_VER}/lib/:${LD_LIBRARY_PATH}"
         export PATH="${SNAP_CURRENT}/zfs-${_ZFS_VER}/bin:${PATH}"
     elif [ -n "${_ZFS_VER}" ]; then
-        echo "==> Unsupported ZFS version (${_ZFS_VER})"
-        echo "Consider installing ZFS tools in the host and use zfs.external"
+        echo "==> Unsupported ZFS version (${_ZFS_VER})" >&2
+        echo "Consider installing ZFS tools in the host and use zfs.external" >&2
     else
-        echo "==> No ZFS support"
-        echo "Consider installing ZFS tools in the host and use zfs.external"
+        echo "==> No ZFS support" >&2
+        echo "Consider installing ZFS tools in the host and use zfs.external" >&2
     fi
 
     # Do not pollute the caller's environment with internal variables


### PR DESCRIPTION
Fix a regression introduced by https://github.com/canonical/lxd-pkg-snap/pull/1132:

```
sudo lxd init --auto
==> Setting up ZFS (2.2)
```