### PR TITLE
strip: ensure `qemu-external` plug target dir exist

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1728,6 +1728,10 @@ parts:
       # Ensure the libdrm layout directory exists for the bind mount to work
       mkdir -p "${CRAFT_PRIME}/gpu-2604/mesa-2604/usr/share/libdrm"
 
+      # Ensure the qemu-external plug target directory always exists
+      # even on architectures where QEMU isn't built (like armhf).
+      mkdir -p "${CRAFT_PRIME}/external/qemu"
+
       # XXX: look for broken symlinks indicating missing/invalid prime
       broken_symlinks="$(find "${CRAFT_PRIME}/" -xtype l \
                            -not -path "${CRAFT_PRIME}/lxc/config/common.conf.d/*")"


### PR DESCRIPTION
This seems to be a new requirement with `snapd` `latest/beta`.

Should address [this](https://launchpadlibrarian.net/863749987/buildlog_snap_ubuntu_resolute_amd64_lxd-pkg-snap_BUILDING.txt.gz):

```
Determining the version from the project repo (version: git).
Version has been set to '0+git.8593915'
Packing...
Reading snap metadata...
Running linters...
Running linter: classic
Running linter: library
Running linter: metadata
Determining the version from the project repo (version: git).
Version has been set to '0+git.8593915'
Cannot pack snap: error: content interface plug "qemu-external" target $SNAP/external/qemu must exist and must be a directory, ensure it is present in the snap or created before packing
Detailed information: Command '['snap', 'pack', '--check-skeleton', PosixPath('/build/lxd/prime')]' returned non-zero exit status 1.
```