### PR TITLE
snapcraft: Fix LXD 4.0 imports (5.21-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1729,6 +1729,7 @@ parts:
       git cherry-pick -x ff483bf743385efa159953aea9667280b15595a7 # lxd/backup: Check for missing .Config in GetInfo (PR #18226)
       git cherry-pick -x 1d92da54a932dc7640b7d80b714c56038c75648b # lxd/backup: Validate all backup config slices for nil values (PR #18226)
       git cherry-pick -x 4a165ccfe964c5beaa90fde1a6e9fdf7b344d308 # lxd/backup: Perform a defensive check against the config itself before trying to convert (PR #18226)
+      git cherry-pick -x e89a318c72061e1ccd89378b67e4e6da04dd5b39 # lxd/backup: Don't always populate volumes in the new format (PR #17074)
 
       # Setup build environment
       export GOTOOLCHAIN="local"


### PR DESCRIPTION
Ensure LXD doesn't panic when importing 4.0 backups.

We originally fixed this in Sep 2025 (https://github.com/canonical/lxd/commit/8f8b6ddb0a13db973f534f65a2b75c28c8b2d474), backported into `stable-5.21` in Nov 2025 (https://github.com/canonical/lxd/commit/e89a318c72061e1ccd89378b67e4e6da04dd5b39) but never cherry-picked into the stable vers.

