### PR TITLE
Revert "github: only commit the `snapcraft.yaml` file during builds"

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -46,8 +46,8 @@ jobs:
           rsync -a --exclude .git --delete . ~/"${PACKAGE}-pkg-snap-lp"/
           cd ~/"${PACKAGE}-pkg-snap-lp"
           lxd-snapcraft -package "${PACKAGE}" -set-version "${ver[0]}" -set-source-commit "${ver[1]}"
-          git add snapcraft.yaml
-          git commit --quiet -s --allow-empty -m "Automatic upstream build (${BRANCH})" -m "Upstream commit: ${localRev}"
+          git add --all
+          git commit --all --quiet -s --allow-empty -m "Automatic upstream build (${BRANCH})" -m "Upstream commit: ${localRev}"
           git show
           git push --quiet
 


### PR DESCRIPTION
Only the `snapcraft.yaml` file is mangled and needs to be committed in the LXD repo but in the `lxd-pkg-snap`, other files need to be propagated to the other git repo on LP.

This reverts commit 4492f6abbfdcdeb803c51b6c3b3a1039e67b5c83.