### PR TITLE
SECURITY: new policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+This repository contains only the snap packaging for LXD. Security issues,
+including those specific to the snap packaging, should be reported against the
+main LXD repository.
+
+To report a security issue, file a [Private Security
+Report](https://github.com/canonical/lxd/security/advisories/new) with
+a description of the issue, the steps you took to create the issue, affected
+versions, and, if known, mitigations for the issue.
+
+The [Ubuntu Security disclosure and embargo
+policy](https://ubuntu.com/security/disclosure-policy) contains more
+information about what you can expect when you contact us and what we expect
+from you.


### PR DESCRIPTION
Encourage reporters to open advisories on LXD's main repo even if they are snap specific.