### PR TITLE
apparmor: drop unneeded part

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1227,19 +1227,8 @@ parts:
       - bin/pzstd
       - bin/zstd
 
-  apparmor:
-    plugin: nil
-    stage-packages:
-      - apparmor
-    organize:
-      sbin/: bin/
-    prime:
-      - bin/apparmor_parser
-
   # Core components
   lxc:
-    after:
-      - apparmor
     source: https://github.com/lxc/lxc
     source-depth: 1
     source-type: git


### PR DESCRIPTION
That `apparmor` part was introduced to get 24.04's parser while using the `core22` base. This was commit 8591ed414b4dab7d045ccb344eb914d07f67b93f

Since LXD uses both `apparmor_parser` and `aa-exec` and only the former was primed, it meant that versions were mixed:

* `apparmor_parser` from 24.04
* `aa-exec` from `core22` (22.04)

Now that LXD switch to building with the `core24` base, it can fully rely on Apparmor related binaries/libs to be provided by the `core24`:

```
$ ll -h /snap/core24/current/usr/{sbin/apparmor_parser,bin/aa-exec,lib/x86_64-linux-gnu/libapparmor.so.1*}
-rwxr-xr-x 1 root root  19K Aug 15  2025 /snap/core24/current/usr/bin/aa-exec*
lrwxrwxrwx 1 root root   21 Aug 15  2025 /snap/core24/current/usr/lib/x86_64-linux-gnu/libapparmor.so.1 -> libapparmor.so.1.17.1
-rw-r--r-- 1 root root  79K Aug 15  2025 /snap/core24/current/usr/lib/x86_64-linux-gnu/libapparmor.so.1.17.1
-rwxr-xr-x 1 root root 1.6M Aug 15  2025 /snap/core24/current/usr/sbin/apparmor_parser*
```