### PR TITLE
lxcfs: disable `init-script` generation

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1320,6 +1320,7 @@ parts:
       - --datadir=/snap/lxd/current/
       - --localstatedir=/var/snap/lxd/common/var/
       - -Ddocs=false
+      - -Dinit-script=   # Disables generation of systemd/sysvinit scripts
       - -Dtests=false
     organize:
       lib/*/lxcfs/liblxcfs.so: lib/


### PR DESCRIPTION
This avoids depending on `systemd` that is the default fallback.