### PR TITLE
`core26` workarounds

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -272,6 +272,15 @@ if [ "${SNAP_BASE}" = "core26" ]; then
     echo "==> Adding missing chroot symlink for core26"
     ln -s /usr/lib/cargo/bin/coreutils/chroot /run/bin/chroot
   fi
+
+  # Force gnudd as the dd implementation
+  # dd from core26's coreutils 'iflag=direct' support is broken: https://github.com/uutils/coreutils/issues/12085
+  if [ -e /usr/lib/cargo/bin/coreutils/dd ]; then
+    GNUDD_PATH="$(command -v gnudd 2>/dev/null || true)"
+    if [ -n "${GNUDD_PATH}" ]; then
+      ln -s "${GNUDD_PATH}" /run/bin/dd
+    fi
+  fi
 fi
 
 # Setup a functional /etc

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -265,6 +265,15 @@ ln -s "${SNAP}/bin/ebtables-legacy" "/run/bin/ebtables"
 ln -s /usr/sbin/xtables-legacy-multi "/run/bin/ip6tables"
 ln -s /usr/sbin/xtables-legacy-multi "/run/bin/iptables"
 
+# core26 workarounds
+if [ "${SNAP_BASE}" = "core26" ]; then
+  # Add missing symlink for chroot
+  if ! command -v chroot >/dev/null && [ -e /usr/lib/cargo/bin/coreutils/chroot ]; then
+    echo "==> Adding missing chroot symlink for core26"
+    ln -s /usr/lib/cargo/bin/coreutils/chroot /run/bin/chroot
+  fi
+fi
+
 # Setup a functional /etc
 echo "==> Preparing a clean copy of /etc"
 

--- a/snapcraft/wrappers/remote-viewer
+++ b/snapcraft/wrappers/remote-viewer
@@ -4,7 +4,7 @@ run_cmd() {
     shift
 
     unset LD_LIBRARY_PATH
-    export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    export PATH="/run/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
     export HOME="${SNAP_REAL_HOME}"
     export USER="${USERNAME}"
 


### PR DESCRIPTION
This should fix the following tests from `lxd-ci`:

* `csi`
* `storage-metadata`