### PR TITLE
lxd: pre lxd-6.8 (latest-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1397,7 +1397,7 @@ parts:
 
   lxd:
     source: https://github.com/canonical/lxd
-    source-commit: 1b4c2ce38d7421246ed9821d6173c8c264309b7b # pre lxd-6.8
+    source-commit: 7d61f77d13bd226b0fa3b6048fd22a1fc8d5f360 # pre lxd-6.8
     # XXX: We often cherry-pick for candidate builds so don't do shallow clone (0 means full clone).
     source-depth: 0
     source-type: git


### PR DESCRIPTION
Includes Replicators in release notes.

https://github.com/canonical/lxd/pull/18160