### PR TITLE
openvswitch: specifically prime just the `vswitch.ovsschema`

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -702,7 +702,7 @@ parts:
     prime:
       - bin/ovs-vsctl
       - lib/*/libunbound*so*
-      - share/openvswitch/*.ovsschema
+      - share/openvswitch/vswitch.ovsschema
 
   ovn:
     after:


### PR DESCRIPTION
The `local-config.ovschema` was probably accidentally scopped in when the glob pattern was introduced:

```
$ ll /snap/lxd/current/share/openvswitch/
total 29
drwxr-xr-x 2 root root    70 Apr 22 06:20 ./
drwxr-xr-x 7 root root   109 Apr 22 06:20 ../
-rw-r--r-- 1 root root  1890 May  2  2025 local-config.ovsschema
-rw-r--r-- 1 root root 27587 May  2  2025 vswitch.ovsschema
```