### PR TITLE
qemu: bump to 8.2.2+ds-0ubuntu1.14 (5.21-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -903,7 +903,7 @@ parts:
       - spice-protocol
       - spice-server
     source: https://git.launchpad.net/ubuntu/+source/qemu
-    source-commit: ace420d02a94265d09522205a4c396689defd241 # import/1%8.2.2+ds-0ubuntu1.13
+    source-commit: cbc9464605aa15db0bbce833942c4ed8dcf33f5d # import/1%8.2.2+ds-0ubuntu1.14
     # Avoid shallow clone (0 means full clone)
     source-depth: 0
     source-type: git


### PR DESCRIPTION
Addresses https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/2126951


(cherry picked from commit 507e2fe99579068d23debe78096eb8c5ca1b007b)