### PR TITLE
buginfo: Use lxc list --all-projects

### DIFF
--- a/snapcraft/commands/buginfo
+++ b/snapcraft/commands/buginfo
@@ -49,7 +49,7 @@ if lxc info >/dev/null 2>&1; then
 
     echo "## Instances"
     echo '```'
-    lxc list
+    lxc list --all-projects
     echo '```'
     echo ""
 


### PR DESCRIPTION
Otherwise we miss some instances. Useful for `sosreport`.