### PR TITLE
qemu: remove unneeded `pycotap` wheel

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -919,12 +919,11 @@ parts:
 
       set -eux
 
-      # Download meson and pycotap Python wheels (normally shipped in upstream tarballs)
-      pip download --dest python/wheels meson==1.9.0 pycotap==1.3.1
+      # Download meson Python wheel (normally shipped in upstream tarballs)
+      pip download --dest python/wheels meson==1.9.0
 
       # Ensure the wheels were downloaded
       [ "$(sha256sum python/wheels/meson-1.9.0-py3-none-any.whl | awk '{print $1}')" = "45e51ddc41e37d961582d06e78c48e0f9039011587f3495c4d6b0781dad92357" ] || { echo "Invalid sha256sum for meson"; exit 1; }
-      [ "$(sha256sum python/wheels/pycotap-1.3.1-py3-none-any.whl | awk '{print $1}')" = "1c3a25b3ff89e48f4e00f1f71dbbc1642b4f65c65d416524d07e73492fff25ea" ] || { echo "Invalid sha256sum for pycotap"; exit 1; }
 
     override-build: |-
       [ "$(uname -m)" = "armv7l" ] && exit 0


### PR DESCRIPTION
Debian carries a patch that disables `pycotap` (only used for tests) since version 9.2.0+ds-5