### PR TITLE
snap-query: rewrite to avoid `python3` dependency

### DIFF
--- a/snapcraft/commands/snap-query
+++ b/snapcraft/commands/snap-query
@@ -1,9 +1,10 @@
-#!/usr/bin/python3
+#!/bin/sh
+set -eu
 
-"""Query the status of the lxd snap."""
+# Query the status of the lxd snap.
 
-# Python implementation of:
-# $ curl -s --unix /run/snapd.socket 'http://unix.socket/v2/changes?select=in-progress&for=lxd'  | jq -r '.result[0].kind'
+# Equivalent to:
+# $ curl -s --unix /run/snapd.socket 'http://unix.socket/v2/changes?select=in-progress&for=lxd' | jq -r '.result[0].kind'
 # auto-refresh
 
 # The full JSON output when querying the in-progress changes for the lxd snap:
@@ -29,68 +30,25 @@
 #   ]
 # }
 
-# Heavily inspired from snapd's api-client.py:
-# https://github.com/snapcore/snapd/blob/master/tests/main/theme-install/api-client/bin/api-client.py
+SOCKET="/run/snapd.socket"
 
-import http.client
-import json
-import socket
-import sys
+if [ ! -S "${SOCKET}" ]; then
+    echo "missing socket" >&2
+    exit 0
+fi
 
-
-# This class is a subclass of http.client.HTTPConnection that connects to a Unix socket instead of a TCP socket.
-class UnixSocketHTTPConnection(http.client.HTTPConnection):
-    def __init__(self, socket_path):
-        super().__init__("snapd")
-        self._socket_path = socket_path
-
-    def connect(self):
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        s.connect(self._socket_path)
-        self.sock = s
-
-
-# This function connects to the Unix socket and requests the in-progress changes for the lxd snap.
-# Returns the kind of the first result, or an empty string if an error occurs.
-def main():
-    # Try to connect to the Unix socket and request the in-progress changes for the lxd snap.
-    # If an exception occurs, print an error message and return an empty string.
-    try:
-        conn = UnixSocketHTTPConnection("/run/snapd.socket")
-        conn.request("GET", "/v2/changes?select=in-progress&for=lxd")
-        response = conn.getresponse()
-        body = response.read().decode()
-    except FileNotFoundError:
-        print("missing socket", file=sys.stderr)
-        return ""
-    except http.client.HTTPException as e:
-        print("HTTP exception:", e, file=sys.stderr)
-        return ""
-    finally:
-        conn.close()
-
-    # If the response status is not 200, print an error message and return an empty string.
-    if response.status != 200:
-        print("HTTP error:", response.status, file=sys.stderr)
-        return ""
-
-    # If the response body is missing or empty, print an error message and return an empty string.
-    if not body:
-        print("Missing/empty body", file=sys.stderr)
-        return ""
-
-    # Try to parse the response body as JSON, and extract the "kind" field from the first result.
-    try:
-        data = json.loads(body)
-    except json.JSONDecodeError as e:
-        print("JSON decode exception:", e, file=sys.stderr)
-        return ""
-
-    if "result" in data and isinstance(data["result"], list) and len(data["result"]):
-        return data["result"][0].get("kind", "")
-
-    return ""
-
-
-if __name__ == "__main__":
-    print(main())
+# Send HTTP GET request via UNIX socket.
+# HTTP/1.0 is used to ensure snapd closes the connection after responding.
+# -C translates LF to CRLF on send (required by HTTP); -N shuts down the
+# write side after EOF so snapd receives a clean end-of-request signal.
+printf 'GET /v2/changes?select=in-progress&for=lxd HTTP/1.0\n\n' \
+    | nc -C -N -U "${SOCKET}" 2>/dev/null \
+    | awk '
+        { gsub(/\r/, "") }
+        NR == 1 && $2 != "200" { print "HTTP error: " $2 > "/dev/stderr"; exit 0 }
+        match($0, /"kind":"[^"]*"/) {
+            seg = substr($0, RSTART, RLENGTH)
+            sub(/^"kind":"/, "", seg); sub(/"$/, "", seg)
+            print seg; exit 0
+        }
+    '


### PR DESCRIPTION
This shell script "lives off the land" and works with `core22`, `core24` and `core26`:

```
$ ll /snap/core2?/current/usr/bin/{printf,nc,awk}
lrwxrwxrwx 1 root root     4 Feb 24 23:01 /snap/core22/current/usr/bin/awk -> mawk*
lrwxrwxrwx 1 root root    10 Feb 24 23:01 /snap/core22/current/usr/bin/nc -> nc.openbsd*
-rwxr-xr-x 1 root root 51648 Feb  7  2024 /snap/core22/current/usr/bin/printf*
lrwxrwxrwx 1 root root     4 Mar 16 23:54 /snap/core24/current/usr/bin/awk -> mawk*
lrwxrwxrwx 1 root root    10 Mar 16 23:54 /snap/core24/current/usr/bin/nc -> nc.openbsd*
-rwxr-xr-x 1 root root 55744 Jun 22  2025 /snap/core24/current/usr/bin/printf*
lrwxrwxrwx 1 root root    13 Apr 23 15:34 /snap/core26/current/usr/bin/awk -> /usr/bin/mawk*
lrwxrwxrwx 1 root root    19 Apr 23 15:34 /snap/core26/current/usr/bin/nc -> /usr/bin/nc.openbsd*
lrwxrwxrwx 1 root root    33 Apr 23 15:33 /snap/core26/current/usr/bin/printf -> ../lib/cargo/bin/coreutils/printf*
```