### PR TITLE
lxd-ui: update 0.22 tag (latest-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1645,7 +1645,7 @@ parts:
     source: https://github.com/canonical/lxd-ui
     source-depth: 1
     source-type: git
-    source-commit: 0413fc5b563e7c44659cc6e9da24f4eab32cfd00 # 0.22
+    source-commit: 65ff2c18f42dd3852f738f235f8482388de6b974 # 0.22
     plugin: nil
     override-prime: |-
       [ "$(uname -m)" = "riscv64" ] && exit 0


### PR DESCRIPTION
tagging to happen at a later time, referencing a commit on main for now (latest-candidate)