### PR TITLE
qemu: only prime `efi-virtio.rom` on `amd64`

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1022,7 +1022,6 @@ parts:
         - share/qemu/efi-virtio.rom
         - share/qemu/vgabios-virtio.bin
       - to arm64:
-        - share/qemu/efi-virtio.rom
         - share/qemu/vgabios-virtio.bin
       - to ppc64el:
         - share/qemu/slof.bin


### PR DESCRIPTION
Requires https://github.com/canonical/lxd/pull/18372