### PR TITLE
daemon.activate: drop obsolete socket activation check

### DIFF
--- a/snapcraft/commands/daemon.activate
+++ b/snapcraft/commands/daemon.activate
@@ -42,17 +42,6 @@ echo "==> Loading snap configuration"
 daemon_group="${daemon_group:-"lxd"}"
 daemon_user_group="${daemon_user_group:-"lxd"}"
 
-# Detect missing socket activation support
-echo "==> Checking for socket activation support"
-if ! nsenter -t 1 -m systemctl is-active -q snap."${SNAP_INSTANCE_NAME}".daemon.unix.socket; then
-    sleep 3s
-    if ! nsenter -t 1 -m systemctl is-active -q snap."${SNAP_INSTANCE_NAME}".daemon.unix.socket; then
-        echo "===> System doesn't support socket activation, starting LXD now"
-        nsenter -t 1 -m systemctl start snap."${SNAP_INSTANCE_NAME}".daemon
-        exit 0
-    fi
-fi
-
 # Start LXD if running as an appliance
 if nsenter -t 1 -m snap model --assertion | grep -q "^model: lxd-core"; then
     echo "==> LXD appliance detected, starting LXD"


### PR DESCRIPTION
The check was introduced in 2018 to handle systems that allegedly lacked socket activation support. However, snapd has always required systemd, so no such system can run snaps in the first place.

The block was also logically flawed: it used systemctl itself to detect the absence of systemd, and the sleep/retry loop was unnecessary since systemd's unit ordering guarantees the socket unit (`sockets.target`) is already settled before activate.service is allowed to run (`After=basic.target`, which comes `After=sockets.target`).

More importantly, the early `exit 0` skipped all subsequent setup steps (group/user creation, socket ownership, first-run guard) and bypassed `lxd activateifneeded`, the authoritative gate that decides whether the daemon actually needs to start. This could cause LXD to be unconditionally force-started on a fresh, never-configured system.

All cases previously targeted by this block are handled correctly by the remaining code paths.