### PR TITLE
Enable building lxd-ui on riscv64

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1633,16 +1633,13 @@ parts:
       - npm
     override-prime: |-
       [ "$(uname -m)" = "armv7l" ] && exit 0
-      [ "$(uname -m)" = "riscv64" ] && exit 0
       craftctl default
     override-pull: |-
       [ "$(uname -m)" = "armv7l" ] && exit 0
-      [ "$(uname -m)" = "riscv64" ] && exit 0
 
       craftctl default
     override-build: |
       [ "$(uname -m)" = "armv7l" ] && exit 0
-      [ "$(uname -m)" = "riscv64" ] && exit 0
 
       craftctl default
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1628,6 +1628,9 @@ parts:
     source-depth: 1
     source-type: git
     plugin: nil
+    build-packages:
+      - nodejs
+      - npm
     override-prime: |-
       [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
@@ -1636,7 +1639,6 @@ parts:
       [ "$(uname -m)" = "armv7l" ] && exit 0
       [ "$(uname -m)" = "riscv64" ] && exit 0
 
-      snap install node --channel=24/stable --classic
       craftctl default
     override-build: |
       [ "$(uname -m)" = "armv7l" ] && exit 0


### PR DESCRIPTION
The node snap does not build on riscv64 but we have recent enough deb packages. Use these for lxd.ui.