### PR TITLE
lxd: suppress errors from sourcing `setup-zfs` helper

### DIFF
--- a/snapcraft/commands/lxd
+++ b/snapcraft/commands/lxd
@@ -23,7 +23,7 @@ export LXD_DIR="${LXD_DIR:-"${SNAP_COMMON}/lxd/"}"
 
 # Set up ZFS userspace tools matching the loaded kernel module
 # shellcheck source=snapcraft/commands/setup-zfs
-. "${SNAP}/commands/setup-zfs" >/dev/null
+. "${SNAP}/commands/setup-zfs" >/dev/null 2>&1
 
 LXD="lxd"
 if [ -x "${SNAP_COMMON}/lxd.debug" ]; then


### PR DESCRIPTION
This should avoid console pollution:

```
==> Unsupported ZFS version (2.1)
Consider installing ZFS tools in the host and use zfs.external
```

And `daemon.start` that also uses that helper should cause the same message to go into the journal.